### PR TITLE
Fix out-of-bounds heap read in SSID parsing (attacker-controlled length)

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -2,6 +2,18 @@
 #include "WiFiScan.h"
 #include "lang_var.h"
 
+// Number of SSID bytes that are safe to read from a sniffed 802.11 frame.
+// payload[37] is the attacker-controlled SSID length field; the SSID itself
+// starts at payload[38]. A malformed/oversized length can point past the end
+// of the captured frame, so clamp the count to what was actually captured
+// (rx_ctrl.sig_len). Evaluates to min(payload[37], len - 38), never negative.
+#define SSID_LEN(pkt, len) \
+  ((len) > 37 \
+    ? ((38 + (pkt)->payload[37] > (len)) \
+        ? ((len) > 38 ? (len) - 38 : 0) \
+        : (int)(pkt)->payload[37]) \
+    : 0)
+
 #ifdef HAS_PSRAM
   struct mac_addr* mac_history = nullptr;
 #endif
@@ -5809,7 +5821,7 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
         if (snifferPacket->payload[37] <= 0)
           display_string.concat(addr);
         else {
-          for (int i = 0; i < snifferPacket->payload[37]; i++)
+          for (int i = 0; i < SSID_LEN(snifferPacket, len); i++)
           {
             Serial.print((char)snifferPacket->payload[i + 38]);
             display_string.concat((char)snifferPacket->payload[i + 38]);
@@ -6464,7 +6476,7 @@ void WiFiScan::pineScanSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t ty
         if (snifferPacket->payload[37] <= 0) {
           essid = "[hidden]";
         } else {
-          for (int i = 0; i < snifferPacket->payload[37]; i++) {
+          for (int i = 0; i < SSID_LEN(snifferPacket, len); i++) {
             essid.concat((char)snifferPacket->payload[i + 38]);
           }
         }
@@ -6547,7 +6559,7 @@ void WiFiScan::pineScanSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t ty
         if (snifferPacket->payload[37] <= 0) {
           essid = "[hidden]";
         } else {
-          for (int i = 0; i < snifferPacket->payload[37]; i++) {
+          for (int i = 0; i < SSID_LEN(snifferPacket, len); i++) {
             essid.concat((char)snifferPacket->payload[i + 38]);
           }
         }
@@ -6733,7 +6745,7 @@ void WiFiScan::multiSSIDSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t t
       uint16_t ssid_hash = 0;
       if (snifferPacket->payload[37] > 0) {
         // Compute Whole SSID hash directly from payload
-        for (int i = 0; i < (int)snifferPacket->payload[37]; i++) {
+        for (int i = 0; i < SSID_LEN(snifferPacket, len); i++) {
           char c = snifferPacket->payload[i + 38];
           ssid_hash = ((ssid_hash << 5) + ssid_hash) + c;
         }
@@ -6783,7 +6795,7 @@ void WiFiScan::multiSSIDSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t t
         if (snifferPacket->payload[37] <= 0) {
           essid = "[hidden]";
         } else {
-          for (int i = 0; i < snifferPacket->payload[37]; i++) {
+          for (int i = 0; i < SSID_LEN(snifferPacket, len); i++) {
             essid.concat((char)snifferPacket->payload[i + 38]);
           }
         }
@@ -6868,7 +6880,7 @@ void WiFiScan::multiSSIDSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t t
         if (snifferPacket->payload[37] <= 0) {
           essid = "[hidden]";
         } else {
-          for (int i = 0; i < snifferPacket->payload[37]; i++) {
+          for (int i = 0; i < SSID_LEN(snifferPacket, len); i++) {
             essid.concat((char)snifferPacket->payload[i + 38]);
           }
         }
@@ -7243,7 +7255,7 @@ void WiFiScan::beaconSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type
           if (snifferPacket->payload[37] <= 0)
             display_string.concat(addr);
           else {
-            for (int i = 0; i < snifferPacket->payload[37]; i++)
+            for (int i = 0; i < SSID_LEN(snifferPacket, len); i++)
             {
               Serial.print((char)snifferPacket->payload[i + 38]);
               display_string.concat((char)snifferPacket->payload[i + 38]);
@@ -7463,7 +7475,7 @@ void WiFiScan::beaconSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type
 
       else if (snifferPacket->payload[0] == 0x80) {
         if (snifferPacket->payload[37] > 0) {
-          for (int i = 0; i < snifferPacket->payload[37]; i++)
+          for (int i = 0; i < SSID_LEN(snifferPacket, len); i++)
             essid.concat((char)snifferPacket->payload[i + 38]);
 
           //Serial.println(essid);
@@ -8495,7 +8507,7 @@ void WiFiScan::wifiSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type) 
           if (snifferPacket->payload[37] <= 0) // There is no ESSID. Just add BSSID
             display_string.concat(addr);
           else { // There is an ESSID. Add it
-            for (int i = 0; i < snifferPacket->payload[37]; i++)
+            for (int i = 0; i < SSID_LEN(snifferPacket, len); i++)
             {
               display_string.concat((char)snifferPacket->payload[i + 38]);
             }
@@ -8690,7 +8702,7 @@ void WiFiScan::eapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
       if (ap_index < 0) { // Check for existing AP in list. Create if not found
 
         if (snifferPacket->payload[37] > 0) {
-          for (int i = 0; i < snifferPacket->payload[37]; i++)
+          for (int i = 0; i < SSID_LEN(snifferPacket, len); i++)
             essid.concat((char)snifferPacket->payload[i + 38]);
         }
 


### PR DESCRIPTION
## Summary

The 802.11 packet sniffer callbacks in `WiFiScan.cpp` copy the SSID out of received frames using a loop whose iteration count is `snifferPacket->payload[37]` — the **SSID length octet** from the frame. That byte is entirely attacker-controlled and is never checked against the number of bytes actually captured (`snifferPacket->rx_ctrl.sig_len`).

A malformed beacon or probe-response frame that advertises an SSID length longer than the frame it arrives in makes the loop read **past the end of the captured packet buffer**. The over-read bytes get appended into the ESSID / display strings, leaking adjacent heap contents, and can crash the device. This is **remotely triggerable during an ordinary passive scan** (Beacon list, Pine scan, Multi-SSID scan, EAPOL scan, signal analyzer, etc.) — no association or interaction required, just a crafted frame in range.

## Impact

- Out-of-bounds heap read (info leak into displayed/stored SSID strings).
- Potential crash / instability on hostile RF environments.
- Trigger is a single crafted management frame; affects the default passive scan paths.

## Fix

Introduce a small helper that clamps the SSID byte count to what was actually captured:

```c
#define SSID_LEN(pkt, len) \
  ((len) > 37 \
    ? ((38 + (pkt)->payload[37] > (len)) \
        ? ((len) > 38 ? (len) - 38 : 0) \
        : (int)(pkt)->payload[37]) \
    : 0)
```

i.e. `min(payload[37], len - 38)`, never negative, and safe when `len <= 38` (it won't even dereference the length octet). Every SSID-copy loop that was bounded by the raw `payload[37]` now uses `SSID_LEN(snifferPacket, len)` as its bound. `len` is already in scope in each callback (`int len = snifferPacket->rx_ctrl.sig_len;`). The existing `payload[37] <= 0` "hidden SSID" guards are left untouched — only the read bound changed.

## Sites fixed (all in `esp32_marauder/WiFiScan.cpp`)

| Callback | What the loop does |
|---|---|
| `apSnifferCallbackFull` | ESSID → display/serial/essid |
| `pineScanSnifferCallback` | ESSID (already-confirmed path) |
| `pineScanSnifferCallback` | ESSID (new-detection path) |
| `multiSSIDSnifferCallback` | SSID hash computation |
| `multiSSIDSnifferCallback` | ESSID (already-confirmed path) |
| `multiSSIDSnifferCallback` | ESSID (reported-AP path) |
| `beaconSnifferCallback` | ESSID → display/serial |
| `beaconSnifferCallback` | ESSID (Flock detection) |
| `wifiSnifferCallback` | ESSID (signal-analyzer name) |
| `eapolSnifferCallback` | ESSID (new-AP path) |

Loops that were already bounded by `len` or by `19 - payload[37]` (fixed-width padding, no payload read) were intentionally left alone.

Diff is 22 insertions / 10 deletions — macro definition plus the ten one-line bound swaps.
