### PR TITLE
Get external SPI SD reader working on M5StickC-Plus

### DIFF
--- a/esp32_marauder/SDInterface.cpp
+++ b/esp32_marauder/SDInterface.cpp
@@ -1,6 +1,7 @@
 #include "SDInterface.h"
 #include "lang_var.h"
 
+
 bool SDInterface::initSD() {
   #ifdef HAS_SD
     String display_string = "";
@@ -20,8 +21,23 @@ bool SDInterface::initSD() {
     pinMode(SD_CS, OUTPUT);
 
     delay(10);
-  
-    if (!SD.begin(SD_CS)) {
+    #if defined(MARAUDER_M5STICKC)
+      /* Set up SPI SD Card using external pin header
+      StickCPlus Header - SPI SD Card Reader
+                  3v3   -   3v3
+                  GND   -   GND
+                   G0   -   CLK
+              G36/G25   -   MISO
+                  G26   -   MOSI
+                        -   CS (jumper to SD Card GND Pin)
+      */
+      enum { SPI_SCK = 0, SPI_MISO = 36, SPI_MOSI = 26 };
+      SPIClass SPI_EXT;
+      SPI_EXT.begin(SPI_SCK, SPI_MISO, SPI_MOSI, SD_CS);
+      if (!SD.begin(SD_CS, SPI_EXT)) {
+    #else
+      if (!SD.begin(SD_CS)) {
+    #endif
       Serial.println(F("Failed to mount SD Card"));
       this->supported = false;
       return false;

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -639,7 +639,7 @@
     #endif
 
     #ifdef MARAUDER_M5STICKC
-      #define SD_CS 10
+      #define SD_CS -1
     #endif
 
     #ifdef MARAUDER_FLIPPER


### PR DESCRIPTION
I wasn't able to get an SD card reader to work with the default SD_CS configuration for the M5StickC-Plus no matter how I wired it up to any of the front pins or Grove port on the back, so I fixed it up. 

This change sets up a new single-purpose external SPI bus on the front-panel pins of the M5StickC-Plus. All requisite logic changes are gated in an ifdef specific to the MARAUDER_M5STICKC board target.

A new SPIClass named SPI_EXT is configured. SD_CS is set to -1 since it's unnecessary, as it's the only peripheral on this new SPI bus. Wiring  notes in a comment. The wiki will be updated accordingly afrer merge.

Testing results:
* SD Interface is initialized at boot
* SD is green in status bar
* PCAPs are logged to the SD Card
* The lower the battery gets, the more likely the SD Card interface will start flaking out
* Certain SD cards are more tolerant to lower voltages than others. External power recommended
* Evilportal errors if ap.config.txt is missing.
* If index.html and ap.config.txt are present on the SD filesystem, ESP32Marauder crashes with a stack trace. This is likely unrelated to the SD Card and may have something to do with the ESP32-Pico-D4 or some other oddity in this platform's tech stack.