### PR TITLE
Fix v6 IP5306 battery driver selection

### DIFF
--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -2711,6 +2711,11 @@
       #undef HAS_MAX1704X
       #undef HAS_AXP192
 
+    #elif defined(HAS_IP5306)
+      #undef HAS_AXP2101
+      #undef HAS_MAX1704X
+      #undef HAS_AXP192
+
     #elif defined(HAS_AXP192)
       #undef HAS_AXP2101
       #undef HAS_IP5306

--- a/tools/check_battery_driver_macros.ps1
+++ b/tools/check_battery_driver_macros.ps1
@@ -1,0 +1,73 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$configsPath = Join-Path $repoRoot "esp32_marauder/configs.h"
+$configs = Get-Content -LiteralPath $configsPath -Raw
+
+function Assert-Match {
+    param(
+        [string]$Text,
+        [string]$Pattern,
+        [string]$Message
+    )
+
+    if ($Text -notmatch $Pattern) {
+        throw $Message
+    }
+}
+
+function Get-MatchOrFail {
+    param(
+        [string]$Text,
+        [string]$Pattern,
+        [string]$Message
+    )
+
+    $match = [regex]::Match($Text, $Pattern, [System.Text.RegularExpressions.RegexOptions]::Singleline)
+
+    if (-not $match.Success) {
+        throw $Message
+    }
+
+    return $match
+}
+
+Assert-Match `
+    -Text $configs `
+    -Pattern "(?s)#if defined\(MARAUDER_V6\) \|\| defined\(MARAUDER_V6_1\).*?#define HAS_BATTERY.*?#define HAS_IP5306" `
+    -Message "MARAUDER_V6/MARAUDER_V6_1 must keep IP5306 battery support enabled."
+
+$cleanupMatch = Get-MatchOrFail `
+    -Text $configs `
+    -Pattern "(?s)//  If we know what we have, we can delete what we're not using(?<cleanup>.*?)#endif\s+// HAS_BATTERY" `
+    -Message "Could not find battery driver cleanup section."
+
+$cleanup = $cleanupMatch.Groups["cleanup"].Value
+
+$ip5306Match = Get-MatchOrFail `
+    -Text $cleanup `
+    -Pattern "(?s)#elif defined\(HAS_IP5306\)(?<ip5306Branch>.*?)(?=\r?\n\s*#elif|\r?\n\s*#else|\r?\n\s*#endif)" `
+    -Message "HAS_IP5306 must have an explicit cleanup branch before the generic fallback."
+
+$ip5306Branch = $ip5306Match.Groups["ip5306Branch"].Value
+
+Assert-Match `
+    -Text $ip5306Branch `
+    -Pattern "#undef HAS_AXP2101" `
+    -Message "HAS_IP5306 cleanup must disable HAS_AXP2101."
+
+Assert-Match `
+    -Text $ip5306Branch `
+    -Pattern "#undef HAS_MAX1704X" `
+    -Message "HAS_IP5306 cleanup must disable HAS_MAX1704X."
+
+Assert-Match `
+    -Text $ip5306Branch `
+    -Pattern "#undef HAS_AXP192" `
+    -Message "HAS_IP5306 cleanup must disable HAS_AXP192."
+
+if ($ip5306Branch -match "#undef HAS_IP5306") {
+    throw "HAS_IP5306 cleanup must preserve HAS_IP5306 for v6/v6.1 battery support."
+}
+
+Write-Host "Battery driver macro checks passed."


### PR DESCRIPTION
## Summary
- Keep `HAS_IP5306` as an explicit battery-driver cleanup case for `MARAUDER_V6` and `MARAUDER_V6_1` builds.
- Disable unrelated AXP/MAX battery drivers when IP5306 is selected.
- Add a small regression check to guard v6/v6.1 battery macro selection.

## Root cause
Between v1.12.1 and v1.12.2, v6/v6.1 boards define IP5306 battery support but the battery cleanup section did not have an explicit `HAS_IP5306` branch. Those builds could fall through to the generic fallback and compile additional battery drivers (`HAS_MAX1704X` and `HAS_AXP192`) that do not belong to the v6/v6.1 IP5306 path.

This preserves battery support while keeping the v6/v6.1 build on the intended IP5306 driver path.

Fixes #1323
Fixes #1324
Fixes #1325
Fixes #1327

## Testing
- `powershell -ExecutionPolicy Bypass -File tools/check_battery_driver_macros.ps1`
- `git show --check --stat --oneline HEAD`
- GitHub Actions `Build and Push Parallel` v6.1 build succeeded on the fork.
- Tested on AWOK Dual V3 `_v6_1.bin`: device boots with this change.