### PR TITLE
Fix string copy

### DIFF
--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -203,7 +203,7 @@ bool EvilPortal::setAP(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_
   }
 
   if (ap_config != "") {
-    strncpy(apName, ap_config.c_str(), strlen(ap_config.c_str()));
+    strncpy(apName, ap_config.c_str(), MAX_AP_NAME_SIZE);
     this->has_ap = true;
     Serial.println("ap config set");
     return true;


### PR DESCRIPTION
strncpy only copies the bytes specified, so if you set a name like "PORTAL" and then want to set a name like "HELLO" the result for apName would be "HELLOL".

Instead copy the size of MAX_AP_NAME_SIZE.