### PR TITLE
ForcePMKID/Probe "false" by default, and not hopping channel on sniff pmkid act. targeted

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -5365,11 +5365,11 @@ void WiFiScan::main(uint32_t currentTime)
     #endif
   }
   else if (currentScanMode == WIFI_SCAN_ACTIVE_LIST_EAPOL) {
-    if (currentTime - initTime >= this->channel_hop_delay * 1000)
-    {
-      initTime = millis();
-      channelHop();
-    }
+    // if (currentTime - initTime >= this->channel_hop_delay * 1000)
+    // {
+    //  initTime = millis();
+    //  channelHop();
+    // } for a better accuracy of eapol (pmkid) sniffing, probably it's better to avoid channelHopping, so we will keep "set_channel" fixed. We remember that with this scan_mode we will inject deauths only to selected network from list (to avoid "hitting" other networks that are probably in the same channel, as it can happen with the base version of active eapol scan).
     #ifdef HAS_SCREEN
       eapolMonitorMain(currentTime);
     #endif    

--- a/esp32_marauder/settings.cpp
+++ b/esp32_marauder/settings.cpp
@@ -266,13 +266,13 @@ bool Settings::createDefaultSettings(fs::FS &fs) {
 
   jsonBuffer["Settings"][0]["name"] = "ForcePMKID";
   jsonBuffer["Settings"][0]["type"] = "bool";
-  jsonBuffer["Settings"][0]["value"] = true;
+  jsonBuffer["Settings"][0]["value"] = false; // as default it's better to not force the injection of deauth packets when we do passive sniff of EAPOL (pmkid)
   jsonBuffer["Settings"][0]["range"]["min"] = false;
   jsonBuffer["Settings"][0]["range"]["max"] = true;
 
   jsonBuffer["Settings"][1]["name"] = "ForceProbe";
   jsonBuffer["Settings"][1]["type"] = "bool";
-  jsonBuffer["Settings"][1]["value"] = true;
+  jsonBuffer["Settings"][1]["value"] = false; // as default it's better to not force the injection of deauth packets when we do passive sniff of PROBE packets
   jsonBuffer["Settings"][1]["range"]["min"] = false;
   jsonBuffer["Settings"][1]["range"]["max"] = true;
 


### PR DESCRIPTION
ForcePMKID and ForceProbe settings are now "disabled" by default, for security reasons (otherwise passive scans can become active unintentionally). The sniff PMKID active targeted list injects deauth only to the selected networks operating in the current channel (which is now fixed and does not hop automatically, so the scan will be more targeted and effective).