### PR TITLE
Enable easier inclusion in other projects

### DIFF
--- a/esp32_marauder/CommandLine.h
+++ b/esp32_marauder/CommandLine.h
@@ -151,7 +151,9 @@ class CommandLine {
     LinkedList<String> parseCommand(String input, char* delim);
     String toLowerCase(String str);
     void filterAccessPoints(String filter);
+#ifndef ENABLE_NONSERIAL_COMMAND_EXECUTION
     void runCommand(String input);
+#endif
     bool checkValueExists(LinkedList<String>* cmd_args_list, int index);
     bool inRange(int max, int index);
     bool apSelected();
@@ -191,6 +193,9 @@ class CommandLine {
 
     void RunSetup();
     void main(uint32_t currentTime);
+#ifdef ENABLE_NONSERIAL_COMMAND_EXECUTION
+    void runCommand(String input);
+#endif
 };
 
 #endif

--- a/esp32_marauder/GpsInterface.h
+++ b/esp32_marauder/GpsInterface.h
@@ -3,6 +3,7 @@
 #ifndef GpsInterface_h
 #define GpsInterface_h
 
+#ifdef HAS_GPS
 #include <MicroNMEA.h>
 #include <SoftwareSerial.h>
 #include <LinkedList.h>
@@ -119,4 +120,5 @@ class GpsInterface {
     void setGPSInfo();
 };
 
+#endif
 #endif

--- a/esp32_marauder/LedInterface.cpp
+++ b/esp32_marauder/LedInterface.cpp
@@ -6,6 +6,7 @@ LedInterface::LedInterface() {
 
 void LedInterface::RunSetup() {
   //Serial.println("Setting neopixel to black...");
+#ifndef DISABLE_STATUS_LED
   strip.setBrightness(0);
   strip.begin();
   strip.setPixelColor(0, strip.Color(0, 0, 0));
@@ -15,6 +16,7 @@ void LedInterface::RunSetup() {
   strip.setPixelColor(0, strip.Color(0, 0, 0));
   strip.show();
   this->initTime = millis();
+#endif
 }
 
 void LedInterface::main(uint32_t currentTime) {
@@ -50,8 +52,10 @@ uint8_t LedInterface::getMode() {
 }
 
 void LedInterface::setColor(int r, int g, int b) {
+#ifndef DISABLE_STATUS_LED
   strip.setPixelColor(0, strip.Color(r, g, b));
-  strip.show();  
+  strip.show();
+#endif
 }
 
 void LedInterface::sniffLed() {
@@ -67,6 +71,7 @@ void LedInterface::ledOff() {
 }
 
 void LedInterface::rainbow() {
+#ifndef DISABLE_STATUS_LED
   strip.setPixelColor(0, this->Wheel((0 * 256 / 100 + this->wheel_pos) % 256));
   strip.show();
 
@@ -75,9 +80,11 @@ void LedInterface::rainbow() {
   this->wheel_pos = this->wheel_pos - this->wheel_speed;
   if (this->wheel_pos < 0)
     this->wheel_pos = 255;
+#endif
 }
 
 uint32_t LedInterface::Wheel(byte WheelPos) {
+#ifndef DISABLE_STATUS_LED
   WheelPos = 255 - WheelPos;
   if(WheelPos < 85) {
     return strip.Color(255 - WheelPos * 3, 0, WheelPos * 3);
@@ -88,4 +95,5 @@ uint32_t LedInterface::Wheel(byte WheelPos) {
   }
   WheelPos -= 170;
   return strip.Color(WheelPos * 3, 255 - WheelPos * 3, 0);
+#endif
 }

--- a/esp32_marauder/LedInterface.h
+++ b/esp32_marauder/LedInterface.h
@@ -6,7 +6,10 @@
 #include "configs.h"
 #include "settings.h"
 #include <Arduino.h>
+
+#ifndef DISABLE_STATUS_LED
 #include <Adafruit_NeoPixel.h>
+#endif
 
 #define Pixels 1
 
@@ -17,7 +20,10 @@
 #define MODE_CUSTOM 4
 
 extern Settings settings_obj;
+
+#ifndef DISABLE_STATUS_LED
 extern Adafruit_NeoPixel strip;
+#endif
 
 class LedInterface {
 

--- a/esp32_marauder/SDInterface.cpp
+++ b/esp32_marauder/SDInterface.cpp
@@ -3,7 +3,7 @@
 
 
 bool SDInterface::initSD() {
-  #ifdef HAS_SD
+  #if defined HAS_SD && !defined USE_SD_MMC_INTERFACE
     String display_string = "";
 
     #ifdef KIT
@@ -86,7 +86,6 @@ bool SDInterface::initSD() {
     
       return true;
   }
-
   #else
     Serial.println("SD support disabled, skipping init");
     return false;

--- a/esp32_marauder/SDInterface.h
+++ b/esp32_marauder/SDInterface.h
@@ -6,7 +6,13 @@
 #include "configs.h"
 
 #include "settings.h"
-#include "SD.h"
+#ifdef USE_SD_MMC_INTERFACE
+  #include "SD_MMC.h"
+  #define SD  SD_MMC
+#else
+  #include "SD.h"
+#endif
+
 #include "Buffer.h"
 #ifdef HAS_SCREEN
   #include "Display.h"

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -20,6 +20,7 @@ extern "C" int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32
 extern "C" {
   uint8_t esp_base_mac_addr[6];
   esp_err_t esp_ble_gap_set_rand_addr(const uint8_t *rand_addr);
+  esp_err_t esp_base_mac_addr_set(const uint8_t *addr);
 }
 
 #ifdef HAS_BT

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -208,8 +208,6 @@ class WiFiScan
       "08 and hurt you"
     };
 
-    char* prefix = "G";
-
     typedef struct
     {
       int16_t fctl;

--- a/esp32_marauder/settings.h
+++ b/esp32_marauder/settings.h
@@ -24,6 +24,7 @@ class Settings {
 
   public:
     bool begin();
+    bool begin(fs::FS fs, String filename);
 
     template <typename T>
     T loadSetting(String name);
@@ -50,6 +51,7 @@ class Settings {
 
     String getSettingsString();
     bool createDefaultSettings(fs::FS &fs);
+    bool createDefaultSettings(fs::FS &fs, String filename);
     void printJsonSettings(String json_string);
     void main(uint32_t currentTime);
 };


### PR DESCRIPTION
Hi,

First thanks for creating the project. I'm interested in using the command line interface from my project instead of the serial interface. This has require a few small changes to tweak which include:
* You can load settings from the SD card rather than SPIFFS
* GPS, LED and SD card can be conditionally compiled out (I use the SD_MMC interface)
* runCommand is exposed if ENABLE_NONSERIAL_COMMAND_EXECUTION is defined
* Its been ported to the latest ESP32 Arduino library