### PR TITLE
Created "-f" parameter in the AP selection to filter the APs that will be selected

### DIFF
--- a/esp32_marauder/CommandLine.h
+++ b/esp32_marauder/CommandLine.h
@@ -110,6 +110,8 @@ class CommandLine {
   private:
     String getSerialInput();
     LinkedList<String> parseCommand(String input, char* delim);
+    String toLowerCase(String str);
+    void filterAccessPoints(String filter);
     void runCommand(String input);
     bool checkValueExists(LinkedList<String>* cmd_args_list, int index);
     bool inRange(int max, int index);


### PR DESCRIPTION
The -f parameter expects one or more filters chained by "or", which can be "equals" or "contains".
The arguments parsing method has also been adjusted to recognize parameters informed within single quotes or double quotes.
For example:
> select -a -f "equals 'E CORP' or contains EVIL"

