### PR TITLE
NMEA Passthrough: BUG FIX + Queue Display Feature Add

### DIFF
--- a/esp32_marauder/GpsInterface.cpp
+++ b/esp32_marauder/GpsInterface.cpp
@@ -102,8 +102,8 @@ void GpsInterface::enqueue(MicroNMEA& nmea){
                     if(this->text_in){
                       int size=text_in->size();
                       if(size){
-                        #ifdef GPS_TEXT_MAXCOPIES
-                          if(this->text_cycles>=GPS_TEXT_MAXCOPIES){
+                        #ifdef GPS_TEXT_MAXCYCLES
+                          if(this->text_cycles>=GPS_TEXT_MAXCYCLES){
                         #else
                           if(this->text_cycles){
                         #endif
@@ -158,8 +158,8 @@ void GpsInterface::enqueue(MicroNMEA& nmea){
                   #else
                     if(size>=5){
                   #endif
-                      #ifdef GPS_TEXT_MAXCOPIES
-                        if(this->text_cycles>=GPS_TEXT_MAXCOPIES){
+                      #ifdef GPS_TEXT_MAXCYCLES
+                        if(this->text_cycles>=GPS_TEXT_MAXCYCLES){
                       #else
                         if(this->text_cycles){
                       #endif
@@ -198,8 +198,8 @@ void GpsInterface::enqueue(MicroNMEA& nmea){
     if(this->queue_enabled_flag){
       if(!this->queue) this->new_queue();
       if(enqueue){
-        String enqueue_me=nmea_sentence.c_str();
-        this->queue->add(enqueue_me);
+        nmea_sentence_t line = { unparsed, msg_id, nmea_sentence.c_str() };
+        this->queue->add(line);
       }
     }
     else
@@ -234,12 +234,12 @@ bool GpsInterface::queue_enabled(){
   return this->queue_enabled_flag;
 }
 
-LinkedList<String>* GpsInterface::get_queue(){
+LinkedList<nmea_sentence_t>* GpsInterface::get_queue(){
   return this->queue;
 }
 
 void GpsInterface::new_queue(){
-  this->queue=new LinkedList<String>;
+  this->queue=new LinkedList<nmea_sentence_t>;
 }
 
 void GpsInterface::flush_queue(){
@@ -250,7 +250,7 @@ void GpsInterface::flush_queue(){
 void GpsInterface::flush_queue_nmea(){
   if(this->queue){
     if(this->queue->size()){
-      LinkedList<String> *delme=this->queue;
+      LinkedList<nmea_sentence_t> *delme=this->queue;
       this->new_queue();
       delete delme;
     }

--- a/esp32_marauder/GpsInterface.cpp
+++ b/esp32_marauder/GpsInterface.cpp
@@ -196,11 +196,25 @@ void GpsInterface::enqueue(MicroNMEA& nmea){
       this->notparsed_nmea_sentence = nmea_sentence.c_str();
 
     if(this->queue_enabled_flag){
-      if(!this->queue) this->new_queue();
       if(enqueue){
         nmea_sentence_t line = { unparsed, msg_id, nmea_sentence.c_str() };
+
+        if(this->queue){
+          #ifdef GPS_NMEA_MAXQUEUE
+            if(this->queue->size()>=GPS_NMEA_MAXQUEUE)
+          #else
+            if(this->queue->size()>=30)
+          #endif
+              this->flush_queue();
+        }
+        else
+           this->new_queue();
+
         this->queue->add(line);
       }
+      else
+        if(!this->queue)
+          this->new_queue();
     }
     else
       this->flush_queue();

--- a/esp32_marauder/GpsInterface.h
+++ b/esp32_marauder/GpsInterface.h
@@ -10,7 +10,26 @@
 #include "configs.h"
 
 //#define GPS_TEXT_MAXLINES 5 //default:5 lines in the buffer maximum
-//#define GPS_TEXT_MAXCOPIES 1 //default:any nonzero number resets, i.e. one copy
+//#define GPS_TEXT_MAXCYCLES 1 //default:1
+
+//#define GPS_NMEA_SCRNLINES TEXT_HEIGHT //default: defined TEXT_HEIGHT from configs.h
+//#define GPS_NMEA_SCRNWRAP true //default:true, except on MARAUDER_MINI where false
+
+#ifdef MARAUDER_MINI
+  #ifndef GPS_NMEA_SCRNWRAP
+    #define GPS_NMEA_SCRNWRAP false
+  #endif
+#else
+  #ifndef GPS_NMEA_SCRNWRAP
+    #define GPS_NMEA_SCRNWRAP true
+  #endif
+#endif
+
+struct nmea_sentence_t {
+  bool unparsed;
+  String type;
+  String sentence;
+};
 
 void gps_nmea_notimp(MicroNMEA& nmea);
 
@@ -38,7 +57,7 @@ class GpsInterface {
     void setType(String t);
 
     void enqueue(MicroNMEA& nmea);
-    LinkedList<String>* get_queue();
+    LinkedList<nmea_sentence_t>* get_queue();
     void flush_queue();
     void flush_text();
     void new_queue();
@@ -84,9 +103,9 @@ class GpsInterface {
     type_t type_flag = GPSTYPE_NATIVE;
 
     bool queue_enabled_flag=0;
-    LinkedList<String> *queue=NULL;
+    LinkedList<nmea_sentence_t> *queue=NULL;
 
-    int text_cycles=0;
+    unsigned int text_cycles=0;
     LinkedList<String> *text_in=NULL;
     LinkedList<String> *text=NULL;
 

--- a/esp32_marauder/GpsInterface.h
+++ b/esp32_marauder/GpsInterface.h
@@ -14,6 +14,7 @@
 
 //#define GPS_NMEA_SCRNLINES TEXT_HEIGHT //default: defined TEXT_HEIGHT from configs.h
 //#define GPS_NMEA_SCRNWRAP true //default:true, except on MARAUDER_MINI where false
+//#define GPS_NMEA_MAXQUEUE 30 //default:30 messages max in queue
 
 #ifdef MARAUDER_MINI
   #ifndef GPS_NMEA_SCRNWRAP

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1688,6 +1688,7 @@ void MenuFunctions::RunSetup()
       gpsInfoMenu.parentMenu = &deviceMenu;
       this->addNodes(&gpsInfoMenu, text09, TFT_LIGHTGREY, NULL, 0, [this]() {
         wifi_scan_obj.currentScanMode = WIFI_SCAN_OFF;
+        wifi_scan_obj.StartScan(WIFI_SCAN_OFF);
         this->changeMenu(gpsInfoMenu.parentMenu);
       }); 
     }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -4825,7 +4825,9 @@ void WiFiScan::main(uint32_t currentTime)
       packets_sent = 0;
     }
   }
-  else if ((currentScanMode == WIFI_SCAN_OFF))
-    if(gps_obj.queue_enabled())
-      gps_obj.disable_queue();
+  #ifdef HAS_GPS
+    else if ((currentScanMode == WIFI_SCAN_OFF))
+      if(gps_obj.queue_enabled())
+        gps_obj.disable_queue();
+  #endif
 }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -4825,4 +4825,7 @@ void WiFiScan::main(uint32_t currentTime)
       packets_sent = 0;
     }
   }
+  else if ((currentScanMode == WIFI_SCAN_OFF))
+    if(gps_obj.queue_enabled())
+      gps_obj.disable_queue();
 }


### PR DESCRIPTION
BUG FIX: When stopping the NMEA Passthrough via the screen, as opposed to serial, the stopscan function was never called, which led to the queue staying active after exit, promptly filling up available heap and forcing reboot.

FIX: Now call stopscan (via startscan(SCAN_OFF)) upon exiting the GPS menu, such as when leaving NMEA Passthrough.

SAFTEY MECHANISM ADDED: RunScan now checks if the scan is off yet the queue is on and disables it if so.

FEATURES ADDED:

1) Above bug fix and safety mechanism
2) Fixed all-on-one-line display of NMEA passthrough, printing each line of output on its own line
3) Now prints all text, and the final two sentences (GxGGA and GxRMC), and fills all available space on the screen (as defined by configs.h) with other sentences from the queue, using the available real estate fully.
4) Wrap is accounted for in the line count.
5) Wrap is now off for GxTXT parsed display.
6) Wrap is on (by default) for everything but the MINI, where it is off.
7) Dynamically sizes output for available screen real estate.

TESTED ON: Flipper Dev Board, Marauder v6 with GPS module (and screen)
PARTIALLY TESTED ON: Mini, no GPS module

NOTE: This fixes a bug I couldn't see until I had screen-capable hardware with GPS to test with.  (I note I mentioned only headless had been tested in my last PR.)  This version should be quite stable, but the display aspects have not been tested on the mini, I'm coding blind.