### PR TITLE
Add 38400 baud probe to GPS auto-detect for Beitian BE-280

### DIFF
--- a/esp32_marauder/GpsInterface.cpp
+++ b/esp32_marauder/GpsInterface.cpp
@@ -21,7 +21,7 @@ void GpsInterface::begin() {
 
   uint32_t gps_baud = this->initGpsBaudAndForce115200();
 
-  if ((gps_baud != 9600) && (gps_baud != 115200))
+  if ((gps_baud != 9600) && (gps_baud != 38400) && (gps_baud != 115200))
     Serial.println(F("Could not detect GPS baudrate"));
 
   delay(1000);
@@ -111,6 +111,10 @@ uint32_t GpsInterface::initGpsBaudAndForce115200() {
 
     probeBaud(9600);
     return 9600;
+  }
+
+  if (probeBaud(38400)) {
+    return 38400;
   }
 
   probeBaud(9600);


### PR DESCRIPTION
## Problem

 `GpsInterface::initGpsBaudAndForce115200()` currently only probes 9600 and 115200. GPS modules defaulting to other rates fall through to the all-fail return; Marauder logs "Could not detect GPS baudrate", `gps_enabled` stays false, every `gps` CLI command becomes a
 no-op, and the WiFi Marauder companion shows zero coordinates.

 ## Why it matters in practice — the Beitian BE-280

 The BE-280 (M10050 chip, widely sold on Amazon) defaults to **38400 baud** and has **no flash to persist a baud reconfigure** — per the seller's own product description: *"BE-280 gps module without flash memory to save configuration, so you need to reset data next time 
 when you use it."* Sending `$PCAS01,…` to switch it to 9600 wouldn't survive a power cycle, so without a probe at 38400 the module is permanently invisible to Marauder.

 ## Change

 Adds a `probeBaud(38400)` fallback after the existing 9600 branch in `initGpsBaudAndForce115200()`. Returns 38400 on success and operates at that rate natively — no PCAS upshift, since no-flash modules would lose it anyway and 38400 is plenty fast for 1 Hz NMEA. Also
 extends the boot-time error-suppressor inequality chain in `begin()` to include 38400. 6 lines total, additive only.

 ## Tested

 ESP32-S2 Flipper WiFi Dev Board (`MARAUDER_FLIPPER`), Marauder v1.12.1, two BE-280 modules + two dev boards. Before: "Could not detect GPS baudrate" at boot, `gps -g *` returns silence. After: clean boot, `gps -g lat` returns valid coordinates, `gpsdata` streams `====
 GPS Data ====` blocks every ~5 s with Fix: Yes / Sats: 6-9, WiFi Marauder companion "GPS Data - tracker" view displays real position.