### PR TITLE
Packet transmission via serial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .vscode/arduino.json
 .vscode/c_cpp_properties.json
+esp32_marauder/.vscode/settings.json

--- a/esp32_marauder/Buffer.h
+++ b/esp32_marauder/Buffer.h
@@ -16,11 +16,13 @@ extern Settings settings_obj;
 class Buffer {
   public:
     Buffer();
-    void open(fs::FS* fs, String fn = "");
+    void createPcapFile(fs::FS* fs, String fn = "");
+    void open();
     void close(fs::FS* fs);
     void addPacket(uint8_t* buf, uint32_t len);
     void save(fs::FS* fs);
     void forceSave(fs::FS* fs);
+    void forceSaveSerial();
   private:
     void write(int32_t n);
     void write(uint32_t n);

--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -520,12 +520,16 @@ void CommandLine::runCommand(String input) {
       }
       // Update via SD
       else if (sd_sw != -1) {
-        if (!sd_obj.supported) {
-          Serial.println("SD card is not connected. Cannot perform SD Update");
-          return;
-        }
-        wifi_scan_obj.currentScanMode = OTA_UPDATE;
-        sd_obj.runUpdate();
+        #ifndef WRITE_PACKETS_SERIAL
+          if (!sd_obj.supported) {
+            Serial.println("SD card is not connected. Cannot perform SD Update");
+            return;
+          }
+          wifi_scan_obj.currentScanMode = OTA_UPDATE;
+          sd_obj.runUpdate();
+        #else
+          Serial.println("SD card not initialized. Cannot perform SD Update");
+        #endif
       }
     }
   }

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -132,27 +132,29 @@ MenuFunctions::MenuFunctions()
     lv_textarea_set_text(ta1, "");
     lv_textarea_set_placeholder_text(ta1, "Ducky script");
   
-    if (sd_obj.supported) {
-      // Create load button
-      lv_obj_t * label;
-      lv_obj_t * load_btn = lv_btn_create(lv_scr_act(), NULL);
-      lv_obj_set_event_cb(load_btn, load_btn_cb);
-      lv_obj_set_height(load_btn, 35);
-      lv_obj_set_width(load_btn, LV_HOR_RES / 3);
-      lv_obj_align(load_btn, ta1, LV_ALIGN_IN_TOP_RIGHT, NULL, (LV_VER_RES / 2) - 35); // align to text area
-      label = lv_label_create(load_btn, NULL);
-      lv_label_set_text(label, text05);
-    
-      // Create Save As button
-      lv_obj_t * label2;
-      lv_obj_t * save_as_btn = lv_btn_create(lv_scr_act(), NULL);
-      lv_obj_set_event_cb(save_as_btn, load_btn_cb);
-      lv_obj_set_height(save_as_btn, 35);
-      lv_obj_set_width(save_as_btn, LV_HOR_RES / 3);
-      lv_obj_align(save_as_btn, ta1, LV_ALIGN_IN_TOP_MID, NULL, (LV_VER_RES / 2) - 35); // align to text area
-      label2 = lv_label_create(save_as_btn, NULL);
-      lv_label_set_text(label2, text06);
-    }
+    #ifndef WRITE_PACKETS_SERIAL
+      if (sd_obj.supported) {
+        // Create load button
+        lv_obj_t * label;
+        lv_obj_t * load_btn = lv_btn_create(lv_scr_act(), NULL);
+        lv_obj_set_event_cb(load_btn, load_btn_cb);
+        lv_obj_set_height(load_btn, 35);
+        lv_obj_set_width(load_btn, LV_HOR_RES / 3);
+        lv_obj_align(load_btn, ta1, LV_ALIGN_IN_TOP_RIGHT, NULL, (LV_VER_RES / 2) - 35); // align to text area
+        label = lv_label_create(load_btn, NULL);
+        lv_label_set_text(label, text05);
+      
+        // Create Save As button
+        lv_obj_t * label2;
+        lv_obj_t * save_as_btn = lv_btn_create(lv_scr_act(), NULL);
+        lv_obj_set_event_cb(save_as_btn, load_btn_cb);
+        lv_obj_set_height(save_as_btn, 35);
+        lv_obj_set_width(save_as_btn, LV_HOR_RES / 3);
+        lv_obj_align(save_as_btn, ta1, LV_ALIGN_IN_TOP_MID, NULL, (LV_VER_RES / 2) - 35); // align to text area
+        label2 = lv_label_create(save_as_btn, NULL);
+        lv_label_set_text(label2, text06);
+      }
+    #endif
     
     // Focus it on one of the text areas to start
     lv_keyboard_set_textarea(kb, ta1);
@@ -1274,10 +1276,14 @@ void MenuFunctions::updateStatusBar()
   MenuFunctions::battery(false);
 
   // Draw SD info
-  if (sd_obj.supported)
-    the_color = TFT_GREEN;
-  else
+  #ifndef WRITE_PACKETS_SERIAL
+    if (sd_obj.supported)
+      the_color = TFT_GREEN;
+    else
+      the_color = TFT_RED;
+  #else
     the_color = TFT_RED;
+  #endif
 
   #ifndef MARAUDER_MINI
     display_obj.tft.drawXBitmap(170,
@@ -1360,10 +1366,14 @@ void MenuFunctions::drawStatusBar()
   MenuFunctions::battery2(true);
 
   // Draw SD info
-  if (sd_obj.supported)
-    the_color = TFT_GREEN;
-  else
+  #ifndef WRITE_PACKETS_SERIAL
+    if (sd_obj.supported)
+      the_color = TFT_GREEN;
+    else
+      the_color = TFT_RED;
+  #else
     the_color = TFT_RED;
+  #endif
 
   #ifndef MARAUDER_MINI
     display_obj.tft.drawXBitmap(170,
@@ -1943,10 +1953,12 @@ void MenuFunctions::RunSetup()
     changeMenu(&updateMenu);
     web_obj.setupOTAupdate();
   });
-  if (sd_obj.supported) addNodes(&whichUpdateMenu, text_table1[40], TFT_MAGENTA, NULL, SD_UPDATE, [this]() {
-    wifi_scan_obj.currentScanMode = OTA_UPDATE;
-    changeMenu(&confirmMenu);
-  });
+  #ifndef WRITE_PACKETS_SERIAL
+    if (sd_obj.supported) addNodes(&whichUpdateMenu, text_table1[40], TFT_MAGENTA, NULL, SD_UPDATE, [this]() {
+      wifi_scan_obj.currentScanMode = OTA_UPDATE;
+      changeMenu(&confirmMenu);
+    });
+  #endif
   addNodes(&whichUpdateMenu, text_table1[41], TFT_RED, NULL, ESP_UPDATE_ICO, [this]() {
     wifi_scan_obj.currentScanMode = ESP_UPDATE;
     changeMenu(&espUpdateMenu);

--- a/esp32_marauder/SDInterface.cpp
+++ b/esp32_marauder/SDInterface.cpp
@@ -77,7 +77,8 @@ void SDInterface::addPacket(uint8_t* buf, uint32_t len) {
 
 void SDInterface::openCapture(String file_name) {
   if (this->supported)
-    buffer_obj.open(&SD, file_name);
+    buffer_obj.createPcapFile(&SD, file_name);
+    buffer_obj.open();
 }
 
 void SDInterface::runUpdate() {

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -553,7 +553,11 @@ String WiFiScan::freeRAM()
 // Function to start running a beacon scan
 void WiFiScan::RunAPScan(uint8_t scan_mode, uint16_t color)
 {
-  sd_obj.openCapture("ap");
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj.open();
+  #else
+    sd_obj.openCapture("ap");
+  #endif
 
   #ifdef MARAUDER_FLIPPER
     flipper_led.sniffLED();
@@ -774,20 +778,26 @@ void WiFiScan::RunInfo()
     display_obj.tft.println(text_table4[27] + free_ram);
   #endif
 
-  if (sd_obj.supported) {
+  #ifdef WRITE_PACKETS_SERIAL
     #ifdef HAS_SCREEN
-      display_obj.tft.println(text_table4[28]);
-      display_obj.tft.print(text_table4[29]);
-      display_obj.tft.print(sd_obj.card_sz);
-      display_obj.tft.println("MB");
+      display_obj.tft.println(text_table4[48]);
     #endif
-  }
-  else {
-    #ifdef HAS_SCREEN
-      display_obj.tft.println(text_table4[30]);
-      display_obj.tft.println(text_table4[31]);
-    #endif
-  }  
+  #else
+    if (sd_obj.supported) {
+      #ifdef HAS_SCREEN
+        display_obj.tft.println(text_table4[28]);
+        display_obj.tft.print(text_table4[29]);
+        display_obj.tft.print(sd_obj.card_sz);
+        display_obj.tft.println("MB");
+      #endif
+    } else {
+      #ifdef HAS_SCREEN
+        display_obj.tft.println(text_table4[30]);
+        display_obj.tft.println(text_table4[31]);
+      #endif
+    }
+  #endif
+
 
   battery_obj.battery_level = battery_obj.getBatteryLevel();
   if (battery_obj.i2c_supported) {
@@ -808,7 +818,11 @@ void WiFiScan::RunInfo()
 }
 
 void WiFiScan::RunEspressifScan(uint8_t scan_mode, uint16_t color) {
-  sd_obj.openCapture("espressif");
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj.open();
+  #else
+    sd_obj.openCapture("espressif");
+  #endif
 
   #ifdef MARAUDER_FLIPPER
     flipper_led.sniffLED();
@@ -853,7 +867,11 @@ void WiFiScan::RunPacketMonitor(uint8_t scan_mode, uint16_t color)
     led_obj.setMode(MODE_SNIFF);
   #endif
 
-  sd_obj.openCapture("packet_monitor");
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj.open();
+  #else
+    sd_obj.openCapture("packet_monitor");
+  #endif
 
   #ifndef MARAUDER_MINI
     
@@ -937,7 +955,11 @@ void WiFiScan::RunEapolScan(uint8_t scan_mode, uint16_t color)
       display_obj.tft.fillScreen(TFT_BLACK);
     #endif
   
-    sd_obj.openCapture("eapol");
+    #ifdef WRITE_PACKETS_SERIAL
+      buffer_obj.open();
+    #else
+      sd_obj.openCapture("eapol");
+    #endif
   
     #ifdef HAS_SCREEN
       #ifdef TFT_SHIELD
@@ -962,7 +984,11 @@ void WiFiScan::RunEapolScan(uint8_t scan_mode, uint16_t color)
       display_obj.tftDrawExitScaleButtons();
     #endif
   #else
-    sd_obj.openCapture("eapol");
+    #ifdef WRITE_PACKETS_SERIAL
+      buffer_obj.open();
+    #else
+      sd_obj.openCapture("eapol");
+    #endif
     
     #ifdef HAS_SCREEN
       display_obj.TOP_FIXED_AREA_2 = 48;
@@ -1055,7 +1081,11 @@ void WiFiScan::RunMimicFlood(uint8_t scan_mode, uint16_t color) {
 
 void WiFiScan::RunPwnScan(uint8_t scan_mode, uint16_t color)
 {
-  sd_obj.openCapture("pwnagotchi");
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj.open();
+  #else
+    sd_obj.openCapture("pwnagotchi");
+  #endif
 
   #ifdef MARAUDER_FLIPPER
     flipper_led.sniffLED();
@@ -1095,7 +1125,11 @@ void WiFiScan::RunPwnScan(uint8_t scan_mode, uint16_t color)
 // Function to start running a beacon scan
 void WiFiScan::RunBeaconScan(uint8_t scan_mode, uint16_t color)
 {
-  sd_obj.openCapture("beacon");
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj.open();
+  #else
+    sd_obj.openCapture("beacon");
+  #endif
 
   #ifdef MARAUDER_FLIPPER
     flipper_led.sniffLED();
@@ -1134,7 +1168,11 @@ void WiFiScan::RunBeaconScan(uint8_t scan_mode, uint16_t color)
 
 void WiFiScan::RunStationScan(uint8_t scan_mode, uint16_t color)
 {
-  sd_obj.openCapture("station");
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj.open();
+  #else
+    sd_obj.openCapture("station");
+  #endif
 
   #ifdef MARAUDER_FLIPPER
     flipper_led.sniffLED();
@@ -1173,7 +1211,11 @@ void WiFiScan::RunStationScan(uint8_t scan_mode, uint16_t color)
 
 void WiFiScan::RunRawScan(uint8_t scan_mode, uint16_t color)
 {
-  sd_obj.openCapture("raw");
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj.open();
+  #else
+    sd_obj.openCapture("raw");
+  #endif
 
   #ifdef MARAUDER_FLIPPER
     flipper_led.sniffLED();
@@ -1212,7 +1254,11 @@ void WiFiScan::RunRawScan(uint8_t scan_mode, uint16_t color)
 
 void WiFiScan::RunDeauthScan(uint8_t scan_mode, uint16_t color)
 {
-  sd_obj.openCapture("deauth");
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj.open();
+  #else
+    sd_obj.openCapture("deauth");
+  #endif
 
   #ifdef MARAUDER_FLIPPER
     flipper_led.sniffLED();
@@ -1253,7 +1299,11 @@ void WiFiScan::RunDeauthScan(uint8_t scan_mode, uint16_t color)
 // Function for running probe request scan
 void WiFiScan::RunProbeScan(uint8_t scan_mode, uint16_t color)
 {
-  sd_obj.openCapture("probe");
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj.open();
+  #else
+    sd_obj.openCapture("probe");
+  #endif
 
   #ifdef MARAUDER_FLIPPER
     flipper_led.sniffLED();
@@ -1358,7 +1408,6 @@ void WiFiScan::RunBluetoothScan(uint8_t scan_mode, uint16_t color)
   } // scanCompleteCB
 #endif
 
-
 // Function to extract MAC addr from a packet at given offset
 void WiFiScan::getMAC(char *addr, uint8_t* data, uint16_t offset) {
   sprintf(addr, "%02x:%02x:%02x:%02x:%02x:%02x", data[offset+0], data[offset+1], data[offset+2], data[offset+3], data[offset+4], data[offset+5]);
@@ -1366,8 +1415,6 @@ void WiFiScan::getMAC(char *addr, uint8_t* data, uint16_t offset) {
 
 void WiFiScan::espressifSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -1433,19 +1480,13 @@ void WiFiScan::espressifSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t t
     display_obj.loading = false;
   #endif
   
-
-  
   Serial.println();
 
-  if (save_packet)
-    sd_obj.addPacket(snifferPacket->payload, len);
-  //}
+  addPacket(snifferPacket, len);
 }
 
 void WiFiScan::pwnSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
-{
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
+{ 
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -1538,21 +1579,16 @@ void WiFiScan::pwnSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
             display_obj.loading = false;
           }
         #endif
-        
-  
-        
+
         Serial.println();
 
-        if (save_packet)
-          sd_obj.addPacket(snifferPacket->payload, len);
+        addPacket(snifferPacket, len);
       }
     }
   }
 }
 
-void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type) {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
+void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type) {  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -1702,8 +1738,7 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
 
         Serial.println();
 
-        if (save_packet)
-          sd_obj.addPacket(snifferPacket->payload, len);
+        addPacket(snifferPacket, len);
       }
     }
   }
@@ -1711,8 +1746,6 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
 
 void WiFiScan::apSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -1828,8 +1861,7 @@ void WiFiScan::apSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 
         Serial.println();
 
-        if (save_packet)
-          sd_obj.addPacket(snifferPacket->payload, len);
+        addPacket(snifferPacket, len);
       }
     }
   }
@@ -1837,8 +1869,6 @@ void WiFiScan::apSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 
 void WiFiScan::beaconSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -1896,20 +1926,15 @@ void WiFiScan::beaconSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type
           display_obj.loading = false;
         }
       #endif
-      
 
-      
       Serial.println();
 
-      if (save_packet)
-        sd_obj.addPacket(snifferPacket->payload, len);
+      addPacket(snifferPacket, len);
     }
   }
 }
 
 void WiFiScan::stationSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type) {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -2064,14 +2089,11 @@ void WiFiScan::stationSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t typ
 
   access_points->set(ap_index, ap);
 
-  if (save_packet)
-    sd_obj.addPacket(snifferPacket->payload, len);
+  addPacket(snifferPacket, len);
 }
 
 void WiFiScan::rawSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -2118,19 +2140,14 @@ void WiFiScan::rawSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
       display_obj.loading = false;
     }
   #endif
-  
 
-  
   Serial.println();
 
-  if (save_packet)
-    sd_obj.addPacket(snifferPacket->payload, len);
+  addPacket(snifferPacket, len);
 }
 
 void WiFiScan::deauthSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -2190,15 +2207,12 @@ void WiFiScan::deauthSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type
       
       Serial.println();
 
-      if (save_packet)
-        sd_obj.addPacket(snifferPacket->payload, len);
+      addPacket(snifferPacket, len);
     }
   }
 }
 
 void WiFiScan::probeSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type) {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -2261,15 +2275,12 @@ void WiFiScan::probeSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
       
       Serial.println();    
 
-      if (save_packet)
-        sd_obj.addPacket(snifferPacket->payload, len);
+      addPacket(snifferPacket, len);
     }
   }
 }
 
 void WiFiScan::beaconListSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type) {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -2351,8 +2362,7 @@ void WiFiScan::beaconListSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t 
       
       Serial.println();    
 
-      if (save_packet)
-        sd_obj.addPacket(snifferPacket->payload, len);
+      addPacket(snifferPacket, len);
     }
   }
 }
@@ -2763,8 +2773,6 @@ void WiFiScan::sendDeauthAttack(uint32_t currentTime, String dst_mac_str) {
 
 void WiFiScan::wifiSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
-  
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
   WifiMgmtHdr *frameControl = (WifiMgmtHdr*)snifferPacket->payload;
   wifi_pkt_rx_ctrl_t ctrl = (wifi_pkt_rx_ctrl_t)snifferPacket->rx_ctrl;
@@ -2825,14 +2833,12 @@ void WiFiScan::wifiSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
       #endif
     #endif
 
-    if (save_packet)
-      sd_obj.addPacket(snifferPacket->payload, len);
+    addPacket(snifferPacket, len);
   }
 }
 
 void WiFiScan::eapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
   bool send_deauth = settings_obj.loadSetting<bool>(text_table4[5]);
   
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
@@ -2935,13 +2941,11 @@ void WiFiScan::eapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 //    Serial.print("\n");
   }
 
-  if (save_packet)
-    sd_obj.addPacket(snifferPacket->payload, len);
+  addPacket(snifferPacket, len);
 }
 
 void WiFiScan::activeEapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 {
-  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
   bool send_deauth = settings_obj.loadSetting<bool>(text_table4[5]);
   
   wifi_promiscuous_pkt_t *snifferPacket = (wifi_promiscuous_pkt_t*)buf;
@@ -3013,8 +3017,18 @@ void WiFiScan::activeEapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t
 //    Serial.print("\n");
   }
 
-  if (save_packet)
-    sd_obj.addPacket(snifferPacket->payload, len);
+  addPacket(snifferPacket, len);
+}
+
+void WiFiScan::addPacket(wifi_promiscuous_pkt_t *snifferPacket, int len) {
+  bool save_packet = settings_obj.loadSetting<bool>(text_table4[7]);
+  if (save_packet) {
+    #ifdef WRITE_PACKETS_SERIAL
+      buffer_obj.addPacket(snifferPacket->payload, len);
+    #else
+      sd_obj.addPacket(snifferPacket->payload, len);
+    #endif
+  }
 }
 
 #ifdef HAS_SCREEN

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -345,5 +345,6 @@ class WiFiScan
     static void activeEapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type);
     static void eapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type);
     static void wifiSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type);
+    static void addPacket(wifi_promiscuous_pkt_t *snifferPacket, int len);
 };
 #endif

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -3,6 +3,10 @@
   #define configs_h
 
   #define POLISH_POTATO
+
+  // Indicates that it must redirect the stream with the captured packets to serial (1)
+  // If not defined, will write packages to SD card if supported
+  // #define WRITE_PACKETS_SERIAL
   
   //#define MARAUDER_MINI
   //#define MARAUDER_V4

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -129,8 +129,11 @@ void setup()
   delay(10);
 
   Serial.begin(115200);
-  
-  //Serial.begin(115200);
+
+  #ifdef WRITE_PACKETS_SERIAL
+    // Starts a second serial channel to stream the captured packets
+    Serial1.begin(115200);
+  #endif
 
   //Serial.println("\n\nHello, World!\n");
 
@@ -205,21 +208,23 @@ void setup()
     display_obj.tft.println(F(text_table0[2]));
   #endif
 
-  // Do some SD stuff
-  if(sd_obj.initSD()) {
-    //Serial.println(F("SD Card supported"));
-    #ifdef HAS_SCREEN
-      display_obj.tft.println(F(text_table0[3]));
-    #endif
-  }
-  else {
-    Serial.println(F("SD Card NOT Supported"));
-    #ifdef HAS_SCREEN
-      display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
-      display_obj.tft.println(F(text_table0[4]));
-      display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
-    #endif
-  }
+  #ifdef WRITE_PACKETS_SERIAL
+    buffer_obj = Buffer();
+  #else
+    // Do some SD stuff
+    if(sd_obj.initSD()) {
+      #ifdef HAS_SCREEN
+        display_obj.tft.println(F(text_table0[3]));
+      #endif
+    } else {
+      Serial.println(F("SD Card NOT Supported"));
+      #ifdef HAS_SCREEN
+        display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
+        display_obj.tft.println(F(text_table0[4]));
+        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+      #endif
+    }
+  #endif
 
   battery_obj.RunSetup();
 
@@ -303,7 +308,13 @@ void loop()
       display_obj.main(wifi_scan_obj.currentScanMode);
     #endif
     wifi_scan_obj.main(currentTime);
-    sd_obj.main();
+
+    #ifdef WRITE_PACKETS_SERIAL
+      buffer_obj.forceSaveSerial();
+    #else
+      sd_obj.main();
+    #endif
+
     #ifndef MARAUDER_FLIPPER
       battery_obj.main(currentTime);
       temp_obj.main(currentTime);

--- a/esp32_marauder/lang_var.h
+++ b/esp32_marauder/lang_var.h
@@ -177,12 +177,13 @@ PROGMEM const char text4_44[] = " AP Scan ";
 PROGMEM const char text4_45[] = "Clearing Stations...";
 PROGMEM const char text4_46[] = "Stations Cleared: ";
 PROGMEM const char text4_47[] = "Targeted Deauth";
+PROGMEM const char text4_48[] = "Using serial to transmit packets";
 
 //Making tables
 PROGMEM const char *text_table0[] = {text0_0,text0_1, text0_2, text0_3, text0_4, text0_5, text0_6, text0_7, text0_8};
 PROGMEM const char *text_table1[] = {text1_0,text1_1,text1_2,text1_3,text1_4,text1_5,text1_6,text1_7,text1_8,text1_9,text1_10,text1_11,text1_12,text1_13,text1_14,text1_15,text1_16,text1_17,text1_18,text1_19,text1_20,text1_21,text1_22,text1_23,text1_24,text1_25,text1_26,text1_27,text1_28,text1_29,text1_30,text1_31,text1_32,text1_33,text1_34,text1_35,text1_36,text1_37,text1_38,text1_39,text1_40,text1_41,text1_42,text1_43,text1_44,text1_45,text1_46,text1_47,text1_48,text1_49,text1_50,text1_51,text1_52,text1_53,text1_54,text1_55,text1_56,text1_57,text1_58,text1_59,text1_60,text1_61,text1_62};
 PROGMEM const char *text_table2[] = {text2_0,text2_1,text2_2,text2_3,text2_4,text2_5,text2_6,text2_7,text2_8,text2_9,text2_10,text2_11,text2_12,text2_13,text2_14};
 PROGMEM const char *text_table3[] = {text3_0,text3_1,text3_2,text3_3,text3_4,text3_5};
-PROGMEM const char *text_table4[] = {text4_0,text4_1,text4_2,text4_3,text4_4,text4_5,text4_6,text4_7,text1_54,text4_9,text4_10,text4_11,text4_12,text4_13,text4_14,text4_15,text4_16,text4_17,text4_18,text4_19,text4_20,text4_21,text4_22,text4_23,text4_24,text4_25,text4_26,text4_27,text4_28,text4_29,text4_30,text4_31,text4_32,text4_33,text4_34,text4_35,text4_36,text4_37,text4_38,text4_39,text4_40,text4_41,text4_42,text4_43,text4_44,text4_45,text4_46,text4_47};
+PROGMEM const char *text_table4[] = {text4_0,text4_1,text4_2,text4_3,text4_4,text4_5,text4_6,text4_7,text1_54,text4_9,text4_10,text4_11,text4_12,text4_13,text4_14,text4_15,text4_16,text4_17,text4_18,text4_19,text4_20,text4_21,text4_22,text4_23,text4_24,text4_25,text4_26,text4_27,text4_28,text4_29,text4_30,text4_31,text4_32,text4_33,text4_34,text4_35,text4_36,text4_37,text4_38,text4_39,text4_40,text4_41,text4_42,text4_43,text4_44,text4_45,text4_46,text4_47, text4_48};
 
 #endif


### PR DESCRIPTION
Added WRITE_PACKETS_SERIAL macro to transmit packets via serial (1) instead of using SD card.
If WRITE_PACKETS_SERIAL is not defined, will continue writing packets to SD card if supported.