### PR TITLE
Add initial support for the M5StickC LED

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -555,6 +555,8 @@ void WiFiScan::startWiFiAttacks(uint8_t scan_mode, uint16_t color, String title_
     flipper_led.attackLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.attackLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.attackLED();
   #else
     led_obj.setMode(MODE_ATTACK);
   #endif
@@ -578,6 +580,8 @@ bool WiFiScan::shutdownWiFi() {
       flipper_led.offLED();
     #elif defined(XIAO_ESP32_S3)
       xiao_led.offLED();
+    #elif defined(MARAUDER_M5STICKC)
+      stickc_led.offLED();
     #else
       led_obj.setMode(MODE_OFF);
     #endif
@@ -603,6 +607,8 @@ bool WiFiScan::shutdownBLE() {
         flipper_led.offLED();
       #elif defined(XIAO_ESP32_S3)
         xiao_led.offLED();
+      #elif defined(MARAUDER_M5STICKC)
+        stickc_led.offLED();
       #else
         led_obj.setMode(MODE_OFF);
       #endif
@@ -839,6 +845,8 @@ void WiFiScan::RunEvilPortal(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif
@@ -886,6 +894,8 @@ void WiFiScan::RunAPScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif
@@ -1169,6 +1179,8 @@ void WiFiScan::RunPacketMonitor(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif
@@ -1252,6 +1264,8 @@ void WiFiScan::RunEapolScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif
@@ -1407,6 +1421,8 @@ void WiFiScan::RunPwnScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif
@@ -1591,6 +1607,8 @@ void WiFiScan::RunBeaconScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif
@@ -1654,6 +1672,8 @@ void WiFiScan::RunStationScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif
@@ -1702,6 +1722,8 @@ void WiFiScan::RunRawScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif
@@ -1752,6 +1774,8 @@ void WiFiScan::RunDeauthScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif
@@ -1811,6 +1835,8 @@ void WiFiScan::RunProbeScan(uint8_t scan_mode, uint16_t color)
     flipper_led.sniffLED();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.sniffLED();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.sniffLED();
   #else
     led_obj.setMode(MODE_SNIFF);
   #endif

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -36,6 +36,8 @@
   #include "flipperLED.h"
 #elif defined(XIAO_ESP32_S3)
   #include "xiaoLED.h"
+#elif defined(MARAUDER_M5STICKC)
+  #include "stickcLED.h"
 #else
   #include "LedInterface.h"
 #endif
@@ -108,6 +110,8 @@ extern Settings settings_obj;
   extern flipperLED flipper_led;
 #elif defined(XIAO_ESP32_S3)
   extern xiaoLED xiao_led;
+#elif defined(MARAUDER_M5STICKC)
+  extern stickcLED stickc_led;
 #else
   extern LedInterface led_obj;
 #endif

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -30,7 +30,7 @@
     #define HAS_BATTERY
     #define HAS_BT
     #define HAS_BUTTONS
-    #define HAS_NEOPIXEL_LED
+    //#define HAS_NEOPIXEL_LED
     #define HAS_PWR_MGMT
     #define HAS_SCREEN
     #define HAS_SD
@@ -238,8 +238,8 @@
       #define TFT_CS 5
       #define TFT_DC 23
       #define TFT_RST 18
-      #define TFT_BL 10
-      #define TOUCH_CS 10
+      #define TFT_BL -1
+      #define TOUCH_CS -1
       //#define SD_CS 1
 
       #define SCREEN_BUFFER

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -39,6 +39,8 @@ https://www.online-utility.org/image/convert/to/XBM
   #include "flipperLED.h"
 #elif defined(XIAO_ESP32_S3)
   #include "xiaoLED.h"
+#elif defined(MARAUDER_M5STICKC)
+  #include "stickcLED.h"
 #else
   #include "LedInterface.h"
 #endif
@@ -121,6 +123,8 @@ CommandLine cli_obj;
   flipperLED flipper_led;
 #elif defined(XIAO_ESP32_S3)
   xiaoLED xiao_led;
+#elif defined(MARAUDER_M5STICKC)
+  stickcLED stickc_led;
 #else
   LedInterface led_obj;
 #endif
@@ -339,6 +343,8 @@ void setup()
     flipper_led.RunSetup();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.RunSetup();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.RunSetup();
   #else
     led_obj.RunSetup();
   #endif
@@ -435,6 +441,8 @@ void loop()
     flipper_led.main();
   #elif defined(XIAO_ESP32_S3)
     xiao_led.main();
+  #elif defined(MARAUDER_M5STICKC)
+    stickc_led.main();
   #else
     led_obj.main(currentTime);
   #endif

--- a/esp32_marauder/stickcLED.cpp
+++ b/esp32_marauder/stickcLED.cpp
@@ -1,0 +1,53 @@
+#include "stickcLED.h"
+// NB M5Stick C Plus LED is active low, so digitalWrite() calls are inverted
+void stickcLED::RunSetup() {
+    pinMode(STICKC_LED_PIN, OUTPUT);
+
+if (!settings_obj.loadSetting<bool>("EnableLED")) {
+    digitalWrite(STICKC_LED_PIN, HIGH);
+    return;
+}
+
+delay(50);
+
+  digitalWrite(STICKC_LED_PIN, LOW);
+  delay(500);
+  digitalWrite(STICKC_LED_PIN, HIGH);
+  delay(250);
+  digitalWrite(STICKC_LED_PIN, LOW);
+  delay(500);
+  digitalWrite(STICKC_LED_PIN, HIGH);
+  delay(250);
+  digitalWrite(STICKC_LED_PIN, LOW);
+  delay(500);
+  digitalWrite(STICKC_LED_PIN, HIGH);
+}
+
+void stickcLED::attackLED() {
+  if (!settings_obj.loadSetting<bool>("EnableLED"))
+    return;
+    
+  digitalWrite(STICKC_LED_PIN, LOW);
+  delay(300);
+  digitalWrite(STICKC_LED_PIN, HIGH);
+}
+
+void stickcLED::sniffLED() {
+  if (!settings_obj.loadSetting<bool>("EnableLED"))
+    return;
+    
+  digitalWrite(STICKC_LED_PIN, LOW);
+  delay(300);
+  digitalWrite(STICKC_LED_PIN, HIGH);
+}
+
+void stickcLED::offLED() {
+  if (!settings_obj.loadSetting<bool>("EnableLED"))
+    return;
+  
+  digitalWrite(STICKC_LED_PIN, HIGH);
+}
+
+void stickcLED::main() {
+  // do nothing
+}

--- a/esp32_marauder/stickcLED.h
+++ b/esp32_marauder/stickcLED.h
@@ -1,0 +1,23 @@
+#ifndef stickcLED_H
+#define stickcLED_H
+
+#include "configs.h"
+#include "settings.h"
+
+#include <Arduino.h>
+
+#define STICKC_LED_PIN 10
+
+extern Settings settings_obj;
+
+class stickcLED {
+
+    public:
+        void RunSetup();
+        void main();
+        void attackLED();
+        void sniffLED();
+        void offLED();
+};
+
+#endif  /* stickcLED_H */


### PR DESCRIPTION
This is tied to Issue #371 
Note that when Pin 10 is HIGH the LED is off. When Pin 10 is LOW the LED is on, counter to how you would expect. See stickcLED.cpp for details. I added support for the M5Stick LED on pin 10, reusing the pattern for Flipper and Xiao boards, however it seems like something else is still trying to use pin 10, lighting the LED back up when the menu comes back.

TFT_BL and TOUCH_CS were both set to pin 10 in the MARAUDER_M5STICKC definitions despite the fact that the TFT backlight is controlled by AXP192 and there's no touch screen. Setting both of those to -1 didn't remedy it. While sniffing and scanning, the LED blinks and goes dark. I'm still hunting down what's pulling Pin 10 low at the menu screen to fully resolve issue #371 