### PR TITLE
Attach a UART GPS to GROVE port on M5StickC-Plus

### DIFF
--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -36,7 +36,7 @@
     #define HAS_SD
     #define USE_SD
     #define HAS_TEMP_SENSOR
-    //#define HAS_GPS
+    #define HAS_GPS
   #endif
 
   #ifdef MARAUDER_MINI
@@ -824,6 +824,11 @@
       #endif
       #define GPS_TX 9
       #define GPS_RX 21
+      #define mac_history_len 512
+    #elif defined(MARAUDER_M5STICKC)
+      #define GPS_SERIAL_INDEX 1
+      #define GPS_TX 33
+      #define GPS_RX 32
       #define mac_history_len 512
     #endif
   #else


### PR DESCRIPTION
I have a GouuuTech GT-U7 GPS with UART and USB. This mod should work for UBlox Neo 6M and others that have a UART interface designed for microcontrollers. Connect + and - leads and run GPS TX to Pin 33, RX to Pin 32 on the grove port on the back of the M5Stick C Plus. When wired up as described and with this diff, the GPS is registered as connected.