### PR TITLE
Add support for ElectronicCats Wi-Fi Marauder Flipper Shield

### DIFF
--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -144,6 +144,8 @@
     //#define HAS_NEOPIXEL_LED
     //#define HAS_PWR_MGMT
     //#define HAS_SCREEN
+    // To support ElectronicCats Wi-Fi Marauder
+    //#define EC_ESP32_S3
     #define HAS_GPS
     #ifndef WRITE_PACKETS_SERIAL
       #define HAS_SD
@@ -197,9 +199,9 @@
   //// FLIPPER ZERO HAT SETTINGS
   #ifdef FLIPPER_ZERO_HAT
 
-    //#ifdef MARAUDER_FLIPPER
-    //  #define USE_FLIPPER_SD
-    //#endif
+    #ifdef MARAUDER_FLIPPER
+     #define USE_FLIPPER_SD
+    #endif
 
     #ifdef XIAO_ESP32_S3
       #define USE_FLIPPER_SD
@@ -786,6 +788,13 @@
     #ifdef USE_FLIPPER_SD
       #define XIAO_RX1 1
       #define XIAO_TX1 2
+    #endif
+  #endif
+
+  #ifdef EC_ESP32_S3
+    #ifdef USE_FLIPPER_SD
+      #define EC_ESP32_S3_RX1 18
+      #define EC_ESP32_S3_TX1 17
     #endif
   #endif
   //// END BOARD PIN OVERRIDES

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -203,6 +203,8 @@ void setup()
     
     #ifdef XIAO_ESP32_S3
       Serial1.begin(115200, SERIAL_8N1, XIAO_RX1, XIAO_TX1);
+    #elif EC_ESP32_S3
+      Serial1.begin(115200, SERIAL_8N1, EC_ESP32_S3_RX1, EC_ESP32_S3_TX1);
     #else
       Serial1.begin(115200);
     #endif


### PR DESCRIPTION
This adds support for [ElectronicCats Wi-Fi Marauder Flipper Add-On](https://electroniccats.com/store/flipper-add-on-marauder_spoof/)

Only `TX1` and `RX1` pins need to be changed.