### PR TITLE
Add ESP32CAM support

### DIFF
--- a/esp32_marauder/SDInterface.h
+++ b/esp32_marauder/SDInterface.h
@@ -4,7 +4,13 @@
 #include "configs.h"
 
 #include "settings.h"
-#include "SD.h"
+
+#ifdef SD_IS_MMC
+  #include "SD_MMC.h"
+#else
+  #include "SD.h"
+#endif
+
 #include "Buffer.h"
 #ifdef HAS_SCREEN
   #include "Display.h"

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -416,7 +416,7 @@ void WiFiScan::startWiFiAttacks(uint8_t scan_mode, uint16_t color, String title_
     flipper_led.attackLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.attackLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_ATTACK);
   #endif
   initTime = millis();
@@ -439,7 +439,7 @@ bool WiFiScan::shutdownWiFi() {
       flipper_led.offLED();
     #elif defined(XIAO_ESP32_S3)
       xiao_led.offLED();
-    #else
+    #elif defined(HAS_NEOPIXEL_LED)
       led_obj.setMode(MODE_OFF);
     #endif
   
@@ -463,7 +463,7 @@ bool WiFiScan::shutdownBLE() {
         flipper_led.offLED();
       #elif defined(XIAO_ESP32_S3)
         xiao_led.offLED();
-      #else
+      #elif defined(HAS_NEOPIXEL_LED)
         led_obj.setMode(MODE_OFF);
       #endif
     
@@ -600,7 +600,7 @@ void WiFiScan::RunEvilPortal(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
 
@@ -647,7 +647,7 @@ void WiFiScan::RunAPScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
 
@@ -923,7 +923,7 @@ void WiFiScan::RunEspressifScan(uint8_t scan_mode, uint16_t color) {
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
 
@@ -962,7 +962,7 @@ void WiFiScan::RunPacketMonitor(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
 
@@ -1045,7 +1045,7 @@ void WiFiScan::RunEapolScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
   
@@ -1200,7 +1200,7 @@ void WiFiScan::RunPwnScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
 
@@ -1248,7 +1248,7 @@ void WiFiScan::RunBeaconScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
   
@@ -1295,7 +1295,7 @@ void WiFiScan::RunStationScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
   
@@ -1343,7 +1343,7 @@ void WiFiScan::RunRawScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
   
@@ -1393,7 +1393,7 @@ void WiFiScan::RunDeauthScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
   
@@ -1442,7 +1442,7 @@ void WiFiScan::RunProbeScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
-  #else
+  #elif defined(HAS_NEOPIXEL_LED)
     led_obj.setMode(MODE_SNIFF);
   #endif
   

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -41,7 +41,7 @@
   #include "flipperLED.h"
 #elif defined(XIAO_ESP32_S3)
   #include "xiaoLED.h"
-#else
+#elif defined(HAS_NEOPIXEL_LED)
   #include "LedInterface.h"
 #endif
 //#include "MenuFunctions.h"
@@ -107,7 +107,7 @@ extern Settings settings_obj;
   extern flipperLED flipper_led;
 #elif defined(XIAO_ESP32_S3)
   extern xiaoLED xiao_led;
-#else
+#elif defined(HAS_NEOPIXEL_LED)
   extern LedInterface led_obj;
 #endif
 

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -7,7 +7,7 @@
   //Indicates that it must redirect the stream with the captured packets to serial (1)
   //If not defined, will write packages to SD card if supported
   //#define WRITE_PACKETS_SERIAL
-  
+
   //// BOARD TARGETS
   //#define MARAUDER_M5STICKC
   //#define MARAUDER_MINI
@@ -15,6 +15,7 @@
   //#define MARAUDER_V6
   //#define MARAUDER_KIT
   //#define GENERIC_ESP32
+  //#define MARAUDER_ESP32CAM
   #define MARAUDER_FLIPPER
   //#define ESP32_LDDB
   //#define MARAUDER_DEV_BOARD_PRO
@@ -97,6 +98,20 @@
     //#define HAS_PWR_MGMT
     //#define HAS_SCREEN
     //#define HAS_SD
+    //#define USE_SD
+    //#define HAS_TEMP_SENSOR
+  #endif
+
+  #ifdef MARAUDER_ESP32CAM
+    //#define FLIPPER_ZERO_HAT
+    //#define HAS_BATTERY
+    #define HAS_BT
+    //#define HAS_BUTTONS
+    //#define HAS_NEOPIXEL_LED
+    //#define HAS_PWR_MGMT
+    //#define HAS_SCREEN
+    #define HAS_SD
+    #define USE_SD
     //#define HAS_TEMP_SENSOR
   #endif
 
@@ -157,9 +172,9 @@
   //// FLIPPER ZERO HAT SETTINGS
   #ifdef FLIPPER_ZERO_HAT
 
-    //#ifdef MARAUDER_FLIPPER
-    //  #define USE_FLIPPER_SD
-    //#endif
+    #ifdef MARAUDER_FLIPPER
+      #define USE_FLIPPER_SD
+    #endif
 
     #ifdef XIAO_ESP32_S3
       #define USE_FLIPPER_SD
@@ -193,7 +208,7 @@
       #define U_BTN -1
       #define R_BTN -1
       #define D_BTN 39
-    #endif  
+    #endif
 
   #endif
   //// END BUTTON DEFINITIONS
@@ -245,24 +260,24 @@
       #define BUTTON_ARRAY_LEN 11
       #define STATUS_BAR_WIDTH (TFT_HEIGHT/16)
       #define LVGL_TICK_PERIOD 6
-    
+
       #define FRAME_X 100
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
 
     #endif
@@ -280,7 +295,7 @@
       #endif
 
       #define TFT_SHIELD
-    
+
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
       #define HEIGHT_1 TFT_WIDTH
@@ -299,32 +314,32 @@
       #define BUTTON_ARRAY_LEN 11
       #define STATUS_BAR_WIDTH 16
       #define LVGL_TICK_PERIOD 6
-    
+
       #define FRAME_X 100
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
 
     #ifdef MARAUDER_V6
       #define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -336,7 +351,7 @@
       #endif
 
       #define TFT_DIY
-    
+
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
       #define HEIGHT_1 TFT_WIDTH
@@ -360,27 +375,27 @@
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
-    #endif 
+    #endif
 
     #ifdef MARAUDER_KIT
       #define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -393,7 +408,7 @@
 
       #define TFT_DIY
       #define KIT
-    
+
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
       #define HEIGHT_1 TFT_WIDTH
@@ -429,12 +444,12 @@
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
-  
+
     #ifdef MARAUDER_MINI
       #define TFT_MISO 19
       #define TFT_MOSI 23
@@ -444,7 +459,7 @@
       #define TFT_RST 5
       #define TFT_BL 32
       #define TOUCH_CS 21
-      #define SD_CS 4
+      //#define SD_CS 4
 
       #define SCREEN_BUFFER
 
@@ -496,7 +511,7 @@
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
     #endif
 
@@ -506,9 +521,9 @@
   //// MENU DEFINITIONS
   #ifdef MARAUDER_V4
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -525,9 +540,9 @@
 
   #ifdef MARAUDER_V6
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -544,9 +559,9 @@
 
   #ifdef MARAUDER_KIT
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -560,12 +575,12 @@
     #define BUTTON_PADDING 22
     //#define BUTTON_ARRAY_LEN 5
   #endif
-  
+
   #ifdef MARAUDER_MINI
     #define BANNER_TIME 50
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X (TFT_WIDTH/2) // Centre of key
     #define KEY_Y (TFT_HEIGHT/4.5)
@@ -581,9 +596,9 @@
 
   #ifdef MARAUDER_M5STICKC
     #define BANNER_TIME 50
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X (TFT_WIDTH/2) // Centre of key
     #define KEY_Y (TFT_HEIGHT/5)
@@ -600,11 +615,9 @@
 
   //// SD DEFINITIONS
   #ifdef FLIPPER_ZERO_HAT
-
     #ifdef USE_FLIPPER_SD
       #define WRITE_PACKETS_SERIAL
     #endif
-
   #elif defined(USE_SD)
 
     #ifdef MARAUDER_V4
@@ -625,6 +638,10 @@
 
     #ifdef MARAUDER_M5STICKC
       #define SD_CS 10
+    #endif
+
+    #ifdef MARAUDER_ESP32CAM
+      #define SD_IS_MMC
     #endif
 
     #ifdef MARAUDER_FLIPPER
@@ -686,6 +703,8 @@
     #define MEM_LOWER_LIM 20000
   #elif defined(GENERIC_ESP32)
     #define MEM_LOWER_LIM 20000
+  #elif defined(MARAUDER_ESP32CAM)
+    #define MEM_LOWER_LIM 20000
   #elif defined(MARAUDER_FLIPPER)
     #define MEM_LOWER_LIM 20000
   #elif defined(ESP32_LDDB)
@@ -697,9 +716,8 @@
   #endif
   //// END MEMORY LOWER LIMIT STUFF
 
-  //// NEOPIXEL STUFF  
+  //// NEOPIXEL STUFF
   #ifdef HAS_NEOPIXEL_LED
-    
     #if defined(ESP32_LDDB)
       #define PIN 17
     #elif defined(MARAUDER_DEV_BOARD_PRO)
@@ -707,7 +725,6 @@
     #else
       #define PIN 25
     #endif
-  
   #endif
   //// END NEOPIXEL STUFF
 
@@ -745,5 +762,4 @@
     #define MAX_HTML_SIZE 20000
   #endif
   //// END EVIL PORTAL STUFF
-
 #endif


### PR DESCRIPTION
Added initial ESP32CAM support.

Brownout detection does not seem to be working or maybe it does.

You can test this by unplugging the USB cable, the ESP32CAM seems to lock up now instead of throwing the brownout error. When you plug the USB back into the Flipper the ESP32CAM might reset.

I have not looked much further into it as it seems to be working if you do not fiddle with a USB cable.

ESP32CAM needs SD_MMC, I added defines for this.

I only checked if this builds with the Flipper Zero Development board and my ESP32CAM.