### PR TITLE
CYD GPS and Adafruit MAX17048 pin update

### DIFF
--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -2008,4 +2008,3 @@
 
   //// END FUNNY FLIPPER LED STUFF
 #endif
-

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -23,7 +23,7 @@
   //#define XIAO_ESP32_S3
   //#define MARAUDER_REV_FEATHER
   //#define MARAUDER_CYD_MICRO // 2432S028
-  //#define MARAUDER_CYD_2USB // Another 2432S028 but it has tWo UsBs OoOoOoO
+  #define MARAUDER_CYD_2USB // Another 2432S028 but it has tWo UsBs OoOoOoO
   //#define MARAUDER_CYD_GUITION // ESP32-2432S024 GUITION
   //// END BOARD TARGETS
 
@@ -185,7 +185,7 @@
   #ifdef MARAUDER_CYD_MICRO
     #define HAS_FLIPPER_LED
     //#define FLIPPER_ZERO_HAT
-    //#define HAS_BATTERY
+    #define HAS_BATTERY
     #define HAS_BT
     #define HAS_BT_REMOTE
     #define HAS_BUTTONS
@@ -1802,11 +1802,11 @@
       #define GPS_RX 13
     #elif defined(MARAUDER_CYD_MICRO)
       #define GPS_SERIAL_INDEX 2
-      #define GPS_TX 27 // Fits the extended I/O
-      #define GPS_RX 22
+      #define GPS_TX 1 // Community pinout matching old forks and even bruce firmware allowing for hardware standardization
+      #define GPS_RX 3
     #elif defined(MARAUDER_CYD_2USB)
       #define GPS_SERIAL_INDEX 2
-      #define GPS_TX 1 // Changed to Fr4nkFletcher's Pinout for compatibility with custom expansion boards already developed. Allowing backwards compatibility. 
+      #define GPS_TX 1 // Community pinout matching old forks and even bruce firmware allowing for hardware standardization
       #define GPS_RX 3
     #elif defined(MARAUDER_CYD_GUITION)
       #define GPS_SERIAL_INDEX 2
@@ -1894,6 +1894,11 @@
 
     #ifdef MARAUDER_V7_1
       #define I2C_SDA 33
+      #define I2C_SCL 27
+    #endif
+
+    #ifdef MARAUDER_CYD_MICRO
+      #define I2C_SDA 22
       #define I2C_SCL 27
     #endif
 
@@ -2003,3 +2008,4 @@
 
   //// END FUNNY FLIPPER LED STUFF
 #endif
+

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -23,7 +23,7 @@
   //#define XIAO_ESP32_S3
   //#define MARAUDER_REV_FEATHER
   //#define MARAUDER_CYD_MICRO // 2432S028
-  #define MARAUDER_CYD_2USB // Another 2432S028 but it has tWo UsBs OoOoOoO
+  //#define MARAUDER_CYD_2USB // Another 2432S028 but it has tWo UsBs OoOoOoO
   //#define MARAUDER_CYD_GUITION // ESP32-2432S024 GUITION
   //// END BOARD TARGETS
 

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -203,7 +203,7 @@
   #ifdef MARAUDER_CYD_2USB
     #define HAS_FLIPPER_LED
     //#define FLIPPER_ZERO_HAT
-    //#define HAS_BATTERY
+    #define HAS_BATTERY
     #define HAS_BT
     #define HAS_BT_REMOTE
     #define HAS_BUTTONS
@@ -1806,8 +1806,8 @@
       #define GPS_RX 22
     #elif defined(MARAUDER_CYD_2USB)
       #define GPS_SERIAL_INDEX 2
-      #define GPS_TX 27 // Fits the extended I/O
-      #define GPS_RX 22
+      #define GPS_TX 1 // Changed to Fr4nkFletcher's Pinout for compatibility with custom expansion boards already developed. Allowing backwards compatibility. 
+      #define GPS_RX 3
     #elif defined(MARAUDER_CYD_GUITION)
       #define GPS_SERIAL_INDEX 2
       #define GPS_TX 21 // Fits the extended I/O
@@ -1894,6 +1894,11 @@
 
     #ifdef MARAUDER_V7_1
       #define I2C_SDA 33
+      #define I2C_SCL 27
+    #endif
+
+    #ifdef MARAUDER_CYD_2USB
+      #define I2C_SDA 22
       #define I2C_SCL 27
     #endif
 


### PR DESCRIPTION
This changes the pin mapping for the CYD 2.8 inch dev boards to match what other Marauder forks have used previously. There are many custom builds and even custom expansion boards that use the pins from Fr4nkFletchers fork. This change will prevent the community from needing to adapt their builds, and match Bruce firmware (also allowing for hardware compatibility across firmwares). This also adds compatibility for the Adafruit MAX17048 module!

Adafruit MAX17048 module: CN1 port
GPS: P1 port