### PR TITLE
Add night mode: hold-to-blackout with progressive dimming

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -1357,13 +1357,13 @@ void CommandLine::runCommand(String input) {
           brightnessCycle();
         } else if (s_arg != -1) {
           uint8_t lvl = cmd_args.get(s_arg + 1).toInt();
-          if (lvl < 10) {
+          if (lvl < 13) {
             extern void brightnessSave(uint8_t level);
             brightnessSave(lvl);
             Serial.print(F("[Brightness] Set to level "));
             Serial.println(lvl);
           } else {
-            Serial.println(F("Level must be 0-9"));
+            Serial.println(F("Level must be 0-12"));
           }
         } else {
           Serial.print(F("[Brightness] Current level: "));

--- a/esp32_marauder/CommandLine.h
+++ b/esp32_marauder/CommandLine.h
@@ -195,7 +195,7 @@ const char PROGMEM HELP_BT_WARDRIVE_CMD[] = "btwardrive";
 const char PROGMEM HELP_BT_SKIM_CMD[] = "sniffskim";
 
 const char PROGMEM BRIGHTNESS_CMD[] = "brightness";
-const char PROGMEM HELP_BRIGHTNESS_CMD[] = "brightness [-c cycle] [-s <0-9>]";
+const char PROGMEM HELP_BRIGHTNESS_CMD[] = "brightness [-c cycle] [-s <0-12>]";
 
 const char PROGMEM HELP_FOOT[] = "==================================";
 

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -186,45 +186,72 @@ void MenuFunctions::main(uint32_t currentTime)
   #endif
 
 
-  // Brightness gesture: hold top or bottom zone 1.5s to enter brightness mode
+  // Brightness gesture: hold top or bottom zone 2.5s with dimming effect → enter brightness mode
   #ifdef HAS_ILI9341
     if (pressed && (wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF ||
                     wifi_scan_obj.currentScanMode == WIFI_CONNECTED)) {
-      uint16_t zoneUp = TFT_HEIGHT * 25 / 100;
-      uint16_t zoneDown = TFT_HEIGHT * 75 / 100;
-      if (t_y < zoneUp || t_y >= zoneDown) {
+      uint16_t zoneMid = TFT_HEIGHT * 25 / 100;
+      uint16_t zoneMidEnd = TFT_HEIGHT * 75 / 100;
+      if (t_y < zoneMid || t_y >= zoneMidEnd) {
         uint32_t hold_start = millis();
         uint16_t hx, hy;
         bool held = false;
+        extern uint8_t getBrightnessLevel();
+        const uint8_t bl_lut[] = {3, 8, 15, 26, 51, 77, 102, 128, 153, 179, 204, 230, 255};
+        uint8_t cur_duty = bl_lut[getBrightnessLevel()];
+        uint8_t dim_stage = 0;
         while (display_obj.updateTouch(&hx, &hy)) {
-          if (millis() - hold_start >= 1500) {
+          uint32_t held_ms = millis() - hold_start;
+          // Progressive dim: 3 stages over 2.5s
+          if (held_ms >= 800 && dim_stage == 0) {
+            dim_stage = 1;
+            #if ESP_ARDUINO_VERSION_MAJOR >= 3
+              ledcWrite(TFT_BL, cur_duty * 2 / 3);
+            #else
+              ledcWrite(0, cur_duty * 2 / 3);
+            #endif
+          }
+          if (held_ms >= 1600 && dim_stage == 1) {
+            dim_stage = 2;
+            #if ESP_ARDUINO_VERSION_MAJOR >= 3
+              ledcWrite(TFT_BL, cur_duty / 3);
+            #else
+              ledcWrite(0, cur_duty / 3);
+            #endif
+          }
+          if (held_ms >= 2500) {
             held = true;
             break;
           }
           delay(10);
         }
         if (held) {
-          // Wait for release before entering brightness mode
-          while (display_obj.updateTouch(&hx, &hy)) delay(10);
+          // Enter brightness mode immediately — don't wait for release
           this->brightnessMode();
           return;
         }
+        // Released early — restore brightness
+        #if ESP_ARDUINO_VERSION_MAJOR >= 3
+          ledcWrite(TFT_BL, cur_duty);
+        #else
+          ledcWrite(0, cur_duty);
+        #endif
       }
     }
   #endif
 
-  // Screen blackout: hold top zone 2s during any scan → screen off
-  // Any tap while blacked out → restore at minimum brightness
+  // Screen blackout: wake on any tap → restore last saved brightness
   #ifdef HAS_ILI9341
     if (pressed && this->screen_blacked_out) {
-      // Wake from blackout at minimum brightness
       while (display_obj.updateTouch(&t_x, &t_y)) delay(10);
+      extern uint8_t getBrightnessLevel();
       extern void brightnessSave(uint8_t level);
-      brightnessSave(0);  // level 0 = duty 3 (~1%)
+      brightnessSave(getBrightnessLevel());  // restores backlight to saved level
       this->screen_blacked_out = false;
       return;
     }
 
+    // Quick blackout during scans: hold top zone 3s
     if (pressed && wifi_scan_obj.currentScanMode != WIFI_SCAN_OFF &&
         wifi_scan_obj.currentScanMode != WIFI_CONNECTED) {
       uint16_t zoneUp = TFT_HEIGHT * 25 / 100;
@@ -233,7 +260,7 @@ void MenuFunctions::main(uint32_t currentTime)
         uint16_t hx, hy;
         bool held = false;
         while (display_obj.updateTouch(&hx, &hy)) {
-          if (millis() - hold_start >= 2000) {
+          if (millis() - hold_start >= 3000) {
             held = true;
             break;
           }
@@ -241,7 +268,6 @@ void MenuFunctions::main(uint32_t currentTime)
         }
         if (held) {
           while (display_obj.updateTouch(&hx, &hy)) delay(10);
-          // Black out screen
           extern void backlightOff();
           backlightOff();
           this->screen_blacked_out = true;
@@ -3770,8 +3796,9 @@ void MenuFunctions::displayCurrentMenu(int start_index)
 
 // ============================================================
 // BRIGHTNESS ADJUSTMENT MODE
-// Hold top/bottom zone 1.5s to enter. TAP TOP = brighter, TAP BOTTOM = dimmer.
-// TAP MIDDLE or wait 3s = save & exit.
+// Hold top/bottom 3s to enter. TAP TOP = brighter, TAP BOTTOM = dimmer.
+// Hold anywhere 3s = darkening countdown → blackout.
+// Auto-save after 4s idle.
 // ============================================================
 #ifndef HAS_MINI_SCREEN
   void MenuFunctions::brightnessMode() {
@@ -3789,21 +3816,18 @@ void MenuFunctions::displayCurrentMenu(int start_index)
       #define BL_PREVIEW(duty) ledcWrite(0, (duty))
     #endif
 
+    // Restore backlight to saved level (entry gesture leaves it dimmed)
+    BL_PREVIEW(levels[level]);
+
     display_obj.tft.fillScreen(TFT_BLACK);
     display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
     display_obj.tft.drawCentreString("BRIGHTNESS", TFT_WIDTH/2, 30, 2);
 
-    display_obj.tft.setTextColor(TFT_DARKGREY, TFT_BLACK);
+    display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
     display_obj.tft.drawCentreString("TAP TOP = BRIGHTER", TFT_WIDTH/2, 10, 1);
-    display_obj.tft.drawCentreString("TAP BOTTOM = DIMMER", TFT_WIDTH/2, TFT_HEIGHT/2 + 45, 1);
+    display_obj.tft.drawCentreString("TAP BOTTOM = DIMMER", TFT_WIDTH/2, TFT_HEIGHT - 30, 1);
     display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
-    display_obj.tft.drawCentreString("TAP MIDDLE = SAVE", TFT_WIDTH/2, TFT_HEIGHT/2 + 60, 1);
-    // Blackout button — full width, 50px tall at bottom (same feel as POI button)
-    uint16_t boY = TFT_HEIGHT - 50;
-    display_obj.tft.fillRect(0, boY, TFT_WIDTH, 50, TFT_BLACK);
-    display_obj.tft.drawRect(0, boY, TFT_WIDTH, 50, TFT_RED);
-    display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
-    display_obj.tft.drawCentreString("BLACKOUT", TFT_WIDTH/2, boY + 18, 2);
+    display_obj.tft.drawCentreString("HOLD = BLACKOUT", TFT_WIDTH/2, TFT_HEIGHT - 15, 1);
 
     auto drawBar = [&]() {
       uint16_t barX = 30, barY = TFT_HEIGHT/2 - 25, barW = TFT_WIDTH - 60, barH = 30;
@@ -3818,13 +3842,14 @@ void MenuFunctions::displayCurrentMenu(int start_index)
     };
     drawBar();
 
-    uint16_t zoneUp = TFT_HEIGHT * 25 / 100;
-    uint16_t zoneDown = TFT_HEIGHT * 75 / 100;
+    uint16_t zoneSplit = TFT_HEIGHT / 2;
+    // Drain any ongoing touch from entry gesture before starting loop
+    { uint16_t dx, dy; while (display_obj.updateTouch(&dx, &dy)) delay(10); }
     uint32_t lastTouch = millis();
 
     while (true) {
-      // Auto-save after 3s of no touch
-      if (millis() - lastTouch >= 3000) {
+      // Auto-save after 4s of no touch
+      if (millis() - lastTouch >= 4000) {
         brightnessSave(level);
         break;
       }
@@ -3832,32 +3857,61 @@ void MenuFunctions::displayCurrentMenu(int start_index)
       uint16_t tx, ty;
       if (display_obj.updateTouch(&tx, &ty)) {
         lastTouch = millis();
-        // Wait for release
-        while (display_obj.updateTouch(&tx, &ty)) delay(10);
+        uint32_t hold_start = millis();
+        uint8_t darken_stage = 0;
+        uint8_t saved_duty = levels[level];
+        bool blacked_out = false;
 
-        if (ty >= TFT_HEIGHT - 50) {
-          // Blackout button
-          extern void backlightOff();
-          backlightOff();
-          this->screen_blacked_out = true;
+        // Track hold duration while finger is down
+        while (display_obj.updateTouch(&tx, &ty)) {
+          uint32_t held_ms = millis() - hold_start;
+
+          // Darkening countdown: dim backlight each second toward blackout
+          if (held_ms >= 1000 && darken_stage == 0) {
+            darken_stage = 1;
+            BL_PREVIEW(saved_duty * 2 / 3);
+          }
+          if (held_ms >= 2000 && darken_stage == 1) {
+            darken_stage = 2;
+            BL_PREVIEW(saved_duty / 3);
+          }
+          if (held_ms >= 3000 && darken_stage == 2) {
+            // Save current level then blackout
+            brightnessSave(level);
+            extern void backlightOff();
+            backlightOff();
+            this->screen_blacked_out = true;
+            blacked_out = true;
+            break;
+          }
+          delay(10);
+        }
+
+        if (blacked_out) {
+          // Wait for release then exit
+          while (display_obj.updateTouch(&tx, &ty)) delay(10);
           break;
-        } else if (ty < zoneUp) {
+        }
+
+        // Released before 3s — restore brightness and handle as tap
+        BL_PREVIEW(saved_duty);
+
+        if (ty < zoneSplit) {
+          // Top half = brighter
           if (level < numLevels - 1) {
             level++;
             BL_PREVIEW(levels[level]);
             drawBar();
           }
-        } else if (ty >= zoneDown) {
+        } else {
+          // Bottom half = dimmer
           if (level > 0) {
             level--;
             BL_PREVIEW(levels[level]);
             drawBar();
           }
-        } else {
-          // Middle = save now
-          brightnessSave(level);
-          break;
         }
+        lastTouch = millis();
         delay(150);
       }
       delay(30);

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -213,6 +213,44 @@ void MenuFunctions::main(uint32_t currentTime)
     }
   #endif
 
+  // Screen blackout: hold top zone 2s during any scan → screen off
+  // Any tap while blacked out → restore at minimum brightness
+  #ifdef HAS_ILI9341
+    if (pressed && this->screen_blacked_out) {
+      // Wake from blackout at minimum brightness
+      while (display_obj.updateTouch(&t_x, &t_y)) delay(10);
+      extern void brightnessSave(uint8_t level);
+      brightnessSave(0);  // level 0 = duty 3 (~1%)
+      this->screen_blacked_out = false;
+      return;
+    }
+
+    if (pressed && wifi_scan_obj.currentScanMode != WIFI_SCAN_OFF &&
+        wifi_scan_obj.currentScanMode != WIFI_CONNECTED) {
+      uint16_t zoneUp = TFT_HEIGHT * 25 / 100;
+      if (t_y < zoneUp) {
+        uint32_t hold_start = millis();
+        uint16_t hx, hy;
+        bool held = false;
+        while (display_obj.updateTouch(&hx, &hy)) {
+          if (millis() - hold_start >= 2000) {
+            held = true;
+            break;
+          }
+          delay(10);
+        }
+        if (held) {
+          while (display_obj.updateTouch(&hx, &hy)) delay(10);
+          // Black out screen
+          extern void backlightOff();
+          backlightOff();
+          this->screen_blacked_out = true;
+          return;
+        }
+      }
+    }
+  #endif
+
   // This is if there are scans/attacks going on
   #ifdef HAS_ILI9341
     if ((wifi_scan_obj.currentScanMode != WIFI_SCAN_OFF) &&
@@ -3740,8 +3778,8 @@ void MenuFunctions::displayCurrentMenu(int start_index)
     extern void brightnessSave(uint8_t level);
     extern uint8_t getBrightnessLevel();
 
-    const uint8_t levels[] = {26, 51, 77, 102, 128, 153, 179, 204, 230, 255};
-    const uint8_t numLevels = 10;
+    const uint8_t levels[] = {3, 8, 15, 26, 51, 77, 102, 128, 153, 179, 204, 230, 255};
+    const uint8_t numLevels = 13;
     uint8_t level = getBrightnessLevel();
 
     // LEDC write compatibility (2.x vs 3.x board package)
@@ -3757,9 +3795,15 @@ void MenuFunctions::displayCurrentMenu(int start_index)
 
     display_obj.tft.setTextColor(TFT_DARKGREY, TFT_BLACK);
     display_obj.tft.drawCentreString("TAP TOP = BRIGHTER", TFT_WIDTH/2, 10, 1);
-    display_obj.tft.drawCentreString("TAP BOTTOM = DIMMER", TFT_WIDTH/2, TFT_HEIGHT - 20, 1);
+    display_obj.tft.drawCentreString("TAP BOTTOM = DIMMER", TFT_WIDTH/2, TFT_HEIGHT/2 + 45, 1);
     display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
-    display_obj.tft.drawCentreString("TAP MIDDLE or WAIT 3s = SAVE", TFT_WIDTH/2, TFT_HEIGHT/2 + 50, 1);
+    display_obj.tft.drawCentreString("TAP MIDDLE = SAVE", TFT_WIDTH/2, TFT_HEIGHT/2 + 60, 1);
+    // Blackout button — full width, 50px tall at bottom (same feel as POI button)
+    uint16_t boY = TFT_HEIGHT - 50;
+    display_obj.tft.fillRect(0, boY, TFT_WIDTH, 50, TFT_BLACK);
+    display_obj.tft.drawRect(0, boY, TFT_WIDTH, 50, TFT_RED);
+    display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
+    display_obj.tft.drawCentreString("BLACKOUT", TFT_WIDTH/2, boY + 18, 2);
 
     auto drawBar = [&]() {
       uint16_t barX = 30, barY = TFT_HEIGHT/2 - 25, barW = TFT_WIDTH - 60, barH = 30;
@@ -3791,7 +3835,13 @@ void MenuFunctions::displayCurrentMenu(int start_index)
         // Wait for release
         while (display_obj.updateTouch(&tx, &ty)) delay(10);
 
-        if (ty < zoneUp) {
+        if (ty >= TFT_HEIGHT - 50) {
+          // Blackout button
+          extern void backlightOff();
+          backlightOff();
+          this->screen_blacked_out = true;
+          break;
+        } else if (ty < zoneUp) {
           if (level < numLevels - 1) {
             level++;
             BL_PREVIEW(levels[level]);

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -265,6 +265,7 @@ class MenuFunctions
     boolean pressed = false;
 
     bool disable_touch;
+    bool screen_blacked_out = false;
 
     String loaded_file = "";
 

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -120,9 +120,9 @@ uint32_t currentTime  = 0;
   #define BL_CHANNEL 0
   #define BL_FREQ 5000
   #define BL_RESOLUTION 8
-  const uint8_t BL_LEVELS[] = {26, 51, 77, 102, 128, 153, 179, 204, 230, 255};
-  const uint8_t BL_NUM_LEVELS = 10;
-  uint8_t bl_level_idx = 9; // default full brightness
+  const uint8_t BL_LEVELS[] = {3, 8, 15, 26, 51, 77, 102, 128, 153, 179, 204, 230, 255};
+  const uint8_t BL_NUM_LEVELS = 13;
+  uint8_t bl_level_idx = 12; // default full brightness
   Preferences bl_prefs;
 #endif
 
@@ -144,8 +144,8 @@ uint32_t currentTime  = 0;
     #ifdef HAS_SCREEN
       BL_SETUP();
       bl_prefs.begin("backlight", false);
-      bl_level_idx = bl_prefs.getUChar("level", 9);
-      if (bl_level_idx >= BL_NUM_LEVELS) bl_level_idx = 9;
+      bl_level_idx = bl_prefs.getUChar("level", 12);
+      if (bl_level_idx >= BL_NUM_LEVELS) bl_level_idx = 12;
       BL_SET(BL_LEVELS[bl_level_idx]);
     #endif
   }


### PR DESCRIPTION
## Summary
Redesigned brightness and blackout UX for touchscreen boards. Replaces the old blackout button (which overlapped the dimmer zone) with a gesture-based system using progressive screen dimming as visual feedback.

### Changes
- **Entry**: Hold top or bottom zone for 2.5s → screen progressively dims as feedback → enters brightness mode
- **Brightness adjustment**: Tap top half = brighter, tap bottom half = dimmer (clean 50/50 split, no zone conflicts)
- **Blackout**: Hold anywhere for 3s → screen darkens each second (2/3 → 1/3 → off)
- **Wake**: Tap while blacked out → restores to last saved brightness level
- **Auto-save**: Exits and saves after 4s of no touch (no manual save button needed)
- **Quick blackout during scans**: Hold top zone 3s → immediate blackout
- Ultra-low brightness levels (1%, 3%, 6%) for pitch dark environments — addresses #1091

### Files Changed
- `MenuFunctions.cpp` — brightness mode UX, entry gesture, blackout logic, wake-from-blackout restore

### Removed
- Blackout button (caused zone overlap with dimmer)
- Middle-zone "save" tap (replaced by auto-save on idle)
- Fixed 1% wake brightness (now restores to saved level)

## Test plan
- [ ] Hold top/bottom zone 2.5s from main menu → screen dims progressively → brightness mode opens
- [ ] Release early during hold → screen restores, no mode change
- [ ] Tap top half in brightness mode → brightness increases
- [ ] Tap bottom half → brightness decreases
- [ ] Stop touching for 4s → auto-saves and exits to menu
- [ ] Hold anywhere 3s in brightness mode → screen darkens each second → blackout
- [ ] Tap while blacked out → wakes at last saved brightness (not 1%)
- [ ] Start a scan, hold top zone 3s → quick blackout
- [ ] `brightness -s 0` via CLI → sets to 1% (ultra-low)
- [ ] Brightness persists across reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)