### PR TITLE
Upgrade/arduino esp32 v3

### DIFF
--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -4,6 +4,8 @@ char apName[MAX_AP_NAME_SIZE] = "PORTAL";
 
 #ifdef HAS_PSRAM
   char* index_html = nullptr;
+#else
+  extern char index_html[MAX_HTML_SIZE] = "TEST";
 #endif
 
 AsyncWebServer server(80);

--- a/esp32_marauder/EvilPortal.h
+++ b/esp32_marauder/EvilPortal.h
@@ -39,10 +39,10 @@ extern Buffer buffer_obj;
 
 extern char apName[MAX_AP_NAME_SIZE];
 
-#ifndef HAS_PSRAM
-  char index_html[MAX_HTML_SIZE] = "TEST";
+#ifdef HAS_PSRAM
+  extern char* index_html ;
 #else
-  extern char* index_html;
+  extern char index_html[MAX_HTML_SIZE] ;
 #endif
 
 struct ssid {

--- a/esp32_marauder/GpsInterface.cpp
+++ b/esp32_marauder/GpsInterface.cpp
@@ -8,7 +8,7 @@ char nmeaBuffer[100];
 
 MicroNMEA nmea(nmeaBuffer, sizeof(nmeaBuffer));
 
-HardwareSerial Serial2(GPS_SERIAL_INDEX);
+HardwareSerial SerialGPS(GPS_SERIAL_INDEX);
 
 static const char *PCAS_SET_115200 = "$PCAS01,5*19\r\n";
 
@@ -17,7 +17,7 @@ static const uint32_t PROBE_MS = 1200;
 void GpsInterface::begin() {
 
   
-  Serial2.begin(9600, SERIAL_8N1, GPS_TX, GPS_RX);
+  SerialGPS.begin(9600, SERIAL_8N1, GPS_TX, GPS_RX);
 
   uint32_t gps_baud = this->initGpsBaudAndForce115200();
 
@@ -26,18 +26,18 @@ void GpsInterface::begin() {
 
   delay(1000);
 
-  MicroNMEA::sendSentence(Serial2, "$PSTMSETPAR,1201,0x00000042");
-  MicroNMEA::sendSentence(Serial2, "$PSTMSAVEPAR");
+  MicroNMEA::sendSentence(SerialGPS, "$PSTMSETPAR,1201,0x00000042");
+  MicroNMEA::sendSentence(SerialGPS, "$PSTMSAVEPAR");
 
-  MicroNMEA::sendSentence(Serial2, "$PSTMSRR");
+  MicroNMEA::sendSentence(SerialGPS, "$PSTMSRR");
 
   delay(1000);
 
-  if (Serial2.available()) {
+  if (SerialGPS.available()) {
     this->gps_enabled = true;
-    while (Serial2.available()) {
+    while (SerialGPS.available()) {
       //Fetch the character one by one
-      char c = Serial2.read();
+      char c = SerialGPS.read();
       //Serial.print(c);
       //Pass the character to the library
       nmea.process(c);
@@ -57,18 +57,18 @@ void GpsInterface::begin() {
 }
 
 bool GpsInterface::probeBaud(uint32_t baud) {
-  Serial2.end();
+  SerialGPS.end();
   delay(50);
 
-  Serial2.begin(baud, SERIAL_8N1, GPS_TX, GPS_RX);
+  SerialGPS.begin(baud, SERIAL_8N1, GPS_TX, GPS_RX);
 
   uint32_t start = millis();
   bool sawDollar = false;
   bool parsedSentence = false;
 
   while (millis() - start < PROBE_MS) {
-    while (Serial2.available()) {
-      char c = (char)Serial2.read();
+    while (SerialGPS.available()) {
+      char c = (char)SerialGPS.read();
 
       if (c == '$') {
         sawDollar = true;
@@ -92,8 +92,8 @@ bool GpsInterface::probeBaud(uint32_t baud) {
 }
 
 void GpsInterface::setGpsTo115200From9600() {
-  Serial2.print(PCAS_SET_115200);
-  Serial2.flush();
+  SerialGPS.print(PCAS_SET_115200);
+  SerialGPS.flush();
   delay(200);
 }
 
@@ -380,7 +380,7 @@ void GpsInterface::flush_queue_textin(){
 }
 
 void GpsInterface::sendSentence(const char* sentence){
-  MicroNMEA::sendSentence(Serial2, sentence);
+  MicroNMEA::sendSentence(SerialGPS, sentence);
 }
 
 void GpsInterface::sendSentence(Stream &s, const char* sentence){
@@ -747,9 +747,9 @@ String GpsInterface::getNmeaNotparsed() {
 }
 
 void GpsInterface::main() {
-  while (Serial2.available()) {
+  while (SerialGPS.available()) {
     //Fetch the character one by one
-    char c = Serial2.read();
+    char c = SerialGPS.read();
     //Serial.print(c);
     //Pass the character to the library
     nmea.process(c);

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -35,12 +35,23 @@ LinkedList<Flipper>* flippers;
 LinkedList<IPAddress>* ipList;
 LinkedList<ProbeReqSsid>* probe_req_ssids;
 
-extern "C" int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3){
-    if (arg == 31337)
-      return 1;
-    else
-      return 0;
-}
+extern "C" int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3) ;
+
+/*
+ * Replacing the ieee80211_raw_frame_sanity_check() system function with this one no longer
+ * works in new versions of Arduino Core 3.0.0+. We'll instead patch the system library
+ * libnet80211.a so that the original function always returns OK.
+ *
+ extern "C" int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3){
+
+    Serial.printf("TX_ATTEMPT\n\r"); // Let's add this to see if this function is
+                                     // called by the driver.
+     if (arg == 31337)
+       return 1;
+     else
+       return 0;
+ }
+*/
 
 extern "C" {
   uint8_t esp_base_mac_addr[6];
@@ -1550,10 +1561,11 @@ bool WiFiScan::isFlockCamera(const uint8_t* payload, size_t len, const String& n
 }
 
 void WiFiScan::RunSetup() {
-  if (ieee80211_raw_frame_sanity_check(31337, 0, 0) == 1)
-    this->wsl_bypass_enabled = true;
+
+  if (ieee80211_raw_frame_sanity_check(31337, 0, 0) == 0)
+     this->wsl_bypass_enabled = true;
   else
-    this->wsl_bypass_enabled = false;
+     this->wsl_bypass_enabled = false;
 
   #ifdef HAS_PSRAM
     ssids = new (ps_malloc(sizeof(LinkedList<ssid>))) LinkedList<ssid>();

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -331,7 +331,9 @@ class WiFiScan
     void initWiFi(uint8_t scan_mode);
     uint8_t bluetoothScanTime = 5;
     int packets_sent = 0;
-    const wifi_promiscuous_filter_t filt = {.filter_mask=WIFI_PROMIS_FILTER_MASK_MGMT | WIFI_PROMIS_FILTER_MASK_DATA};
+    const wifi_promiscuous_filter_t filt = {
+      .filter_mask=WIFI_PROMIS_FILTER_MASK_MGMT | WIFI_PROMIS_FILTER_MASK_DATA | WIFI_PROMIS_FILTER_MASK_CTRL
+      };
     #ifdef HAS_BT
       NimBLEScan* pBLEScan;
     #endif

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -29,7 +29,7 @@
   //#define MARAUDER_CYD_2USB // Another 2432S028 but it has tWo UsBs OoOoOoO
   //#define MARAUDER_CYD_GUITION // ESP32-2432S024 GUITION
   //#define MARAUDER_CYD_3_5_INCH
-  //#define MARAUDER_C5
+  #define MARAUDER_C5
   //#define MARAUDER_CARDPUTER
   //#define MARAUDER_CARDPUTER_ADV
   //#define MARAUDER_V8
@@ -472,10 +472,10 @@
     #define HAS_NEOPIXEL_LED
     //#define HAS_PWR_MGMT
     //#define HAS_SCREEN
-    #define HAS_GPS
-    #define HAS_C5_SD
-    #define HAS_SD
-    #define USE_SD
+    //#define HAS_GPS
+    //#define HAS_C5_SD
+    //#define HAS_SD
+    //#define USE_SD
     #define HAS_DUAL_BAND
     //#define HAS_PSRAM
     //#define HAS_TEMP_SENSOR

--- a/tools/libnet_patcher.py
+++ b/tools/libnet_patcher.py
@@ -1,0 +1,35 @@
+#
+# libnet80211.a patcher
+#
+# Written by Google Ai & Anton Ermakov, 2026
+#
+
+# Replace this paths by your own.
+file_path = "/home/anton/Arduino/hardware/espressif/arduino-esp32/tools/esp32-arduino-libs/esp32c5/lib/libnet80211.a"
+
+# Find the beginning of the function
+# riscv32-esp-elf-objdump -d libnet80211.a | grep -A 15 "<ieee80211_raw_frame_sanity_check>"
+#
+# The beginning looks like this (but check with objdump!):
+target = b"\x79\x71\x06\xd6\x22\xd4\x26\xd2\x4a\xd0\x4e\xce\x52\xcc\x56\xca\x5a\xc8\x95\xe9"
+
+# Can be replaced with: li a0, 1 ​​(05 45) + ret (67 80) - always return 0x1
+# Now change to: li a0, 0 (01 45) + ret (67 80) - always return 0x0
+# The logic of this function has changed in the new library. Now, if the check 
+# is successful, it returns 0x0, and if it fails, it returns some number != 0.
+# So, we return 0x0 here.
+replacement = b"\x01\x45\x82\x80\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00"
+
+with open(file_path, "rb") as f:
+    data = f.read()
+
+count = data.count(target)
+if(count != 1):
+    print(f"Found {count} signatures. Patch is not applied!")
+    exit()
+
+if target in data:
+    new_data = data.replace(target, replacement + target[len(replacement):], 1)
+    with open(file_path, "wb") as f:
+        f.write(new_data)
+    print("Patch successully applied!")


### PR DESCRIPTION
"Hi Koko! I've got Marauder running on the new ESP32-C5-DevKit.
Key updates:

Support Arduino Core 3.0.0+
Binary patcher for libnet80211.a (bypasses sanity check for raw TX).
Fixes for Arduino Core 3.0.0+ (Serial2 renaming, EvilPortal PSRAM logic).
Enabled Control Frame filters for sniffing.
Deauthentication frames on 5 GHz are sent but freeze.