### PR TITLE
Select AP for EP but deauth multiple

### DIFF
--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -28,6 +28,8 @@ void EvilPortal::setup() {
 }
 
 void EvilPortal::cleanup() {
+  this->ap_index = -1;
+
   #ifdef HAS_PSRAM
     free(index_html);
     index_html = nullptr;
@@ -193,11 +195,13 @@ bool EvilPortal::setHtml() {
 
 bool EvilPortal::setAP(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_points) {
   // See if there are selected APs first
+  int targ_ap_index = -1;
   String ap_config = "";
   String temp_ap_name = "";
   for (int i = 0; i < access_points->size(); i++) {
     if (access_points->get(i).selected) {
       temp_ap_name = access_points->get(i).essid;
+      targ_ap_index = i;
       break;
     }
   }
@@ -295,6 +299,7 @@ bool EvilPortal::setAP(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_
     strncpy(apName, ap_config.c_str(), MAX_AP_NAME_SIZE);
     this->has_ap = true;
     Serial.println("ap config set");
+    this->ap_index = targ_ap_index;
     return true;
   }
   else

--- a/esp32_marauder/EvilPortal.h
+++ b/esp32_marauder/EvilPortal.h
@@ -104,6 +104,8 @@ class EvilPortal {
   public:
     EvilPortal();
 
+    int ap_index = -1;
+
     String target_html_name = "index.html";
     uint8_t selected_html_index = 0;
 

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -188,6 +188,7 @@ class MenuFunctions
     Menu wifiGeneralMenu;
     Menu wifiAPMenu;
     Menu wifiIPMenu;
+    Menu ssidsMenu;
     #ifdef HAS_BT
       Menu airtagMenu;
     #endif
@@ -210,6 +211,8 @@ class MenuFunctions
 
     // Settings things menus
     Menu generateSSIDsMenu;
+
+    Menu evilPortalMenu;
 
     static void lv_tick_handler();
 

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -7576,7 +7576,7 @@ void WiFiScan::main(uint32_t currentTime)
     }
   }
   else if (currentScanMode == WIFI_SCAN_EVIL_PORTAL) {
-    if (currentTime - initTime >= this->channel_hop_delay * HOP_DELAY) {
+    if (currentTime - initTime >= (this->channel_hop_delay * HOP_DELAY) / 2) {
       initTime = millis();
       if (this->ep_deauth) {
         for (int i = 0; i < access_points->size(); i++) {
@@ -7586,6 +7586,10 @@ void WiFiScan::main(uint32_t currentTime)
         }
       }
     }
+
+    if (evil_portal_obj.ap_index > -1)
+      this->changeChannel(access_points->get(evil_portal_obj.ap_index).channel);
+    
     evil_portal_obj.main(currentScanMode);
   }
   else if (currentScanMode == WIFI_PACKET_MONITOR)


### PR DESCRIPTION
You now have the ability to start evil portal by selecting from your lists of APs and SSIDs. Additionally, any APs marked at selected, as long as EPDeauth setting is enabled, will result in deauthentication attacks being executed against those APs