### PR TITLE
fix(core): add task wdt feeding to prevent reboots during attack loops

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1,4 +1,5 @@
 #include "esp_random.h"
+#include "esp_task_wdt.h"
 #include "WiFiScan.h"
 #include "lang_var.h"
 
@@ -8720,6 +8721,7 @@ void WiFiScan::broadcastCustomBeacon(uint32_t current_time, AccessPoint custom_s
 
   this->changeChannel(this->set_channel);
   delay(1);
+  esp_task_wdt_reset();
 
   // Figure out what's going at the end and the lengths
   uint8_t temp[64]; // big enough for worst case
@@ -8825,7 +8827,8 @@ void WiFiScan::broadcastCustomBeacon(uint32_t current_time, ssid custom_ssid) {
   memcpy(temp_frame, packet, frame_len);
 
   this->changeChannel(this->set_channel);
-  delay(1);  
+  delay(1);
+  esp_task_wdt_reset();
 
   // Randomize SRC MAC
   temp_frame[10] = temp_frame[16] = custom_ssid.bssid[0];
@@ -8860,7 +8863,8 @@ void WiFiScan::broadcastSetSSID(uint32_t current_time, const char* ESSID) {
   #endif
   this->changeChannel(this->set_channel);
 
-  delay(1);  
+  delay(1);
+  esp_task_wdt_reset();
 
   // Randomize SRC MAC
   packet[10] = packet[16] = random(256);
@@ -9018,7 +9022,8 @@ void WiFiScan::sendDeauthFrame(uint8_t bssid[6], int channel, uint8_t mac[6]) {
   WiFiScan::set_channel = channel;
   this->changeChannel(channel);
   delay(1);
-  
+  esp_task_wdt_reset();
+
   // Build AP source packet
   deauth_frame_default[4] = mac[0];
   deauth_frame_default[5] = mac[1];
@@ -9116,6 +9121,7 @@ void WiFiScan::sendEapolBagMsg1(uint8_t bssid[6], int channel, uint8_t mac[6], u
   WiFiScan::set_channel = channel;
   this->changeChannel(channel);
   delay(1);
+  esp_task_wdt_reset();
 
   uint8_t frame_size = 153;
 
@@ -9168,6 +9174,7 @@ void WiFiScan::sendEapolBagMsg1(uint8_t bssid[6], int channel, String dst_mac_st
   WiFiScan::set_channel = channel;
   this->changeChannel(channel);
   delay(1);
+  esp_task_wdt_reset();
 
   uint8_t frame_size = 153;
 
@@ -9216,6 +9223,7 @@ void WiFiScan::sendAssociationSleep(const char* ESSID, uint8_t bssid[6], int cha
   WiFiScan::set_channel = channel;
   this->changeChannel(channel);
   delay(1);
+  esp_task_wdt_reset();
 
   static uint16_t sequence_number = 0;
 


### PR DESCRIPTION
## Description
This PR addresses spontaneous Task Watchdog Timer (TWDT) reboots occurring during intensive attack loops (e.g., deauth/beacon spam). 

### Problem
In dense environments or during long-running attack sequences, the loops within `WiFiScan.cpp` (like `sendDeauthFrame` or `broadcastCustomBeacon`) do not always yield enough time for the Idle task to feed the TWDT. This leads to watchdog timeouts and unexpected device reboots in the field.

### Changes
- Added `#include "esp_task_wdt.h"` to `WiFiScan.cpp`.
- Integrated `esp_task_wdt_reset()` within critical attack functions to ensure the watchdog is fed during high-frequency packet transmission.

### Impact
- Improved system stability during all Wi-Fi based attacks.
- Prevents "Reboot loops" when the device is under heavy RF load.

| Function | Change |
| :--- | :--- |
| `broadcastCustomBeacon` | Added WDT reset per iteration |
| `sendDeauthFrame` | Added WDT reset per iteration |
| `sendEapolBugMsg1` | Added WDT reset |
| `sendAssociationSleep` | Added WDT reset |

Tested on ESP32-S1 (Marauder) - no spontaneous reboots observed after 30+ mins of continuous deauth spam.