### PR TITLE
Allowed to enter custom SSIDs with spaces in the name as long as they are enclosed in quotes

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -36,20 +36,23 @@ void CommandLine::main(uint32_t currentTime) {
 
 LinkedList<String> CommandLine::parseCommand(String input, char* delim) {
   LinkedList<String> cmd_args;
-  
-  if (input != "") {
-    
-    char fancy[input.length() + 1] = {};
-    input.toCharArray(fancy, input.length() + 1);
-        
-    char* ptr = strtok(fancy, delim);
-  
-    while (ptr != NULL) {
-      cmd_args.add(String(ptr));
-  
-      ptr = strtok(NULL, delim);
+
+  bool inQuote = false;
+  String buffer = "";
+
+  for (int i = 0; i < input.length(); i++) {
+    char c = input.charAt(i);
+    // Do not break parameters that are enclosed in quotes
+    if (c == '"') {
+      inQuote = !inQuote;
+    } else if (!inQuote && strchr(delim, c) != NULL) {
+      cmd_args.add(buffer);
+      buffer = "";
+    } else {
+      buffer += c;
     }
   }
+  cmd_args.add(buffer);
 
   return cmd_args;
 }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -176,7 +176,7 @@ int WiFiScan::clearSSIDs() {
 }
 
 bool WiFiScan::addSSID(String essid) {
-  ssid s = {essid, {random(256), random(256), random(256), random(256), random(256), random(256)}, false};
+  ssid s = {essid, random(1, 12), {random(256), random(256), random(256), random(256), random(256), random(256)}, false};
   ssids->add(s);
   Serial.println(ssids->get(ssids->size() - 1).essid);
 
@@ -191,7 +191,7 @@ int WiFiScan::generateSSIDs(int count) {
     for (uint8_t i = 0; i < 6; i++)
       essid.concat(alfa[random(65)]);
 
-    ssid s = {essid, {random(256), random(256), random(256), random(256), random(256), random(256)}, false};
+    ssid s = {essid, random(1, 12), {random(256), random(256), random(256), random(256), random(256), random(256)}, false};
     ssids->add(s);
     Serial.println(ssids->get(ssids->size() - 1).essid);
   }
@@ -2437,7 +2437,7 @@ void WiFiScan::broadcastCustomBeacon(uint32_t current_time, AccessPoint custom_s
 }
 
 void WiFiScan::broadcastCustomBeacon(uint32_t current_time, ssid custom_ssid) {
-  set_channel = random(1,12); 
+  set_channel = custom_ssid.channel;
   esp_wifi_set_channel(set_channel, WIFI_SECOND_CHAN_NONE);
   delay(1);  
 
@@ -3623,12 +3623,12 @@ void WiFiScan::main(uint32_t currentTime)
     // which makes beacon spam less effective
     for (int i = 0; i < access_points->size(); i++) {
       if (access_points->get(i).selected)
-        this->broadcastCustomBeacon(currentTime, ssid{access_points->get(i).essid, {random(256), 
-                                                                                    random(256), 
-                                                                                    random(256), 
-                                                                                    random(256), 
-                                                                                    random(256), 
-                                                                                    random(256)}});
+        this->broadcastCustomBeacon(currentTime, ssid{access_points->get(i).essid, random(1, 12), {random(256), 
+                                                                                                   random(256),
+                                                                                                   random(256),
+                                                                                                   random(256),
+                                                                                                   random(256),
+                                                                                                   random(256)}});
     }
       
 

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -88,6 +88,7 @@ esp_err_t esp_wifi_80211_tx(wifi_interface_t ifx, const void *buffer, int len, b
 
 struct ssid {
   String essid;
+  int channel;
   int bssid[6];
   bool selected;
 };


### PR DESCRIPTION
Adjusted parameter parsing method to recognize parameters that are enclosed in quotes. This makes it possible to enter custom SSIDs with space-separated words.
For example:
> ssid -a -n "EVIL CORP"