### PR TITLE
Add s2 mini dev board support

### DIFF
--- a/PCBs/FlipperZero/WiFi-Devboard-Pro/README.md
+++ b/PCBs/FlipperZero/WiFi-Devboard-Pro/README.md
@@ -3,6 +3,7 @@
 - Header Pin x8: [C2883805](https://www.lcsc.com/product-detail/Pin-Headers_XKB-Connectivity-X6511WVS-08H-C60D48R1_C2883805.html)
 - Header Pin x10: [C2883807](https://www.lcsc.com/product-detail/Pin-Headers_XKB-Connectivity-X6511WVS-10H-C60D48R1_C2883807.html)
 - Alternative Header: [M20-8771246](https://www.mouser.com/ProductDetail/Harwin/M20-8771246?qs=WS5Jv%252B%252Bx1qWzrNY%252Bb2U9JQ%3D%3D&countryCode=US&currencyCode=USD)
+  - or [M20-8771042](https://www.mouser.com/ProductDetail/Harwin/M20-8771042?qs=%252Bk6%2F5FB6qrlBSpg9%252Bi11Bg%3D%3D)
 - Light Pipe: [PLP2-188](https://www.digikey.com/en/products/detail/bivar-inc/PLP2-188/5721973?utm_medium=email&utm_source=oce&utm_campaign=4251_OCE23RT&utm_content=productdetail_US&utm_cid=2955578&so=79456987&mkt_tok=MDI4LVNYSy01MDcAAAGJOBaFWa7m6RHsJZT6mWcYRd9LRyXmqis92EV7j5ftyM5NuNOSOPqUp292m0P5E3FKrEWCFuvb9fObSzuSvVMsopuOMPjO46ylCAR1IzCL)
 - M2x6mm Round Top Screw: [97763A407](https://www.mcmaster.com/97763A407/)
 - M2x8mm Countersunk Screw: [91294A005](https://www.mcmaster.com/91294A005/)

--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -68,10 +68,10 @@ bool EvilPortal::setHtml() {
     File html_file = sd_obj.getFile("/" + this->target_html_name);
     if (!html_file) {
       #ifdef HAS_SCREEN
-        this->sendToDisplay("Could not find /index.html.");
+        this->sendToDisplay("Could not find /" + this->target_html_name);
         this->sendToDisplay("Touch to exit...");
       #endif
-      Serial.println("Could not find /index.html. Use stopscan...");
+      Serial.println("Could not find /" + this->target_html_name + ". Use stopscan...");
       return false;
     }
     else {

--- a/esp32_marauder/GpsInterface.h
+++ b/esp32_marauder/GpsInterface.h
@@ -2,9 +2,13 @@
 #define GpsInterface_h
 
 #include <MicroNMEA.h>
-#include <SoftwareSerial.h>
-
 #include "configs.h"
+
+//SoftwareSerial causes compliation issues with ESP32-S2FN4R2 mini dev boards, but ESP doesn't have a custom IDF target for them.
+// using extra preprocessor directives here to prevent meddling with other ESP32-S2's like the flipper wifi devboard. 
+#ifndef ESP32_S2_MINI_MARAUDER_FLIPPER
+  #include <SoftwareSerial.h>
+#endif
 
 class GpsInterface {
   public:

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1461,7 +1461,11 @@ const char* WiFiScan::generateRandomName() {
 }
 
 void WiFiScan::generateRandomMac(uint8_t* mac) {
-  for (int i = 0; i < 6; i++) {
+  // Set the locally administered bit and unicast bit for the first byte
+  mac[0] = 0x02; // The locally administered bit is the second least significant bit
+
+  // Generate the rest of the MAC address
+  for (int i = 1; i < 6; i++) {
     mac[i] = random(0, 255);
   }
 }

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -22,12 +22,13 @@
   //#define XIAO_ESP32_S3
   //// END BOARD TARGETS
 
-  #define MARAUDER_VERSION "v0.13.2"
+  #define MARAUDER_VERSION "v0.13.3"
 
  //// BOARD FEATURES
   #ifdef MARAUDER_M5STICKC
     //#define FLIPPER_ZERO_HAT
     #define HAS_BATTERY
+    #define HAS_BT
     #define HAS_BUTTONS
     #define HAS_NEOPIXEL_LED
     #define HAS_PWR_MGMT

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -17,6 +17,7 @@
   //#define MARAUDER_KIT
   //#define GENERIC_ESP32
   #define MARAUDER_FLIPPER
+  //#define ESP32_S2_MINI_MARAUDER_FLIPPER
   //#define ESP32_LDDB
   //#define MARAUDER_DEV_BOARD_PRO
   //#define XIAO_ESP32_S3
@@ -123,6 +124,12 @@
     #endif
     //#define HAS_TEMP_SENSOR
   #endif
+
+  #ifdef ESP32_S2_MINI_MARAUDER_FLIPPER
+    #define MARAUDER_FLIPPER //use the same settings as usual, we're just changing the Serial0 pins
+    #define S2_MINI_TX0 37
+    #define S2_MINI_RX0 39
+  #endif 
 
   #ifdef ESP32_LDDB
     //#define FLIPPER_ZERO_HAT

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -192,7 +192,13 @@ void setup()
     delay(10);
   #endif
 
-  Serial.begin(115200);
+  #ifdef ESP32_S2_MINI_MARAUDER_FLIPPER
+    Serial.begin(115200,SERIAL_8N1,S2_MINI_TX0,S2_MINI_RX0);
+  #else
+    Serial.begin(115200);
+  #endif
+
+  // Serial.begin(115200);
 
   // Starts a second serial channel to stream the captured packets
   #ifdef WRITE_PACKETS_SERIAL


### PR DESCRIPTION
Adding support for ESP32-S2FN4R2 mini dev boards. Serial0 defaults to pins 43/44, which aren't made available to the end user on the breakout board. I've added a new board definition that allows users to selectively change these pins to ones that are accessible on the dev board. 