### PR TITLE
compilation errors for the ESP32-C3 platform ,require HAS_AXP192 for AXP192 code 

### DIFF
--- a/esp32_marauder/AXP192.cpp
+++ b/esp32_marauder/AXP192.cpp
@@ -1,11 +1,31 @@
 #include "AXP192.h"
 
+#ifdef HAS_AXP192
+
+#ifndef AXP192_SDA
+  #ifdef I2C_SDA
+     #define AXP192_SDA I2C_SDA
+     #define AXP192_SCL I2C_SCL
+  #else
+     #define AXP192_SDA 21
+     #define AXP192_SCL 22
+   #endif
+#endif
+
 AXP192::AXP192() {
 }
 
 void AXP192::begin(void) {
-    Wire1.begin(21, 22);
-    Wire1.setClock(400000);
+
+    #if defined(I2C_SDA) && (AXP192_SDA == I2C_SDA)
+      _wire = &Wire;
+    #else
+      _wire = &Wire1;
+    #endif
+
+    _wire->begin(AXP192_SDA, AXP192_SCL);
+
+    _wire->setClock(400000);
 
     // Set LDO2 & LDO3(TFT_LED & TFT) 3.0V
     Write1Byte(0x28, 0xcc);
@@ -47,18 +67,18 @@ void AXP192::begin(void) {
 }
 
 void AXP192::Write1Byte(uint8_t Addr, uint8_t Data) {
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.write(Data);
-    Wire1.endTransmission();
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->write(Data);
+    _wire->endTransmission();
 }
 
 uint8_t AXP192::Read8bit(uint8_t Addr) {
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 1);
-    return Wire1.read();
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 1);
+    return _wire->read();
 }
 
 uint16_t AXP192::Read12Bit(uint8_t Addr) {
@@ -79,50 +99,50 @@ uint16_t AXP192::Read13Bit(uint8_t Addr) {
 
 uint16_t AXP192::Read16bit(uint8_t Addr) {
     uint16_t ReData = 0;
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 2);
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 2);
     for (int i = 0; i < 2; i++) {
         ReData <<= 8;
-        ReData |= Wire1.read();
+        ReData |= _wire->read();
     }
     return ReData;
 }
 
 uint32_t AXP192::Read24bit(uint8_t Addr) {
     uint32_t ReData = 0;
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 3);
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 3);
     for (int i = 0; i < 3; i++) {
         ReData <<= 8;
-        ReData |= Wire1.read();
+        ReData |= _wire->read();
     }
     return ReData;
 }
 
 uint32_t AXP192::Read32bit(uint8_t Addr) {
     uint32_t ReData = 0;
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 4);
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 4);
     for (int i = 0; i < 4; i++) {
         ReData <<= 8;
-        ReData |= Wire1.read();
+        ReData |= _wire->read();
     }
     return ReData;
 }
 
 void AXP192::ReadBuff(uint8_t Addr, uint8_t Size, uint8_t *Buff) {
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, (int)Size);
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, (int)Size);
     for (int i = 0; i < Size; i++) {
-        *(Buff + i) = Wire1.read();
+        *(Buff + i) = _wire->read();
     }
 }
 
@@ -291,11 +311,11 @@ void AXP192::SetSleep(void) {
 }
 
 uint8_t AXP192::GetWarningLeve(void) {
-    Wire1.beginTransmission(0x34);
-    Wire1.write(0x47);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 1);
-    uint8_t buf = Wire1.read();
+    _wire->beginTransmission(0x34);
+    _wire->write(0x47);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 1);
+    uint8_t buf = _wire->read();
     return (buf & 0x01);
 }
 
@@ -433,3 +453,4 @@ void AXP192::SetPeripherialsPower(uint8_t state) {
     // uint8_t data;
     // Set EXTEN to enable 5v boost
 }
+#endif HAS_AXP192

--- a/esp32_marauder/AXP192.h
+++ b/esp32_marauder/AXP192.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "configs.h"
+
+#ifdef HAS_AXP192
+
 #ifndef __AXP192_H__
 #define __AXP192_H__
 
@@ -78,6 +82,10 @@ class AXP192 {
     uint32_t Read24bit(uint8_t Addr);
     uint32_t Read32bit(uint8_t Addr);
     void ReadBuff(uint8_t Addr, uint8_t Size, uint8_t *Buff);
+
+    private:
+      TwoWire *_wire;
 };
 
 #endif
+#endif HAS_AXP192

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -896,6 +896,13 @@
       #define TOUCH_CS -1
       //#define SD_CS 1
 
+      #define I2C_SDA 21
+      #define I2C_SCL 22
+      #define I2C_INT 35
+      // J1 Grove connector
+      // GPIO32
+      // GPIO33
+
       #define SCREEN_BUFFER
 
       #define MAX_SCREEN_BUFFER 9
@@ -2796,7 +2803,7 @@
   #ifdef HAS_BATTERY
 
     #if defined(MARAUDER_M5STICKC) || defined(MARAUDER_M5STICKCP2) 
-      #define I2C_SDA 33
+      #define I2C_SDA 21
       #define I2C_SCL 22
 
     #elif defined(MARAUDER_V4) || defined(MARAUDER_V6) || defined(MARAUDER_V6_1) || defined(MARAUDER_KIT)


### PR DESCRIPTION
The code encountered compilation errors for the ESP32-C3 platform.

```cpp
esp32_marauder/AXP192.cpp: In member function 'void AXP192::begin()':
esp32_marauder/AXP192.cpp:7:5: error: 'Wire1' was not declared in this scope; did you mean 'Wire'?
    7 |     Wire1.begin(21, 22);
      |     ^~~~~
```
On further inspection C3 only support one I2C interface thus Wire1 is not defined

To resolve this issue, I encapsulated the AXP192 code within a conditional compilation block using `#ifdef HAS_AXP192`

Upon further analysis, I observed that the values for SDA and SCL were hardcoded and had conflicting definitions in `configs.h`. By examining the M5STICK and M5STICKP2 schematics, I corrected the values under the HAS_BATTERY section and added code to the AXP192.cpp file to utilize the appropriate Wire interface. 