### PR TITLE
adds system time commands & RTC Support 

### DIFF
--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -150,6 +150,13 @@ jobs:
           ref: 1.12.0
           path: CustomAdafruit_NeoPixel
 
+      - name: Install Adafruit RTClib 
+        uses: actions/checkout@v2
+        with:
+          repository: adafruit/RTClib
+          ref: 2.1.4
+          path: CustomAdafruit_RTClib
+
       - name: Install ArduinoJson
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -201,6 +201,13 @@ jobs:
           ref: 1.12.0
           path: CustomAdafruit_NeoPixel
 
+      - name: Install Adafruit RTClib 
+        uses: actions/checkout@v2
+        with:
+          repository: adafruit/RTClib
+          ref: 2.1.4
+          path: CustomAdafruit_RTClib
+
       - name: Install ArduinoJson
         uses: actions/checkout@v2
         with:

--- a/esp32_marauder/AXP192.cpp
+++ b/esp32_marauder/AXP192.cpp
@@ -1,11 +1,31 @@
 #include "AXP192.h"
 
+#ifdef HAS_AXP192
+
+#ifndef AXP192_SDA
+  #ifdef I2C_SDA
+     #define AXP192_SDA I2C_SDA
+     #define AXP192_SCL I2C_SCL
+  #else
+     #define AXP192_SDA 21
+     #define AXP192_SCL 22
+   #endif
+#endif
+
 AXP192::AXP192() {
 }
 
 void AXP192::begin(void) {
-    Wire1.begin(21, 22);
-    Wire1.setClock(400000);
+
+    #if defined(I2C_SDA) && (AXP192_SDA == I2C_SDA)
+      _wire = &Wire;
+    #else
+      _wire = &Wire1;
+    #endif
+
+    _wire->begin(AXP192_SDA, AXP192_SCL);
+
+    _wire->setClock(400000);
 
     // Set LDO2 & LDO3(TFT_LED & TFT) 3.0V
     Write1Byte(0x28, 0xcc);
@@ -47,18 +67,18 @@ void AXP192::begin(void) {
 }
 
 void AXP192::Write1Byte(uint8_t Addr, uint8_t Data) {
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.write(Data);
-    Wire1.endTransmission();
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->write(Data);
+    _wire->endTransmission();
 }
 
 uint8_t AXP192::Read8bit(uint8_t Addr) {
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 1);
-    return Wire1.read();
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 1);
+    return _wire->read();
 }
 
 uint16_t AXP192::Read12Bit(uint8_t Addr) {
@@ -79,50 +99,50 @@ uint16_t AXP192::Read13Bit(uint8_t Addr) {
 
 uint16_t AXP192::Read16bit(uint8_t Addr) {
     uint16_t ReData = 0;
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 2);
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 2);
     for (int i = 0; i < 2; i++) {
         ReData <<= 8;
-        ReData |= Wire1.read();
+        ReData |= _wire->read();
     }
     return ReData;
 }
 
 uint32_t AXP192::Read24bit(uint8_t Addr) {
     uint32_t ReData = 0;
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 3);
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 3);
     for (int i = 0; i < 3; i++) {
         ReData <<= 8;
-        ReData |= Wire1.read();
+        ReData |= _wire->read();
     }
     return ReData;
 }
 
 uint32_t AXP192::Read32bit(uint8_t Addr) {
     uint32_t ReData = 0;
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 4);
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 4);
     for (int i = 0; i < 4; i++) {
         ReData <<= 8;
-        ReData |= Wire1.read();
+        ReData |= _wire->read();
     }
     return ReData;
 }
 
 void AXP192::ReadBuff(uint8_t Addr, uint8_t Size, uint8_t *Buff) {
-    Wire1.beginTransmission(0x34);
-    Wire1.write(Addr);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, (int)Size);
+    _wire->beginTransmission(0x34);
+    _wire->write(Addr);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, (int)Size);
     for (int i = 0; i < Size; i++) {
-        *(Buff + i) = Wire1.read();
+        *(Buff + i) = _wire->read();
     }
 }
 
@@ -291,11 +311,11 @@ void AXP192::SetSleep(void) {
 }
 
 uint8_t AXP192::GetWarningLeve(void) {
-    Wire1.beginTransmission(0x34);
-    Wire1.write(0x47);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 1);
-    uint8_t buf = Wire1.read();
+    _wire->beginTransmission(0x34);
+    _wire->write(0x47);
+    _wire->endTransmission();
+    _wire->requestFrom(0x34, 1);
+    uint8_t buf = _wire->read();
     return (buf & 0x01);
 }
 
@@ -433,3 +453,4 @@ void AXP192::SetPeripherialsPower(uint8_t state) {
     // uint8_t data;
     // Set EXTEN to enable 5v boost
 }
+#endif HAS_AXP192

--- a/esp32_marauder/AXP192.h
+++ b/esp32_marauder/AXP192.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "configs.h"
+
+#ifdef HAS_AXP192
+
 #ifndef __AXP192_H__
 #define __AXP192_H__
 
@@ -78,6 +82,10 @@ class AXP192 {
     uint32_t Read24bit(uint8_t Addr);
     uint32_t Read32bit(uint8_t Addr);
     void ReadBuff(uint8_t Addr, uint8_t Size, uint8_t *Buff);
+
+    private:
+      TwoWire *_wire;
 };
 
 #endif
+#endif HAS_AXP192

--- a/esp32_marauder/AXP192.h
+++ b/esp32_marauder/AXP192.h
@@ -3,7 +3,7 @@
 #ifndef __AXP192_H__
 #define __AXP192_H__
 
-#include <configs.h>
+#include "configs.h"
 
 #ifdef HAS_AXP192
 

--- a/esp32_marauder/Buffer.cpp
+++ b/esp32_marauder/Buffer.cpp
@@ -6,6 +6,7 @@ Buffer::Buffer(){
   bufB = (uint8_t*)malloc(BUF_SIZE);
 }
 
+#ifdef NO_USE
 void Buffer::createFile(const char* name, bool is_pcap, bool is_gpx){
   int i=0;
   if (is_pcap) {
@@ -29,6 +30,44 @@ void Buffer::createFile(const char* name, bool is_pcap, bool is_gpx){
 
   Serial.println(fileName);
   
+  file = fs->open(fileName, FILE_WRITE);
+  file.close();
+}
+#endif
+
+void Buffer::createFile(const char* name, bool is_pcap, bool is_gpx) {
+  int i = 0;
+  char buf[64];   // LFN can be up to 255 chars on FatFs
+
+  // With timestamp if system time is set:
+  if (system_time_set) {
+    struct tm timeinfo;
+    getLocalTime(&timeinfo);
+    if (is_pcap) {
+      do {
+        snprintf(buf, sizeof(buf), "/%s_%04d%02d%02d_%02d%02d%02d_%d.pcap",
+          name,
+          timeinfo.tm_year + 1900,
+          timeinfo.tm_mon + 1,
+          timeinfo.tm_mday,
+          timeinfo.tm_hour,
+          timeinfo.tm_min,
+          timeinfo.tm_sec,
+          i++);
+      } while (fs->exists(buf));
+    }
+    // similar for log/gpx...
+  } else {
+    // fallback to existing numeric scheme
+    if (is_pcap) {
+      do {
+        snprintf(buf, sizeof(buf), "/%s_%d.pcap", name, i++);
+      } while (fs->exists(buf));
+    }
+  }
+
+  fileName = String(buf);
+  Serial.println(fileName);
   file = fs->open(fileName, FILE_WRITE);
   file.close();
 }

--- a/esp32_marauder/Buffer.h
+++ b/esp32_marauder/Buffer.h
@@ -12,6 +12,13 @@
 //#define BUF_SIZE 3 * 1024 // Had to reduce buffer size to save RAM. GG @spacehuhn
 //#define SNAP_LEN 2324 // max len of each recieved packet
 
+// #ifdef HAS_RTC
+//   #include "RTC.h"
+//   extern RTC rtc_obj;
+// #endif
+
+extern bool system_time_set;
+
 //extern bool useSD;
 
 extern Settings settings_obj;

--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -1764,24 +1764,25 @@ void CommandLine::runCommand(String input) {
       Serial.println(F("WIFI is not connected."));
       return;
     }
-    #ifdef HAS_RTC
+  #ifdef HAS_RTC
+    log_d("rtc_obj.supported %d", rtc_obj.supported);
+    if(rtc_obj.supported) {
       rtc_obj.sync_rtc_ntp();
-    #else
-      configTime(0, 0, "pool.ntp.org");
-    #endif //  HAS_RTC
-  }
+    } else
+  #endif //  HAS_RTC
+    configTime(GMTOFFSET_SEC, DAYLIGHTOFFSET_SEC, "pool.ntp.org", "time.nist.gov", "1.pool.ntp.org");
 
-
-  // "+%Y-%m-%d %HH:%MM:SS"
-  else if (cmd_args.get(0) == DATE_CMD) {
     struct tm timeinfo;
     if (getLocalTime(&timeinfo)) {
-      Serial.println(&timeinfo, "%F %T");
+        char timeBuffer[64];
+        system_time_set = true;
+        strftime(timeBuffer, sizeof(timeBuffer), "%F %T", &timeinfo);
+        Serial.println(&timeinfo, "%F %T");
     } else {
-      log_w("getLocalTime Fail");
+        log_w("getLocalTime Fail");
+        perror("getLocalTime");
     }
   }
-
 
   else if (cmd_args.get(0) == SETDATE_CMD) {
     struct tm tm_info = {0}; 

--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -237,6 +237,9 @@ void CommandLine::runCommand(String input) {
     Serial.println(HELP_NMEA_CMD);
     Serial.println(HELP_GPS_POI_CMD);
     Serial.println(HELP_GPS_TRACKER_CMD);
+    Serial.println(HELP_NTP_SYNC);
+    Serial.println(HELP_DATE);
+    Serial.println(HELP_SETDATE);
     
     // WiFi sniff/scan
     Serial.println(HELP_EVIL_PORTAL_CMD);
@@ -1346,8 +1349,9 @@ void CommandLine::runCommand(String input) {
     }
   }
   else if (cmd_args.get(0) == JOIN_CMD) {
-    int ap_sw = this->argSearch(&cmd_args, "-a");
-    int pw_sw = this->argSearch(&cmd_args, "-p");
+    int np_sw = this->argSearch(&cmd_args, "-n");   // Network
+    int ap_sw = this->argSearch(&cmd_args, "-a");   // AP Index
+    int pw_sw = this->argSearch(&cmd_args, "-p");   // Password
     int s_sw  = this->argSearch(&cmd_args, "-s");
 
     if ((ap_sw != -1) && (pw_sw != -1)) {
@@ -1363,6 +1367,17 @@ void CommandLine::runCommand(String input) {
           menu_function_obj.changeMenu(menu_function_obj.current_menu);
         #endif
       #endif
+    }
+    else if ((np_sw != -1) && (pw_sw != -1)) {
+      String password = cmd_args.get(pw_sw + 1);
+      String ssid = cmd_args.get(np_sw + 1);
+
+      Serial.println("Using SSID: " + (String)ssid + " Password: " + (String)password);
+      settings_obj.saveSetting<bool>("ClientSSID", ssid);
+      settings_obj.saveSetting<bool>("ClientPW", password);
+
+      wifi_scan_obj.joinWiFi(ssid, password, false);
+
     }
     else if (s_sw != -1) {
       String ssid = settings_obj.loadSetting<String>("ClientSSID");
@@ -1383,6 +1398,7 @@ void CommandLine::runCommand(String input) {
       return;
     }
   }
+
   // Select access points or stations
   else if (cmd_args.get(0) == SEL_CMD) {
     // Get switches
@@ -1737,6 +1753,50 @@ void CommandLine::runCommand(String input) {
     }
     else {
       Serial.println(F("Usage: add -a -b <mac> or add -c -b <mac> -ap <index>"));
+    }
+  }
+
+
+
+  else if (cmd_args.get(0) == NTP_SYNC_CMD) {
+
+    if (!wifi_scan_obj.wifi_connected) {
+      Serial.println(F("WIFI is not connected."));
+      return;
+    }
+    #ifdef HAS_RTC
+      rtc_obj.sync_rtc_ntp();
+    #else
+      configTime(0, 0, "pool.ntp.org");
+    #endif //  HAS_RTC
+  }
+
+
+  // "+%Y-%m-%d %HH:%MM:SS"
+  else if (cmd_args.get(0) == DATE_CMD) {
+    struct tm timeinfo;
+    if (getLocalTime(&timeinfo)) {
+      Serial.println(&timeinfo, "%F %T");
+    } else {
+      log_w("getLocalTime Fail");
+    }
+  }
+
+
+  else if (cmd_args.get(0) == SETDATE_CMD) {
+    struct tm tm_info = {0}; 
+    extern bool set_system_time(struct tm *timeInfo);
+
+    log_d("SETDATE_CMD: %s %s", cmd_args.get(1).c_str(), cmd_args.get(2).c_str());
+    if ( cmd_args.size() == 3 &&
+         strptime(cmd_args.get(1).c_str(), "%F", &tm_info) &&
+         strptime(cmd_args.get(2).c_str(), "%T", &tm_info) ) {
+
+      set_system_time(&tm_info);
+
+    } else {
+      Serial.println(F("Failed to parse time string."));
+      Serial.println(F("expected format: YYYY-MM-DD HH:MM:SS"));
     }
   }
 

--- a/esp32_marauder/CommandLine.h
+++ b/esp32_marauder/CommandLine.h
@@ -20,6 +20,14 @@
   #include "LedInterface.h"
 #endif
 
+#ifdef HAS_RTC
+  #include "RTC.h"
+  extern RTC rtc_obj;
+#endif
+
+// If system time/date has been set
+extern bool system_time_set;
+
 #ifdef HAS_SCREEN
   extern MenuFunctions menu_function_obj;
   extern Display display_obj;
@@ -59,6 +67,9 @@ const char PROGMEM GPS_CMD[] = "gps";
 const char PROGMEM NMEA_CMD[] = "nmea";
 const char PROGMEM GPS_POI_CMD[] = "gpspoi";
 const char PROGMEM GPS_TRACKER_CMD[] = "gpstracker";
+const char PROGMEM NTP_SYNC_CMD[] = "ntp_sync";
+const char PROGMEM DATE_CMD[] = "date";
+const char PROGMEM SETDATE_CMD[] = "setdate";
 
 // WiFi sniff/scan
 const char PROGMEM EVIL_PORTAL_CMD[] = "evilportal";
@@ -135,6 +146,9 @@ const char PROGMEM HELP_GPS_CMD[] = "gps [-t] [-g] <fix/sat/lon/lat/alt/date/acc
 const char PROGMEM HELP_GPS_POI_CMD[] = "gpspoi -s/-m/-e";
 const char PROGMEM HELP_GPS_TRACKER_CMD[] = "gpstracker -c <start/stop>";
 const char PROGMEM HELP_NMEA_CMD[] = "nmea";
+const char PROGMEM HELP_NTP_SYNC[] = "ntp_sync";
+const char PROGMEM HELP_DATE[] = "date";
+const char PROGMEM HELP_SETDATE[] = "setdate YY-MM-DD HH:MM:SS";
 
 // WiFi sniff/scan
 const char PROGMEM HELP_EVIL_PORTAL_CMD[] = "evilportal [-c start [-w html.html]/sethtml <html.html>]";
@@ -175,7 +189,7 @@ const char PROGMEM HELP_SSID_CMD_A[] = "ssid -a [-g <count>/-n <name>]";
 const char PROGMEM HELP_SSID_CMD_B[] = "ssid -r <index>";
 const char PROGMEM HELP_SAVE_CMD[] = "save -a/-s";
 const char PROGMEM HELP_LOAD_CMD[] = "load -a/-s";
-const char PROGMEM HELP_JOIN_CMD[] = "join -a <index> -p <password>/-s";
+const char PROGMEM HELP_JOIN_CMD[] = "join (-a <index> -n <network>) -p <password>/-s";
 const char PROGMEM HELP_MAC_CMD_A[] = "randapmac";
 const char PROGMEM HELP_MAC_CMD_B[] = "randstamac";
 const char PROGMEM HELP_MAC_CMD_C[] = "cloneapmac [-a <index>]";

--- a/esp32_marauder/GpsInterface.cpp
+++ b/esp32_marauder/GpsInterface.cpp
@@ -580,6 +580,9 @@ void GpsInterface::setGPSInfo() {
   this->num_sats = nmea.getNumSatellites();
 
   this->datetime = this->dt_string_from_gps();
+  if (!system_time_set)
+    set_system_time(this->datetime);
+
 
   this->lat_int = nmea.getLatitude();
   this->lon_int = nmea.getLongitude();

--- a/esp32_marauder/GpsInterface.h
+++ b/esp32_marauder/GpsInterface.h
@@ -78,6 +78,8 @@ class GpsInterface {
     String generateGXgga();
     String generateGXrmc();
 
+    bool gps_enabled = false;
+
   private:
     enum type_t {
       GPSTYPE_NATIVE = 0,
@@ -104,7 +106,6 @@ class GpsInterface {
     float accuracy = 0.0;
     String datetime = "";
     
-    bool gps_enabled = false;
     bool good_fix = false;
     char nav_system='\0';
     uint8_t num_sats = 0;

--- a/esp32_marauder/GpsInterface.h
+++ b/esp32_marauder/GpsInterface.h
@@ -16,6 +16,9 @@
 //#define GPS_NMEA_SCRNWRAP true //default:true, except on MARAUDER_MINI where false
 //#define GPS_NMEA_MAXQUEUE 30 //default:30 messages max in queue
 
+extern bool system_time_set;
+extern bool set_system_time(const String&);
+
 #if defined(MARAUDER_MINI) || defined(MARAUDER_MINI_V3)
   #ifndef GPS_NMEA_SCRNWRAP
     #define GPS_NMEA_SCRNWRAP false

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1093,7 +1093,7 @@ void MenuFunctions::updateStatusBar()
 
 
   // #ifdef HAS_RTC
-    if((system_time_set) && (cur_millis & (1 << 12))) {
+    if((system_time_set) && (cur_millis & (1 << 12))) {  // we dont need to update the clock several time a sec.
       char timeBuffer[16];
       struct tm timeinfo;
       // static uint32_t tic = 0;

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1668,6 +1668,9 @@ void MenuFunctions::RunSetup()
   saveATsMenu.name = "Save Airtags";
   loadATsMenu.name = "Load Airtags";
 
+  adminMenu.list = new LinkedList<MenuNode>();
+  adminSubMenu.list = new LinkedList<MenuNode>();
+
   bluetoothSnifferMenu.name = text_table1[23];
   bluetoothAttackMenu.name = "Bluetooth Attacks";
   generateSSIDsMenu.name = text_table1[27];
@@ -1699,6 +1702,8 @@ void MenuFunctions::RunSetup()
     gpsPOIMenu.name = "GPS POI";
   #endif
 
+  adminMenu.name = "Admin Tools";
+  adminSubMenu.name = "-";
   foxHuntMenu.name = "Fox Hunt";
 
   // Build Main Menu
@@ -2591,11 +2596,27 @@ void MenuFunctions::RunSetup()
     wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
     this->changeMenu(current_menu, true);
   });
-  #ifdef HAS_RTC
     this->addNodes(&wifiGeneralMenu, "Sync RTC with WiFi", TFTLIME, NULL, 0, []() {
-      rtc_obj.sync_rtc_ntp();
+
+      #ifdef HAS_RTC
+        log_d("rtc_obj.supported %d", rtc_obj.supported);
+        if(rtc_obj.supported) {
+          rtc_obj.sync_rtc_ntp();
+        } else
+      #endif //  HAS_RTC
+        configTime(GMTOFFSET_SEC, DAYLIGHTOFFSET_SEC, "pool.ntp.org", "time.nist.gov", "1.pool.ntp.org");
+        struct tm timeinfo;
+        if (getLocalTime(&timeinfo)) {
+          char timeBuffer[64];
+          system_time_set = true;
+          strftime(timeBuffer, sizeof(timeBuffer), "%F %T", &timeinfo);
+          display_obj.tft.drawCentreString(timeBuffer, TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
+          Serial.println(&timeinfo, "%F %T");
+        } else {
+          display_obj.tft.drawCentreString("Connection Failed", TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
+          log_d("getLocalTime Fail");
+       }
     });
-  #endif
 
   // Menu for generating and setting MAC addrs for AP and STA
   setMacMenu.parentMenu = &wifiGeneralMenu;
@@ -2988,6 +3009,68 @@ void MenuFunctions::RunSetup()
   this->addNodes(&loadATsMenu, text09, TFTLIGHTGREY, 0, [this]() {
     this->changeMenu(loadATsMenu.parentMenu, true);
   });
+
+
+  // Admin Menu
+  // TFT_GREENYELLOW
+  this->addNodes(&deviceMenu, "Admin Tools", TFTPINK, SD_UPDATE, [this]() {
+    this->changeMenu(&adminMenu, true);
+  });
+  adminMenu.parentMenu = &deviceMenu;
+
+  this->addNodes(&adminMenu, text09, TFTLIGHTGREY, 0, [this]() {
+    this->changeMenu(adminMenu.parentMenu, true);
+  });
+
+#if defined(HAS_SD) || defined(USE_SD)
+  this->addNodes(&adminMenu, "Rescan SD", TFTPINK, SD_UPDATE, [this]() {
+    this->changeMenu(&adminMenu, true);
+    sd_obj.initSD();
+  });
+#endif
+    adminSubMenu.parentMenu = &adminMenu;
+    this->addNodes(&adminSubMenu, text09, TFTLIGHTGREY, 0, [this]() {
+      this->changeMenu(adminSubMenu.parentMenu, true);
+    });
+  #ifdef HAS_GPS
+    if ( !gps_obj.gps_enabled)
+      this->addNodes(&saveFileMenu, "Probe GPS", TFTSKYBLUE, SD_UPDATE, [this]() {
+        gps_obj.begin();
+      });
+  #endif //  HAS_GPS
+
+      this->addNodes(&adminMenu, "Sync RTC with WiFi", TFTPINK, SETTINGS, [this]() {
+        this->changeMenu(&adminSubMenu, true);
+        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+
+        #ifdef HAS_RTC
+          log_d("rtc_obj.supported %d", rtc_obj.supported);
+          if(rtc_obj.supported) {
+            rtc_obj.sync_rtc_ntp();
+          } else
+        #endif //  HAS_RTC
+          configTime(GMTOFFSET_SEC, DAYLIGHTOFFSET_SEC, "pool.ntp.org", "time.nist.gov", "1.pool.ntp.org");
+
+        struct tm timeinfo;
+        if (getLocalTime(&timeinfo)) {
+          char timeBuffer[64];
+          system_time_set = true;
+          strftime(timeBuffer, sizeof(timeBuffer), "%F %T", &timeinfo);
+          display_obj.tft.drawCentreString(timeBuffer, TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
+          Serial.println(&timeinfo, "%F %T");
+        } else {
+          display_obj.tft.drawCentreString("Connection Failed", TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
+          log_d("getLocalTime Fail");
+       }
+
+    });
+
+    this->addNodes(&adminMenu, "Reset Reasion", TFTMAGENTA, SETTINGS, [this]() {
+      this->changeMenu(&adminSubMenu, true);
+        display_obj.tft.setTextColor(TFT_SKYBLUE, TFT_BLACK);
+        display_obj.tft.drawCentreString(resetReasonName(), TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
+        print_reset_reason();
+    });
 
   // GPS Menu
   #ifdef HAS_GPS

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1101,45 +1101,48 @@ void MenuFunctions::updateStatusBar()
 
       // tic = this->initTime;
 
-      if(!getLocalTime(&timeinfo)){
-          Serial.println(F("Failed to obtain time"));
-          return;
+      if(getLocalTime(&timeinfo)){
+
+        //  "%H:%M"
+        strftime(timeBuffer, sizeof(timeBuffer), "%k:%M", &timeinfo);
+
+        int tx, ty, tw, th;
+        tw = (5 * 8) - 4;
+
+        #ifdef HAS_BATTERY
+          if (battery_obj.i2c_supported) {
+            th = 15;
+            bg_color = TFT_BLACK;
+          } else
+        #endif
+          th = 0;
+
+        #ifdef HAS_MINI_SCREEN // SCREEN_ORIENTATION == 1
+          tx = TFT_HEIGHT - tw;
+          // ty = TFT_WIDTH - th; // Bottom Right
+          ty = th;   // Near Top Right
+        #else
+          tx = TFT_WIDTH - tw;
+          // ty = TFT_HEIGHT - th;    // Bottom Right
+          ty = th;   // Near Top Right
+        #endif
+
+        // Serial.print("time: ");
+        // Serial.println(timeBuffer);
+        // Serial.println((String) tx + " : " + (String) ty);
+
+        display_obj.tft.fillRect(tx, ty, tw, th, bg_color);
+        display_obj.tft.setTextColor(TFT_YELLOW, bg_color, true);
+        display_obj.tft.drawString(timeBuffer, tx , ty , 2);
+
+        display_obj.tft.setTextColor(TFT_WHITE, STATUSBAR_COLOR, true);
+      } else {
+          // Serial.println(F("Failed to obtain time"));
+          // return;
+          // system_time_set = false;
+
       }
-
-      //  "%H:%M"
-      strftime(timeBuffer, sizeof(timeBuffer), "%k:%M", &timeinfo);
-
-      int tx, ty, tw, th;
-      tw = (5 * 8) - 4;
-
-      #ifdef HAS_BATTERY
-        if (battery_obj.i2c_supported) {
-          th = 15;
-          bg_color = TFT_BLACK;
-        } else
-      #endif
-        th = 0;
-
-      #ifdef HAS_MINI_SCREEN // SCREEN_ORIENTATION == 1
-        tx = TFT_HEIGHT - tw;
-        // ty = TFT_WIDTH - th; // Bottom Right
-        ty = th;   // Near Top Right
-      #else
-        tx = TFT_WIDTH - tw;
-        // ty = TFT_HEIGHT - th;    // Bottom Right
-        ty = th;   // Near Top Right
-      #endif
-
-      // Serial.print("time: ");
-      // Serial.println(timeBuffer);
-      // Serial.println((String) tx + " : " + (String) ty);
-
-      display_obj.tft.fillRect(tx, ty, tw, th, bg_color);
-      display_obj.tft.setTextColor(TFT_YELLOW, bg_color, true);
-      display_obj.tft.drawString(timeBuffer, tx , ty , 2);
-
-      display_obj.tft.setTextColor(TFT_WHITE, STATUSBAR_COLOR, true);
-    }
+  }
 
   //#endif
 

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1019,6 +1019,7 @@ void MenuFunctions::updateStatusBar()
   display_obj.tft.setTextSize(1);
 
   bool status_changed = false;
+  uint32_t cur_millis = millis();
   
   #if defined(MARAUDER_MINI) || defined(MARAUDER_M5STICKC) || defined(MARAUDER_REV_FEATHER) || defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV) || defined(MARAUDER_MINI_V3)
     display_obj.tft.setFreeFont(NULL);
@@ -1090,6 +1091,58 @@ void MenuFunctions::updateStatusBar()
     #endif
   }
 
+
+  // #ifdef HAS_RTC
+    if((system_time_set) && (cur_millis & (1 << 12))) {
+      char timeBuffer[16];
+      struct tm timeinfo;
+      // static uint32_t tic = 0;
+      uint16_t bg_color = STATUSBAR_COLOR;
+
+      // tic = this->initTime;
+
+      if(!getLocalTime(&timeinfo)){
+          Serial.println(F("Failed to obtain time"));
+          return;
+      }
+
+      //  "%H:%M"
+      strftime(timeBuffer, sizeof(timeBuffer), "%k:%M", &timeinfo);
+
+      int tx, ty, tw, th;
+      tw = (5 * 8) - 4;
+
+      #ifdef HAS_BATTERY
+        if (battery_obj.i2c_supported) {
+          th = 15;
+          bg_color = TFT_BLACK;
+        } else
+      #endif
+        th = 0;
+
+      #ifdef HAS_MINI_SCREEN // SCREEN_ORIENTATION == 1
+        tx = TFT_HEIGHT - tw;
+        // ty = TFT_WIDTH - th; // Bottom Right
+        ty = th;   // Near Top Right
+      #else
+        tx = TFT_WIDTH - tw;
+        // ty = TFT_HEIGHT - th;    // Bottom Right
+        ty = th;   // Near Top Right
+      #endif
+
+      // Serial.print("time: ");
+      // Serial.println(timeBuffer);
+      // Serial.println((String) tx + " : " + (String) ty);
+
+      display_obj.tft.fillRect(tx, ty, tw, th, bg_color);
+      display_obj.tft.setTextColor(TFT_YELLOW, bg_color, true);
+      display_obj.tft.drawString(timeBuffer, tx , ty , 2);
+
+      display_obj.tft.setTextColor(TFT_WHITE, STATUSBAR_COLOR, true);
+    }
+
+  //#endif
+
   // RAM Stuff
   wifi_scan_obj.free_ram = String(esp_get_free_heap_size());
   if ((wifi_scan_obj.free_ram != wifi_scan_obj.old_free_ram) || (status_changed)) {
@@ -1105,7 +1158,14 @@ void MenuFunctions::updateStatusBar()
   #endif
 
   #ifdef HAS_MINI_SCREEN
-    display_obj.tft.drawString(String(getDRAMUsagePercent()) + "%", TFT_WIDTH/1.75, 0, 1);
+    #ifndef HAS_PSRAM
+      display_obj.tft.drawString(String(getDRAMUsagePercent()) + "%", TFT_WIDTH/1.75, 0, 1);
+    #else
+      if (cur_millis & (1 << 13))  // 13 -> 8.192 seconds
+        display_obj.tft.drawString("D:" + String(getDRAMUsagePercent()) + "%", 100, 0, 1);
+      else
+        display_obj.tft.drawString("P:" + String(getPSRAMUsagePercent()) + "%", 100, 0, 1);
+    #endif
   #endif
   }
 
@@ -2528,7 +2588,11 @@ void MenuFunctions::RunSetup()
     wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
     this->changeMenu(current_menu, true);
   });
-
+  #ifdef HAS_RTC
+    this->addNodes(&wifiGeneralMenu, "Sync RTC with WiFi", TFTLIME, NULL, 0, []() {
+      rtc_obj.sync_rtc_ntp();
+    });
+  #endif
 
   // Menu for generating and setting MAC addrs for AP and STA
   setMacMenu.parentMenu = &wifiGeneralMenu;

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -2596,22 +2596,30 @@ void MenuFunctions::RunSetup()
     wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
     this->changeMenu(current_menu, true);
   });
-    this->addNodes(&wifiGeneralMenu, "Sync RTC with WiFi", TFTLIME, NULL, 0, []() {
+    this->addNodes(&wifiGeneralMenu, "Sync RTC with WiFi", TFTLIME, 0, [this]() {
+
 
       #ifdef HAS_RTC
-        log_d("rtc_obj.supported %d", rtc_obj.supported);
         if(rtc_obj.supported) {
           rtc_obj.sync_rtc_ntp();
         } else
       #endif //  HAS_RTC
         configTime(GMTOFFSET_SEC, DAYLIGHTOFFSET_SEC, "pool.ntp.org", "time.nist.gov", "1.pool.ntp.org");
+
         struct tm timeinfo;
         if (getLocalTime(&timeinfo)) {
           char timeBuffer[64];
           system_time_set = true;
           strftime(timeBuffer, sizeof(timeBuffer), "%F %T", &timeinfo);
-          display_obj.tft.drawCentreString(timeBuffer, TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
-          Serial.println(&timeinfo, "%F %T");
+          display_obj.tft.fillScreen(TFT_BLACK);
+          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+
+          #ifdef HAS_MINI_SCREEN
+            display_obj.tft.drawCentreString(timeBuffer, TFT_WIDTH/2, TFT_HEIGHT * 0.33, 2);
+          #else
+            display_obj.tft.drawCentreString(timeBuffer, TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
+          #endif
+         
         } else {
           display_obj.tft.drawCentreString("Connection Failed", TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
           log_d("getLocalTime Fail");
@@ -3056,8 +3064,15 @@ void MenuFunctions::RunSetup()
           char timeBuffer[64];
           system_time_set = true;
           strftime(timeBuffer, sizeof(timeBuffer), "%F %T", &timeinfo);
-          display_obj.tft.drawCentreString(timeBuffer, TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
+          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+
+          #ifdef HAS_MINI_SCREEN
+            display_obj.tft.drawCentreString(timeBuffer, TFT_WIDTH/2, TFT_HEIGHT * 0.33, 2);
+          #else
+            display_obj.tft.drawCentreString(timeBuffer, TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
+          #endif
           Serial.println(&timeinfo, "%F %T");
+         
         } else {
           display_obj.tft.drawCentreString("Connection Failed", TFT_WIDTH/2, TFT_HEIGHT * 0.33, 4);
           log_d("getLocalTime Fail");

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -22,6 +22,14 @@
 #include "SDInterface.h"
 #include "settings.h"
 
+#ifdef HAS_RTC
+  #include "RTC.h"
+  extern RTC rtc_obj;
+#endif
+
+// If system time/date has been set
+extern bool system_time_set;
+
 #ifdef HAS_BUTTONS
   #include "Switches.h"
   #if (U_BTN >= 0)

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -30,6 +30,9 @@
 // If system time/date has been set
 extern bool system_time_set;
 
+extern void print_reset_reason();
+extern const char *resetReasonName();
+
 #ifdef HAS_BUTTONS
   #include "Switches.h"
   #if (U_BTN >= 0)
@@ -206,6 +209,9 @@ class MenuFunctions
 
     Menu foxHuntMenu;
 
+    // Admin
+    Menu adminMenu;
+    Menu adminSubMenu;
     //static void lv_tick_handler();
 
     // Menu icons

--- a/esp32_marauder/PCF85063.cpp
+++ b/esp32_marauder/PCF85063.cpp
@@ -1,0 +1,162 @@
+/*
+ * PCF85063 - Arduino/PlatformIO RTC library
+ * RTClib RTC_PCF8523-compatible interface
+ * Register map from Waveshare BSP PCF85063Constants.h
+ */
+
+
+#include "configs.h"
+
+#ifdef HAS_PCF85063
+
+#include "PCF85063.h"
+
+PCF85063::PCF85063() : _wire(&Wire) {}
+
+// -- RTClib-compatible begin(TwoWire*) -----------------------------------------
+bool PCF85063::begin(TwoWire *wire) {
+    _wire = wire ? wire : &Wire;
+    return _initImpl();
+}
+
+// -- Extended begin(TwoWire&, sda, scl) - Waveshare BSP style -----------------
+bool PCF85063::begin(TwoWire &wire, int sda, int scl) {
+    _wire = &wire;
+    if (sda != -1 && scl != -1) {
+        _wire->setPins(sda, scl);
+    }
+    _wire->begin();
+    return _initImpl();
+}
+
+// -- Shared init - mirrors SensorPCF85063::initImpl() -------------------------
+bool PCF85063::_initImpl() {
+    // Chip detection via RAM register R/W test
+    int val = readReg(REG_RAM);
+    if (val < 0) {
+        log_e("PCF85063: not responding");
+        return false;
+    }
+    uint8_t tmp = (uint8_t)val;
+
+    writeReg(REG_RAM, tmp | 0x80);
+    if (!(readReg(REG_RAM) & 0x80)) {
+        log_e("PCF85063: RAM bit7 set failed - may be PCF8563");
+        return false;
+    }
+    writeReg(REG_RAM, tmp & ~0x80);
+    if (readReg(REG_RAM) & 0x80) {
+        log_e("PCF85063: RAM bit7 clear failed");
+        return false;
+    }
+    writeReg(REG_RAM, tmp);  // restore
+
+    // Force 24H mode
+    int ctrl1 = readReg(REG_CTRL1);
+    if (ctrl1 < 0) return false;
+    if (ctrl1 & (1 << BIT_12H)) {
+        writeReg(REG_CTRL1, (uint8_t)(ctrl1 & ~(1 << BIT_12H)));
+        log_d("PCF85063: forced 24H mode");
+    }
+
+    start();
+
+    // begin() returns true = chip found and clock running
+    // begin() returns false = chip not on bus or hardware fault
+    // OS bit / time validity is the caller's responsibility via
+    // initialized() / lostPower() - checked separately after begin()
+    return isrunning();
+}
+
+// -- RTClib interface ----------------------------------------------------------
+
+DateTime PCF85063::now() {
+    uint8_t buf[7];
+    if (!readRegs(REG_SEC, buf, 7)) return DateTime();
+
+    return DateTime(
+        (uint16_t)_bcd2dec(buf[6])          + 2000,  // YEAR  (REG_YEAR  = 0x0A, offset 6)
+        _bcd2dec(buf[5] & 0x1F),                      // MONTH (REG_MONTH = 0x09, offset 5)
+        _bcd2dec(buf[3] & 0x3F),                      // DAY   (REG_DAY   = 0x07, offset 3)
+        _bcd2dec(buf[2] & 0x3F),                      // HOUR  (REG_HOUR  = 0x06, offset 2)
+        _bcd2dec(buf[1] & 0x7F),                      // MIN   (REG_MIN   = 0x05, offset 1)
+        _bcd2dec(buf[0] & 0x7F)                       // SEC   (REG_SEC   = 0x04, offset 0)
+    );
+}
+
+void PCF85063::adjust(const DateTime &dt) {
+    uint8_t buf[7];
+    buf[0] = _dec2bcd(dt.second())          & 0x7F;  // SEC   - clear OS bit
+    buf[1] = _dec2bcd(dt.minute());                   // MIN
+    buf[2] = _dec2bcd(dt.hour());                     // HOUR
+    buf[3] = _dec2bcd(dt.day());                      // DAY
+    buf[4] = dt.dayOfTheWeek();                       // WEEKDAY
+    buf[5] = _dec2bcd(dt.month());                    // MONTH
+    buf[6] = _dec2bcd((uint8_t)(dt.year() % 100));   // YEAR
+
+    _wire->beginTransmission(PCF85063_ADDR);
+    _wire->write(REG_SEC);
+    _wire->write(buf, 7);
+    bool ok = (_wire->endTransmission() == 0);
+    log_d("PCF85063::adjust %s  %04u-%02u-%02u %02u:%02u:%02u",
+          ok ? "OK" : "FAIL",
+          dt.year(), dt.month(), dt.day(),
+          dt.hour(), dt.minute(), dt.second());
+}
+
+// OS bit clear = clock has been running continuously = initialized
+bool PCF85063::initialized() {
+    int val = readReg(REG_SEC);
+    if (val < 0) return false;
+    return !(val & (1 << BIT_OS));
+}
+
+// inverse of initialized() - mirrors RTClib lostPower()
+bool PCF85063::lostPower() {
+    return !initialized();
+}
+
+void PCF85063::start() {
+    int val = readReg(REG_CTRL1);
+    if (val >= 0) writeReg(REG_CTRL1, (uint8_t)(val & ~(1 << BIT_STOP)));
+}
+
+void PCF85063::stop() {
+    int val = readReg(REG_CTRL1);
+    if (val >= 0) writeReg(REG_CTRL1, (uint8_t)(val | (1 << BIT_STOP)));
+}
+
+uint8_t PCF85063::isrunning() {
+    int val = readReg(REG_CTRL1);
+    if (val < 0) return 0;
+    return !(val & (1 << BIT_STOP));
+}
+
+// -- Low-level I2C -------------------------------------------------------------
+
+bool PCF85063::writeReg(uint8_t reg, uint8_t value) {
+    _wire->beginTransmission(PCF85063_ADDR);
+    _wire->write(reg);
+    _wire->write(value);
+    return (_wire->endTransmission() == 0);
+}
+
+int PCF85063::readReg(uint8_t reg) {
+    uint8_t value = 0;
+    _wire->beginTransmission(PCF85063_ADDR);
+    _wire->write(reg);
+    _wire->endTransmission(true);
+    _wire->requestFrom(PCF85063_ADDR, (uint8_t)1);
+    if (_wire->readBytes(&value, 1) != 1) return -1;
+    return value;
+}
+
+bool PCF85063::readRegs(uint8_t reg, uint8_t *buf, uint8_t len) {
+    _wire->beginTransmission(PCF85063_ADDR);
+    _wire->write(reg);
+    _wire->endTransmission(true);
+    _wire->requestFrom(PCF85063_ADDR, len);
+    return (_wire->readBytes(buf, len) == len);
+}
+
+#endif   // HAS_PCF85063

--- a/esp32_marauder/PCF85063.h
+++ b/esp32_marauder/PCF85063.h
@@ -1,0 +1,228 @@
+/*
+ * PCF85063 - Arduino/PlatformIO RTC library
+ * NXP PCF85063A/TP, I2C address 0x51
+ *
+ * Drop-in replacement for RTClib RTC_PCF8523:
+ *   rtc.begin(&Wire)
+ *   rtc.initialized()
+ *   rtc.lostPower()
+ *   rtc.adjust(DateTime)
+ *   rtc.now()          → DateTime
+ *   rtc.start()
+ *   rtc.stop()
+ *   rtc.isrunning()
+ *
+ * DateTime mirrors RTClib:
+ *   DateTime(year, month, day, hour, minute, second)
+ *   DateTime(F(__DATE__), F(__TIME__))
+ *   DateTime(uint32_t unix_epoch)
+ *   dt.year(), dt.month(), dt.day()
+ *   dt.hour(), dt.minute(), dt.second()
+ *   dt.dayOfTheWeek()
+ *   dt.unixtime()
+ *
+ * Register map (PCF85063Constants.h):
+ *   0x00 CTRL1  0x01 CTRL2  0x02 OFFSET  0x03 RAM
+ *   0x04 SEC    0x05 MIN    0x06 HOUR
+ *   0x07 DAY    0x08 WEEKDAY 0x09 MONTH  0x0A YEAR
+ */
+
+#pragma once
+
+#ifndef PCF85063_h
+#define PCF85063_h
+
+#include "configs.h"
+
+#ifdef HAS_PCF85063
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <stdint.h>
+#include <time.h>
+
+// -- DateTime - mirrors RTClib -------------------------------------------------
+class DateTime {
+public:
+    DateTime() : _year(2000), _month(1), _day(1),
+                 _hour(0), _minute(0), _second(0) {}
+
+    DateTime(uint16_t year, uint8_t month, uint8_t day,
+             uint8_t hour = 0, uint8_t minute = 0, uint8_t second = 0)
+        : _year(year), _month(month), _day(day),
+          _hour(hour), _minute(minute), _second(second) {}
+
+    // DateTime(F(__DATE__), F(__TIME__)) - compile-time stamp
+    DateTime(const char *date, const char *time) {
+        // date = "Oct 11 2026", time = "13:24:43"
+        static const char months[] = "JanFebMarAprMayJunJulAugSepOctNovDec";
+        char mon[4] = {};
+        int d, y;
+        sscanf(date, "%3s %d %d", mon, &d, &y);
+        _year  = (uint16_t)y;
+        _day   = (uint8_t)d;
+        _month = 1;
+        for (uint8_t i = 0; i < 12; i++) {
+            if (strncmp(mon, months + i * 3, 3) == 0) {
+                _month = i + 1;
+                break;
+            }
+        }
+        int h, m, s;
+        sscanf(time, "%d:%d:%d", &h, &m, &s);
+        _hour   = (uint8_t)h;
+        _minute = (uint8_t)m;
+        _second = (uint8_t)s;
+    }
+
+    // DateTime(unix_epoch) - mirrors RTClib
+    DateTime(uint32_t t) {
+        time_t tt = (time_t)t;
+        struct tm *ti = gmtime(&tt);
+        _year   = (uint16_t)(ti->tm_year + 1900);
+        _month  = (uint8_t) (ti->tm_mon  + 1);
+        _day    = (uint8_t)  ti->tm_mday;
+        _hour   = (uint8_t)  ti->tm_hour;
+        _minute = (uint8_t)  ti->tm_min;
+        _second = (uint8_t)  ti->tm_sec;
+    }
+
+    // DateTime(struct tm*)
+    DateTime(struct tm *ti) {
+        _year   = (uint16_t)(ti->tm_year + 1900);
+        _month  = (uint8_t) (ti->tm_mon  + 1);
+        _day    = (uint8_t)  ti->tm_mday;
+        _hour   = (uint8_t)  ti->tm_hour;
+        _minute = (uint8_t)  ti->tm_min;
+        _second = (uint8_t)  ti->tm_sec;
+    }
+
+    // DateTime from ISO8601 string "2026-10-11 13:24:43" or T separator
+    DateTime(const char *iso8601) {
+        if (!iso8601 || strlen(iso8601) < 19) { *this = DateTime(); return; }
+        auto c2 = [](const char *p) -> int {
+            int v = 0;
+            if (*p >= '0' && *p <= '9') v = (*p - '0') * 10;
+            p++;
+            if (*p >= '0' && *p <= '9') v += (*p - '0');
+            return v;
+        };
+        _year   = (uint16_t)(2000 + c2(iso8601 + 2));
+        _month  = (uint8_t)c2(iso8601 + 5);
+        _day    = (uint8_t)c2(iso8601 + 8);
+        _hour   = (uint8_t)c2(iso8601 + 11);
+        _minute = (uint8_t)c2(iso8601 + 14);
+        _second = (uint8_t)c2(iso8601 + 17);
+    }
+
+    // -- Accessors - identical to RTClib ---------------------------------------
+    uint16_t year()   const { return _year;   }
+    uint8_t  month()  const { return _month;  }
+    uint8_t  day()    const { return _day;    }
+    uint8_t  hour()   const { return _hour;   }
+    uint8_t  minute() const { return _minute; }
+    uint8_t  second() const { return _second; }
+
+    // Day of week: 0=Sun … 6=Sat (Zeller's congruence)
+    uint8_t dayOfTheWeek() const {
+        uint16_t y = _year;
+        uint8_t  m = _month;
+        if (m < 3) { m += 12; y--; }
+        uint32_t v = (_day
+                      + ((m + 1) * 26) / 10
+                      + y + y / 4
+                      + 6 * (y / 100)
+                      + y / 400) % 7;
+        return (uint8_t)(v == 0 ? 6 : v - 1);
+    }
+
+    // Unix timestamp (seconds since 1970-01-01 00:00:00 UTC)
+    uint32_t unixtime() const {
+        struct tm t = {};
+        t.tm_year = _year - 1900;
+        t.tm_mon  = _month - 1;
+        t.tm_mday = _day;
+        t.tm_hour = _hour;
+        t.tm_min  = _minute;
+        t.tm_sec  = _second;
+        return (uint32_t)mktime(&t);
+    }
+
+    // Populate a struct tm
+    struct tm toTm() const {
+        struct tm t = {};
+        t.tm_year = _year - 1900;
+        t.tm_mon  = _month - 1;
+        t.tm_mday = _day;
+        t.tm_hour = _hour;
+        t.tm_min  = _minute;
+        t.tm_sec  = _second;
+        t.tm_wday = dayOfTheWeek();
+        return t;
+    }
+
+    bool operator==(const DateTime &o) const {
+        return _year == o._year && _month == o._month && _day == o._day
+            && _hour == o._hour && _minute == o._minute && _second == o._second;
+    }
+
+private:
+    uint16_t _year;
+    uint8_t  _month, _day, _hour, _minute, _second;
+};
+
+// -- PCF85063 - RTClib RTC_PCF8523-compatible interface -----------------------
+class PCF85063 {
+public:
+    PCF85063();
+
+    // RTClib-compatible begin - takes TwoWire pointer
+    bool begin(TwoWire *wire = &Wire);
+
+    // Extended begin - takes TwoWire reference + optional SDA/SCL pins
+    // Matches Waveshare BSP: rtc.begin(Wire, SDA, SCL)
+    bool begin(TwoWire &wire, int sda = -1, int scl = -1);
+
+    // -- RTClib RTC_PCF8523 interface ------------------------------------------
+    DateTime now();
+    void     adjust(const DateTime &dt);
+    bool     initialized();     // true = clock has valid time (OS bit clear)
+    bool     lostPower();       // true = clock lost power (OS bit set)  - inverse of initialized()
+    void     start();
+    void     stop();
+    uint8_t  isrunning();       // matches RTClib spelling
+
+    // -- Low-level -------------------------------------------------------------
+    bool writeReg(uint8_t reg, uint8_t value);
+    int  readReg(uint8_t reg);
+    bool readRegs(uint8_t reg, uint8_t *buf, uint8_t len);
+
+private:
+    TwoWire *_wire;
+
+    // Register addresses from PCF85063Constants.h
+    static constexpr uint8_t PCF85063_ADDR    = 0x51;
+    static constexpr uint8_t REG_CTRL1        = 0x00;
+    static constexpr uint8_t REG_RAM          = 0x03;
+    static constexpr uint8_t REG_SEC          = 0x04;
+    static constexpr uint8_t REG_MIN          = 0x05;
+    static constexpr uint8_t REG_HOUR         = 0x06;
+    static constexpr uint8_t REG_DAY          = 0x07;
+    static constexpr uint8_t REG_WEEKDAY      = 0x08;
+    static constexpr uint8_t REG_MONTH        = 0x09;
+    static constexpr uint8_t REG_YEAR         = 0x0A;
+
+    static constexpr uint8_t BIT_STOP         = 5;
+    static constexpr uint8_t BIT_12H          = 1;
+    static constexpr uint8_t BIT_OS           = 7;   // SEC oscillator-stop flag
+
+    static uint8_t _bcd2dec(uint8_t b) { return ((b >> 4) * 10) + (b & 0x0F); }
+    static uint8_t _dec2bcd(uint8_t d) { return ((d / 10) << 4) | (d % 10);   }
+
+    bool _initImpl();
+};
+
+
+#endif   // HAS_PCF85063
+
+#endif  //  PCF85063_h

--- a/esp32_marauder/RTC.cpp
+++ b/esp32_marauder/RTC.cpp
@@ -59,8 +59,8 @@ void RTC::RunSetup() {
   supported = rtclock.begin(_wire);
 
   if (!supported) {
-    log_w("Couldn't find RTC");
-    // return supported;
+    log_w("RTC Was not detected");
+    return;
   }
 
   setup();

--- a/esp32_marauder/RTC.cpp
+++ b/esp32_marauder/RTC.cpp
@@ -78,11 +78,10 @@ bool RTC::setup() {
         log_d("RTC lostPower");
 
     // rtclock.adjust(DateTime(F(__DATE__), F(__TIME__)));
-    synced = false;
+    system_time_set = false;
     // setSystemTimeFromCompile();
     // log_i("SystemTime set from Build time");
   } else {
-    synced = true;
     system_time_set = true;
     syncFromRTC();
     log_i("SystemTime set from RTC");
@@ -121,7 +120,6 @@ log_i("RTC::DS1307_setup");
     Serial.flush();
     log_w("RTC is NOT initialized");
   }  else {
-    synced = true;
     system_time_set = true;
     syncFromRTC();
     Serial.println(F("SystemTime set from RTC"));
@@ -171,7 +169,6 @@ void RTC::syncFromRTC() {
   struct timeval tv = { .tv_sec = t, .tv_usec = 0 };
 
   settimeofday(&tv, NULL);
-  synced = true;
   system_time_set = true;
   Serial.println(F("system time synced with RTC"));
 // #elif defined(HAS_BM8563)
@@ -209,7 +206,6 @@ void RTC::syncFromRTC() {
           return false;
       }
 
-      synced = true;
       system_time_set = true;
       Serial.println(F("System time updated successfully!"));
       return true;
@@ -237,7 +233,6 @@ void RTC::syncFromRTC() {
     log_w("Failed to obtain time from NTP");
     return false;
   }
-  synced = true;
   system_time_set = true;
 
   Serial.println(&timeinfo, "%A, %B %d %Y %H:%M:%S");
@@ -319,7 +314,6 @@ String RTC::dt_string() {
 
   Serial.println(now.toString("%F %T"));
   Serial.println(now.toString(format));
-
 
   return now.toString(format);   // one I2C read
 }

--- a/esp32_marauder/RTC.cpp
+++ b/esp32_marauder/RTC.cpp
@@ -1,0 +1,354 @@
+#include "configs.h"
+
+#ifdef HAS_RTC
+
+#include "RTC.h"
+
+// https://github.com/adafruit/RTClib
+
+
+/*
+Unfortunately, we can't probe to figure out which ones installed
+There are ways to probe and figure it out, but I don't feel it's worth the extra  code
+  DS1307_ADDRESS 0x68  with AT24C32 0x50
+  DS3231_ADDRESS 0x68
+  PCF8523_ADDRESS 0x68
+  BM8563/PCF8563_ADDRESS 0x51 (7-bit 0x51 or 8bit 0xA2 0xA3)
+*/
+
+#if !defined(RTC_SDA) && defined(I2C_SDA)
+#define RTC_SDA I2C_SDA
+#define RTC_SCL I2C_SCL
+#endif
+
+// default 100000UL
+#ifndef RTC_FREQ
+#define RTC_FREQ -1
+#endif
+
+void RTC::RunSetup() {
+  log_d("RTC::RunSetup SDA=%d SCL=%d Freq=%d", RTC_SDA, RTC_SCL, RTC_FREQ);
+
+  #if defined(I2C_SDA) && (RTC_SDA != I2C_SDA)
+    log_i("RTC::RunSetup Using Wire1");
+    _wire = &Wire1;
+  #else
+    log_i("RTC::RunSetup Using Wire0");
+    _wire = &Wire;
+  #endif
+
+  #ifdef RTC_SDA
+    _wire->setPins(RTC_SDA, RTC_SCL);
+    _wire->begin();
+  #endif
+
+  #if defined(RTC_FREQ) && (RTC_FREQ > 0)
+    _wire->setClock(RTC_FREQ);
+  #endif
+
+  #ifdef DEVELOPER
+    #if defined(HAS_PCF8523)
+      log_d("Looking for PCF8523");
+    #elif defined(HAS_DS1307)
+      log_d("Looking for DS1307");
+    #else
+      log_d("Looking for ?????");
+    #endif
+  #endif
+
+  supported = rtclock.begin(_wire);
+
+  if (!supported) {
+    log_w("Couldn't find RTC");
+    // return supported;
+  }
+
+  setup();
+}
+
+#if defined(HAS_PCF8523)
+
+bool RTC::setup() {
+  log_i("RTC::PCF8523_setup");
+
+  if (!rtclock.initialized() || rtclock.lostPower()) {
+      log_d("RTC is NOT initialized");
+      Serial.println(F("RTC is NOT initialized"));
+      if (rtclock.lostPower())
+        log_d("RTC lostPower");
+
+    // rtclock.adjust(DateTime(F(__DATE__), F(__TIME__)));
+    synced = false;
+    // setSystemTimeFromCompile();
+    // log_i("SystemTime set from Build time");
+  } else {
+    synced = true;
+    system_time_set = true;
+    syncFromRTC();
+    log_i("SystemTime set from RTC");
+  }
+
+  // do this to ensure the RTC is running.
+  rtclock.start();
+
+  // log_d(dt_string());
+  Serial.println(dt_string());
+
+  return supported;
+}
+
+// float RTC::getTemperature() { return 0.0;  }
+
+#elif defined(HAS_DS1307)
+// M5StickC_Plus
+
+bool RTC::setup() {
+int error;
+
+log_i("RTC::DS1307_setup");
+
+  struct tm timeinfo;
+  if (getLocalTime(&timeinfo)) {
+    Serial.print("RTC::setup: getLocalTime=");
+    Serial.println(&timeinfo, "%F %T");
+  } else {
+    log_w("getLocalTime Fail");
+    perror("getLocalTime");
+  }
+
+  if (!rtclock.isrunning()) {
+    Serial.println(F("RTC NOT initialized"));
+    Serial.flush();
+    log_w("RTC is NOT initialized");
+  }  else {
+    synced = true;
+    system_time_set = true;
+    syncFromRTC();
+    Serial.println(F("SystemTime set from RTC"));
+  }
+
+  // #ifdef DEVELOPER
+  //   log_d(dt_string());
+  // #else
+    Serial.print("dt_string(): ");
+    log_d("dt_string(): %s", dt_string());
+  // #endif
+  log_i("RTC::DS1307_setup Done");
+
+  return supported;
+}
+
+
+// float RTC:getTemperature() { rtclock.getTemperature(); }
+
+// #elif defined(HAS_BM8563)
+// bool RTC::setup() {
+//   log_i("RTC::BM8563_setup");
+// }
+
+#endif
+
+void RTC::syncFromRTC() {
+// 1. Read time from the PCF8523
+
+#if defined(HAS_PCF8523) || defined(HAS_DS1307)
+  DateTime now = rtclock.now();
+
+  // 2. Populate the standard C tm structure
+  struct tm tm_time;
+  tm_time.tm_year = now.year() - 1900;  // Years since 1900
+  tm_time.tm_mon  = now.month() - 1;    // Months (0-11)
+  tm_time.tm_mday = now.day();          // Day of the month (1-31)
+  tm_time.tm_hour = now.hour();         // Hours (0-23)
+  tm_time.tm_min  = now.minute();       // Minutes (0-59)
+  tm_time.tm_sec  = now.second();       // Seconds (0-59)
+
+  // Set isdst to -1 to let the system decide based on your timezone settings
+  tm_time.tm_isdst = -1;
+
+  // 3. Convert tm to time_t and configure settimeofday
+  time_t t = mktime(&tm_time);
+  struct timeval tv = { .tv_sec = t, .tv_usec = 0 };
+
+  settimeofday(&tv, NULL);
+  synced = true;
+  system_time_set = true;
+  Serial.println(F("system time synced with RTC"));
+// #elif defined(HAS_BM8563)
+//   log_w("syncFromRTC: BM8563 not yet implemented");
+#endif
+}
+
+
+  // Function to set system time from an ISO 8601 string (e.g., "2026-06-11T13:26:00")
+  bool RTC::getSystemTimeFromString(const char* timeStr) {
+      struct tm timeinfo = {0};
+
+      // Parse the string into the tm struct using format specifiers
+      // %Y = Year, %m = Month, %d = Day, %H = Hour, %M = Minute, %S = Second
+      if (strptime(timeStr, "%Y-%m-%dT%H:%M:%S", &timeinfo) == NULL) {
+          Serial.println(F("Failed to parse time string."));
+          return false;
+      }
+
+      // Convert tm struct to Unix timestamp (seconds since Jan 1 1970)
+      time_t epochTime = mktime(&timeinfo);
+      if (epochTime == -1) {
+          Serial.println(F("Failed to convert tm to epoch time."));
+          return false;
+      }
+
+      // Structure required by settimeofday
+      struct timeval tv;
+      tv.tv_sec = epochTime;
+      tv.tv_usec = 0;        // Microseconds
+
+      // Apply time directly to ESP32 internal clock
+      if (settimeofday(&tv, NULL) != 0) {
+          Serial.println(F("Failed to update system time."));
+          return false;
+      }
+
+      synced = true;
+      system_time_set = true;
+      Serial.println(F("System time updated successfully!"));
+      return true;
+  }
+
+
+  bool RTC::sync_rtc_ntp(const char* ntpServer) {
+    struct tm timeinfo;
+
+    if (!supported) {
+      log_w("RTC not supported");
+      return false;
+    }
+
+  if (!wifi_scan_obj.wifi_connected) {
+    log_w("Wifi Not Connected");
+    return false;
+  }
+
+  configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+
+  delay(1000);
+
+  if (!getLocalTime(&timeinfo)) {
+    log_w("Failed to obtain time from NTP");
+    return false;
+  }
+  synced = true;
+  system_time_set = true;
+
+  Serial.println(&timeinfo, "%A, %B %d %Y %H:%M:%S");
+  Serial.println(F("RTC successfully set via NTP!"));
+
+  time_t epoch_now;
+  time(&epoch_now);
+  struct tm* timeStruct = localtime(&epoch_now);
+
+  DateTime ntpTime(
+    timeStruct->tm_year + 1900,  // Year starts from 1900
+    timeStruct->tm_mon + 1,      // Month (1-12)
+    timeStruct->tm_mday,         // Day of the month
+    timeStruct->tm_hour,         // Hour
+    timeStruct->tm_min,          // Minute
+    timeStruct->tm_sec           // Second
+  );
+
+    rtclock.adjust(ntpTime);
+    Serial.println(F("RTC updated with NTP time."));
+    // log_d("PCF8523 RTC updated with NTP time.");
+
+  /*
+  rtclock.adjust(DateTime(
+    timeinfo.tm_year + 1900,
+    timeinfo.tm_mon + 1,
+    timeinfo.tm_mday,
+    timeinfo.tm_hour,
+    timeinfo.tm_min,
+    timeinfo.tm_sec
+  ));
+  */
+
+  return true;
+}
+
+
+// template <typename T>
+// void RTC::adjust_rtc(T& tm) {
+//    rtclock.adjust(DateTime(tm));
+// }
+
+void RTC::adjust_rtc(const char *time_str) {
+  rtclock.adjust(DateTime(time_str));
+}
+
+void RTC::adjust_rtc(struct tm *timeInfo) {
+    // struct tm tmp = timeInfo;
+    time_t t = mktime(timeInfo);
+    rtclock.adjust(DateTime(t));
+}
+
+void RTC::adjust_rtc(const DateTime &dt) {
+  rtclock.adjust(dt);
+}
+
+void RTC::adjust_rtc(uint32_t t) {
+  rtclock.adjust(DateTime(t));
+}
+
+/*
+void RTC::setSystemTimeFromCompile() {
+    struct tm tm_build = {0};
+
+    // Parse built-in compile time macros
+    strptime(__DATE__, "%b %d %Y", &tm_build);
+    strptime(__TIME__, "%T", &tm_build);
+
+    // Set as UTC
+    tm_build.tm_isdst = -1;
+    time_t t_of_day = mktime(&tm_build);
+
+    if (t_of_day == (time_t)-1) {
+      log_w("setSystemTimeFromCompile: mktime failed");
+      return;
+    }
+
+    // Update the system time
+    struct timeval tv = { .tv_sec = t_of_day, .tv_usec = 0 };
+    settimeofday(&tv, NULL);
+}
+*/
+
+String RTC::dt_string() {
+  if (!supported)  log_w("RTC not supported"); return "";
+
+  DateTime now = rtclock.now();
+
+  char format[] = "%Y-%m-%d %H:%M:%S";  // %F %T";
+
+  Serial.println(now.toString("%F %T"));
+  Serial.println(now.toString(format));
+
+
+  return now.toString(format);   // one I2C read
+}
+
+String RTC::millis_dt_string() {   // punt
+  uint32_t ms = millis();
+  uint32_t s  = (ms / 1000) % 60;
+  uint32_t m  = (ms / 60000) % 60;
+  uint32_t h  = (ms / 3600000) % 24;
+  uint32_t d  =  ms / 86400000UL;
+
+  char buf[20];
+
+  snprintf(buf, sizeof(buf), "%ud %02u:%02u:%02u", d, h, m, s);
+
+  return String(buf);
+}
+
+
+#endif  // HAS_RTC
+

--- a/esp32_marauder/RTC.cpp
+++ b/esp32_marauder/RTC.cpp
@@ -15,7 +15,7 @@
 #endif
 
 // -----------------------------------------------------------------------------
-// RunSetup — wire selection, pin config, begin()
+// RunSetup - wire selection, pin config, begin()
 // -----------------------------------------------------------------------------
 void RTC::RunSetup() {
   log_d("RTC::RunSetup SDA=%d SCL=%d Freq=%d", RTC_SDA, RTC_SCL, RTC_FREQ);
@@ -37,17 +37,19 @@ void RTC::RunSetup() {
     _wire->setClock(RTC_FREQ);
   #endif
 
-  // -- begin() differs per driver ----------------------------------------------
+  // -- begin() - all drivers take TwoWire* --------------------------------------
+  // begin() returns false ONLY if chip not on bus
+  // time validity (OS bit) is checked separately in setup() via initialized()
   #if defined(HAS_PCF85063)
     log_d("Looking for PCF85063");
-    supported = rtclock.begin(*_wire);      // our driver takes TwoWire&
+    supported = rtclock.begin(_wire);
   #elif defined(HAS_PCF8523) || defined(HAS_DS1307)
     log_d("Looking for RTClib device");
-    supported = rtclock.begin(_wire);       // RTClib takes TwoWire*
+    supported = rtclock.begin(_wire);
   #endif
 
   if (!supported) {
-    log_w("RTC not detected");
+    log_e("RTC: chip not found on I2C bus");
     return;
   }
 
@@ -55,7 +57,7 @@ void RTC::RunSetup() {
 }
 
 // -----------------------------------------------------------------------------
-// setup() — per-chip post-init
+// setup() - per-chip post-init
 // -----------------------------------------------------------------------------
 
 #if defined(HAS_PCF85063)
@@ -63,18 +65,24 @@ void RTC::RunSetup() {
 bool RTC::setup() {
   log_i("RTC::PCF85063_setup");
 
-  if (!rtclock.isClockIntegrityOK()) {
-    log_d("RTC integrity lost — time not set");
-    Serial.println(F("RTC is NOT initialized or lost power"));
+  // supported = chip is present on bus (already confirmed by begin())
+  // rtc_synced = time is valid (OS bit clear = battery held time through power loss)
+  // These are independent - chip can be present but time unset
+  if (!rtclock.initialized() || rtclock.lostPower()) {
+    log_w("RTC: chip found but time not set (OS bit set)");
+    Serial.println(F("RTC found - time not set, needs adjust()"));
     system_time_set = false;
+    rtc_synced = false;
+    // supported stays true - caller can call adjust_rtc() or sync_rtc_ntp() later
   } else {
-    system_time_set = true;
+    rtc_synced = true;
     syncFromRTC();
-    log_i("SystemTime set from RTC");
+    system_time_set = true;
+    log_i("RTC: time valid, system clock synced");
   }
 
   Serial.println(dt_string());
-  return supported;
+  return true;  // chip found - always true here
 }
 
 #elif defined(HAS_PCF8523)
@@ -127,35 +135,25 @@ bool RTC::setup() {
 #endif
 
 // -----------------------------------------------------------------------------
-// syncFromRTC — read chip time → set ESP32 system clock
+// syncFromRTC - read chip time → set ESP32 system clock
+// All chips use rtclock.now() → DateTime (RTClib-compatible interface)
 // -----------------------------------------------------------------------------
 void RTC::syncFromRTC() {
-  struct tm tm_time = {};
+  DateTime now = rtclock.now();
+  // struct tm tm_time = now.toTm();
 
-  #if defined(HAS_PCF85063)
-    PCF85063DateTime dt;
-    if (!rtclock.getDateTime(dt)) {
-      log_w("syncFromRTC: PCF85063 read failed");
-      return;
-    }
-    tm_time.tm_year = dt.year - 1900;
-    tm_time.tm_mon  = dt.month - 1;
-    tm_time.tm_mday = dt.day;
-    tm_time.tm_hour = dt.hour;
-    tm_time.tm_min  = dt.minute;
-    tm_time.tm_sec  = dt.second;
+  // 2. Populate the standard C tm structure
+  struct tm tm_time;
+  tm_time.tm_year = now.year() - 1900;  // Years since 1900
+  tm_time.tm_mon  = now.month() - 1;    // Months (0-11)
+  tm_time.tm_mday = now.day();          // Day of the month (1-31)
+  tm_time.tm_hour = now.hour();         // Hours (0-23)
+  tm_time.tm_min  = now.minute();       // Minutes (0-59)
+  tm_time.tm_sec  = now.second();       // Seconds (0-59)
 
-  #elif defined(HAS_PCF8523) || defined(HAS_DS1307)
-    DateTime now = rtclock.now();
-    tm_time.tm_year = now.year()   - 1900;
-    tm_time.tm_mon  = now.month()  - 1;
-    tm_time.tm_mday = now.day();
-    tm_time.tm_hour = now.hour();
-    tm_time.tm_min  = now.minute();
-    tm_time.tm_sec  = now.second();
-  #endif
-
+  // Set isdst to -1 to let the system decide based on your timezone settings
   tm_time.tm_isdst = -1;
+
   time_t t = mktime(&tm_time);
   struct timeval tv = { .tv_sec = t, .tv_usec = 0 };
   settimeofday(&tv, NULL);
@@ -164,43 +162,23 @@ void RTC::syncFromRTC() {
 }
 
 // -----------------------------------------------------------------------------
-// adjust_rtc overloads
+// adjust_rtc overloads - all chips use rtclock.adjust(DateTime)
 // -----------------------------------------------------------------------------
-
-#if defined(HAS_PCF85063)
-
-void RTC::adjust_rtc(uint16_t year, uint8_t month, uint8_t day,
-                     uint8_t hour, uint8_t minute, uint8_t second) {
-  rtclock.setDateTime(year, month, day, hour, minute, second);
-}
-
-void RTC::adjust_rtc(struct tm *timeInfo) {
-  rtclock.setDateTime(
-    (uint16_t)(timeInfo->tm_year + 1900),
-    (uint8_t) (timeInfo->tm_mon  + 1),
-    (uint8_t)  timeInfo->tm_mday,
-    (uint8_t)  timeInfo->tm_hour,
-    (uint8_t)  timeInfo->tm_min,
-    (uint8_t)  timeInfo->tm_sec
-  );
-}
-
-void RTC::adjust_rtc(uint32_t t) {
-  time_t tt = (time_t)t;
-  struct tm *ti = gmtime(&tt);
-  adjust_rtc(ti);
-}
-
-#else  // RTClib targets
 
 void RTC::adjust_rtc(const char *time_str) {
   rtclock.adjust(DateTime(time_str));
 }
 
-void RTC::adjust_rtc(struct tm *timeInfo) {
-  time_t t = mktime(timeInfo);
-  rtclock.adjust(DateTime((uint32_t)t));
-}
+void RTC::adjust_rtc(struct tm *ti) {
+  rtclock.adjust(DateTime(
+    (uint16_t)(ti->tm_year + 1900),
+    (uint8_t) (ti->tm_mon  + 1),
+    (uint8_t)  ti->tm_mday,
+    (uint8_t)  ti->tm_hour,
+    (uint8_t)  ti->tm_min,
+    (uint8_t)  ti->tm_sec
+    ));
+  }
 
 void RTC::adjust_rtc(const DateTime &dt) {
   rtclock.adjust(dt);
@@ -209,8 +187,6 @@ void RTC::adjust_rtc(const DateTime &dt) {
 void RTC::adjust_rtc(uint32_t t) {
   rtclock.adjust(DateTime(t));
 }
-
-#endif
 
 // -----------------------------------------------------------------------------
 // NTP sync
@@ -265,22 +241,12 @@ bool RTC::getSystemTimeFromString(const char *timeStr) {
 // -----------------------------------------------------------------------------
 String RTC::dt_string() {
   if (!supported) { log_w("RTC not supported"); return ""; }
-
-  #if defined(HAS_PCF85063)
-    PCF85063DateTime dt;
-    if (!rtclock.getDateTime(dt)) return "";
-    char buf[20];
-    snprintf(buf, sizeof(buf), "%04u-%02u-%02u %02u:%02u:%02u",
-             dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second);
-    return String(buf);
-
-  #elif defined(HAS_PCF8523) || defined(HAS_DS1307)
-    DateTime now = rtclock.now();
-    char format[] = "%Y-%m-%d %H:%M:%S";
-    return now.toString(format);
-  #endif
-
-  return "";
+  DateTime now = rtclock.now();
+  char buf[20];
+  snprintf(buf, sizeof(buf), "%04u-%02u-%02u %02u:%02u:%02u",
+           now.year(), now.month(), now.day(),
+           now.hour(), now.minute(), now.second());
+  return String(buf);
 }
 
 String RTC::millis_dt_string() {

--- a/esp32_marauder/RTC.cpp
+++ b/esp32_marauder/RTC.cpp
@@ -1,6 +1,6 @@
 #include "configs.h"
 
-#ifdef HAS_RTC
+#if defined(HAS_RTC) && (defined(HAS_DS1307) || defined(HAS_PCF8523)
 
 #include "RTC.h"
 

--- a/esp32_marauder/RTC.cpp
+++ b/esp32_marauder/RTC.cpp
@@ -1,6 +1,6 @@
 #include "configs.h"
 
-#if defined(HAS_RTC) && (defined(HAS_DS1307) || defined(HAS_PCF8523)
+#if defined(HAS_RTC) && (defined(HAS_DS1307) || defined(HAS_PCF8523))
 
 #include "RTC.h"
 

--- a/esp32_marauder/RTC.cpp
+++ b/esp32_marauder/RTC.cpp
@@ -229,7 +229,7 @@ void RTC::syncFromRTC() {
     return false;
   }
 
-  configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+  configTime(GMTOFFSET_SEC, DAYLIGHTOFFSET_SEC, ntpServer);
 
   delay(1000);
 
@@ -259,17 +259,6 @@ void RTC::syncFromRTC() {
     rtclock.adjust(ntpTime);
     Serial.println(F("RTC updated with NTP time."));
     // log_d("PCF8523 RTC updated with NTP time.");
-
-  /*
-  rtclock.adjust(DateTime(
-    timeinfo.tm_year + 1900,
-    timeinfo.tm_mon + 1,
-    timeinfo.tm_mday,
-    timeinfo.tm_hour,
-    timeinfo.tm_min,
-    timeinfo.tm_sec
-  ));
-  */
 
   return true;
 }

--- a/esp32_marauder/RTC.h
+++ b/esp32_marauder/RTC.h
@@ -1,7 +1,7 @@
 
 #include "configs.h"
 
-#ifdef HAS_RTC
+#if defined(HAS_RTC) && (defined(HAS_DS1307) || defined(HAS_PCF8523)
 
 #ifndef rtc_h
 #define rtc_h

--- a/esp32_marauder/RTC.h
+++ b/esp32_marauder/RTC.h
@@ -1,0 +1,102 @@
+
+#include "configs.h"
+
+#ifdef HAS_RTC
+
+#ifndef rtc_h
+#define rtc_h
+
+
+#include <Arduino.h>
+#if defined(HAS_PCF8523) || defined(HAS_DS1307)
+  #include "RTClib.h"
+// #elif defined(HAS_BM8563)
+//   #include "I2C_BM8563.h"
+#endif
+
+#ifndef NTPSERVER
+  #define NTPSERVER "pool.ntp.org"
+#endif
+
+#include <time.h>
+#include <sys/time.h>
+
+#include <Wire.h>
+#include "WiFiScan.h"
+
+
+extern WiFiScan wifi_scan_obj;
+
+// If system time/date has been set
+extern bool system_time_set;
+
+
+/*
+const char* ntpServer = "pool.ntp.org";
+const long gmtOffset_sec = -28800;      // Replace with your offset (e.g., -28800 for PST)
+const int daylightOffset_sec = 3600;    // Adjust daylight savings (e.g., 3600 for DST)
+*/
+
+
+class RTC  {    // RTC_PCF8523
+
+  public:
+
+    #if defined(HAS_PCF8523)
+      RTC_PCF8523 rtclock;
+    #elif defined(HAS_DS1307)
+      RTC_DS1307 rtclock;
+//     #elif defined(HAS_BM8563)
+//       RTC_BM8563 rtclock;
+    #endif
+
+    bool setup();
+
+    void RunSetup();
+    bool supported = false;
+    String dt_string();
+    String millis_dt_string();
+    bool sync_rtc_ntp(const char* ntpServer = NTPSERVER);
+    bool synced = false;
+
+
+    // float getTemperature();  // PCF8523 only
+
+    bool getSystemTimeFromString(const char* timeStr);
+    // static const char* const daysOfTheWeek[] PROGMEM = {
+    //  "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+    //  };
+
+    // const char* ntpServer = NTPSERVER;
+    const long gmtOffset_sec = 0;   // Always 0 for UTC
+    const int daylightOffset_sec = 0;
+    void setSystemTimeFromCompile();
+    void syncFromRTC();
+
+    // template <typename T>
+    // void adjust_rtc(T& tm);
+
+    void adjust_rtc(const char *time_str);
+    void adjust_rtc(struct tm *timeInfo);
+    void adjust_rtc(const DateTime &dt);
+    void adjust_rtc(uint32_t t);
+
+    // helper for direct calls
+    void adjust(const DateTime &dt) {
+      rtclock.adjust(dt);
+    }
+
+  private:
+    TwoWire *_wire;
+
+};
+
+// template <typename T>
+// void adjust_rtc(T tm) {
+//   rtclock.adjust(DateTime(tm));
+// }
+
+
+#endif // rtc_h
+
+#endif // HAS_RTC

--- a/esp32_marauder/RTC.h
+++ b/esp32_marauder/RTC.h
@@ -12,6 +12,7 @@
   #include "RTClib.h"
 // #elif defined(HAS_BM8563)
 //   #include "I2C_BM8563.h"
+
 #endif
 
 #ifndef NTPSERVER
@@ -24,24 +25,14 @@
 #include <Wire.h>
 #include "WiFiScan.h"
 
-
 extern WiFiScan wifi_scan_obj;
 
 // If system time/date has been set
 extern bool system_time_set;
 
-
-/*
-const char* ntpServer = "pool.ntp.org";
-const long gmtOffset_sec = -28800;      // Replace with your offset (e.g., -28800 for PST)
-const int daylightOffset_sec = 3600;    // Adjust daylight savings (e.g., 3600 for DST)
-*/
-
-
 class RTC  {    // RTC_PCF8523
 
   public:
-
     #if defined(HAS_PCF8523)
       RTC_PCF8523 rtclock;
     #elif defined(HAS_DS1307)
@@ -57,8 +48,6 @@ class RTC  {    // RTC_PCF8523
     String dt_string();
     String millis_dt_string();
     bool sync_rtc_ntp(const char* ntpServer = NTPSERVER);
-    bool synced = false;
-
 
     // float getTemperature();  // PCF8523 only
 

--- a/esp32_marauder/RTC.h
+++ b/esp32_marauder/RTC.h
@@ -1,7 +1,7 @@
 
 #include "configs.h"
 
-#if defined(HAS_RTC) && (defined(HAS_DS1307) || defined(HAS_PCF8523)
+#if defined(HAS_RTC) && (defined(HAS_DS1307) || defined(HAS_PCF8523))
 
 #ifndef rtc_h
 #define rtc_h

--- a/esp32_marauder/RTC.h
+++ b/esp32_marauder/RTC.h
@@ -68,8 +68,8 @@ class RTC  {    // RTC_PCF8523
     //  };
 
     // const char* ntpServer = NTPSERVER;
-    const long gmtOffset_sec = 0;   // Always 0 for UTC
-    const int daylightOffset_sec = 0;
+    // const long gmtOffset_sec = 0;   // Always 0 for UTC
+    // const int daylightOffset_sec = 0;
     void setSystemTimeFromCompile();
     void syncFromRTC();
 

--- a/esp32_marauder/RTC.h
+++ b/esp32_marauder/RTC.h
@@ -15,7 +15,7 @@
   #include "RTClib.h"
 #endif
 
-// -- Native PCF85063 driver ----------------------------------------------------
+// -- PCF85063 driver - RTClib-compatible interface -----------------------------
 #if defined(HAS_PCF85063)
   #include "PCF85063.h"
 #endif
@@ -32,7 +32,7 @@ extern bool system_time_set;
 class RTC {
 public:
 
-  // -- Hardware object — one per build target ----------------------------------
+  // -- Hardware object - one per build target ----------------------------------
   #if defined(HAS_PCF8523)
     RTC_PCF8523  rtclock;
   #elif defined(HAS_DS1307)
@@ -42,6 +42,7 @@ public:
   #endif
 
   bool   supported = false;
+  bool   rtc_synced = false;
 
   void   RunSetup();
   bool   setup();
@@ -56,24 +57,12 @@ public:
   bool getSystemTimeFromString(const char *timeStr);
   void setSystemTimeFromCompile();
 
-  // -- Adjust overloads -------------------------------------------------------
-  // PCF85063 uses its own struct; RTClib targets use DateTime
-  #if defined(HAS_PCF85063)
-    void adjust_rtc(uint16_t year, uint8_t month, uint8_t day,
-                    uint8_t hour, uint8_t minute, uint8_t second);
-    void adjust_rtc(struct tm *timeInfo);
-    void adjust_rtc(uint32_t t);          // Unix epoch
-    void adjust(uint16_t year, uint8_t month, uint8_t day,
-                uint8_t hour, uint8_t minute, uint8_t second) {
-      rtclock.setDateTime(year, month, day, hour, minute, second);
-    }
-  #else
-    void adjust_rtc(const char *time_str);
-    void adjust_rtc(struct tm *timeInfo);
-    void adjust_rtc(const DateTime &dt);
-    void adjust_rtc(uint32_t t);
-    void adjust(const DateTime &dt) { rtclock.adjust(dt); }
-  #endif
+  // -- Adjust overloads - all chips use DateTime now --------------------------
+  void adjust_rtc(const char *time_str);   // ISO8601 string
+  void adjust_rtc(struct tm *timeInfo);
+  void adjust_rtc(const DateTime &dt);
+  void adjust_rtc(uint32_t t);             // Unix epoch
+  void adjust(const DateTime &dt) { rtclock.adjust(dt); }
 
 private:
   TwoWire *_wire = nullptr;

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -141,6 +141,8 @@
     #define HAS_SD
     #define USE_SD
     #define HAS_TEMP_SENSOR
+    #define HAS_RTC
+      #define HAS_RTC8563
     #define HAS_GPS
   #endif
 
@@ -227,8 +229,10 @@
 
   #ifdef MARAUDER_REV_FEATHER
     //#define FLIPPER_ZERO_HAT
-    //#define HAS_BATTERY
+    #define HAS_BATTERY
     //#define HAS_BT
+    #define HAS_RTC
+      #define HAS_PCF8523
     #define HAS_MINI_KB
     #define HAS_BUTTONS
     #define HAS_NEOPIXEL_LED
@@ -2897,7 +2901,6 @@
     #endif
 
   #endif  // HAS_BATTERY
-
 
   //// MARAUDER TITLE STUFF
   #ifdef MARAUDER_V4

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -896,6 +896,13 @@
       #define TOUCH_CS -1
       //#define SD_CS 1
 
+      #define I2C_SDA 21
+      #define I2C_SCL 22
+      #define I2C_INT 35
+      // J1 Grove connector
+      // GPIO32
+      // GPIO33
+
       #define SCREEN_BUFFER
 
       #define MAX_SCREEN_BUFFER 9
@@ -2796,7 +2803,7 @@
   #ifdef HAS_BATTERY
 
     #if defined(MARAUDER_M5STICKC) || defined(MARAUDER_M5STICKCP2) 
-      #define I2C_SDA 33
+      #define I2C_SDA 21
       #define I2C_SCL 22
 
     #elif defined(MARAUDER_V4) || defined(MARAUDER_V6) || defined(MARAUDER_V6_1) || defined(MARAUDER_KIT)

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -590,6 +590,19 @@
   #endif
   //// END BOARD FEATURES
 
+    #if defined(HAS_PCF8523) || defined(HAS_DS1307)
+        #define HAS_RTC         // i2c real-time clock (RTC)
+    #endif
+
+    #ifndef GMTOFFSET_SEC
+      #define GMTOFFSET_SEC 0  // -8 hours for Pacific Time
+    #endif
+
+    #ifndef DAYLIGHTOFFSET_SEC
+      #define DAYLIGHTOFFSET_SEC 0
+    #endif
+
+
   //// POWER MANAGEMENT
   #ifdef HAS_PWR_MGMT
     #if defined(HAS_AXP192)
@@ -900,6 +913,9 @@
       #define TOUCH_CS -1
       //#define SD_CS 1
 
+      #define RTC_SDA 33
+      #define RTC_SCL 22
+
       #define SCREEN_BUFFER
 
       #define MAX_SCREEN_BUFFER 9
@@ -975,6 +991,9 @@
       #define TFT_RST 12
       #define TFT_BL 27
       #define TOUCH_CS -1
+
+      #define RTC_SDA 33
+      #define RTC_SCL 22
 
       #define SCREEN_BUFFER
 
@@ -1983,6 +2002,9 @@
       //#define TOUCH_CS 21
       #define SD_CS 4
 
+      #define RTC_SCL 4
+      #define RTC_SDA 3
+
       #define SCREEN_BUFFER
 
       #define MAX_SCREEN_BUFFER 9
@@ -2562,6 +2584,7 @@
   #define TFTDARKGREY  16
   #define TFTSKYBLUE   17
   #define TFTLIME      18
+  #define TFTPINK      21
   //// END SPACE SAVING COLORS
 
   #define TFT_FARTGRAY 0x528a
@@ -2797,13 +2820,6 @@
   //// END GPS STUFF
 
 
-#ifdef HAS_RTC
-  #if (defined(HAS_DS1307) || defined(HAS_PCF8523))
-    // Need i2c
-  #else
-    #undef HAS_RTC
-  #endif
-#endif
 
   //// BATTERY STUFF
   #ifdef HAS_BATTERY

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -4,6 +4,9 @@
 
   #define configs_h
 
+  #include "soc/soc_caps.h"
+  #include "esp_arduino_version.h"
+
   #define POLISH_POTATO
 
   //#define DEVELOPER

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -2796,6 +2796,15 @@
   #endif
   //// END GPS STUFF
 
+
+#ifdef HAS_RTC
+  #if (defined(HAS_DS1307) || defined(HAS_PCF8523))
+    // Need i2c
+  #else
+    #undef HAS_RTC
+  #endif
+#endif
+
   //// BATTERY STUFF
   #ifdef HAS_BATTERY
 

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -144,8 +144,8 @@
     #define HAS_SD
     #define USE_SD
     #define HAS_TEMP_SENSOR
-    #define HAS_RTC
-      #define HAS_RTC8563
+    // #define HAS_RTC
+    //  #define HAS_RTC8563
     #define HAS_GPS
   #endif
 

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -225,6 +225,31 @@ uint32_t currentTime  = 0;
   SDInterface sd_obj = SDInterface(&sharedSPI, SD_CS);
 #endif
 
+//  Converts reason type to a C string.
+//  Type is located in /tools/sdk/esp32/include/esp_system/include/esp_system.h
+const char *resetReasonName() {
+  esp_reset_reason_t r = esp_reset_reason();
+  switch (r) {
+    case ESP_RST_UNKNOWN:   return "Unknown";
+    case ESP_RST_POWERON:   return "PowerOn";    //Power on or RST pin toggled
+    case ESP_RST_EXT:       return "ExtPin";     //External pin - not applicable for ESP32
+    case ESP_RST_SW:        return "Reboot";     //esp_restart()
+    case ESP_RST_PANIC:     return "Crash";      //Exception/panic
+    case ESP_RST_INT_WDT:   return "WDT_Int";    //Interrupt watchdog (software or hardware)
+    case ESP_RST_TASK_WDT:  return "WDT_Task";   //Task watchdog
+    case ESP_RST_WDT:       return "WDT_Other";  //Other watchdog
+    case ESP_RST_DEEPSLEEP: return "Sleep";      //Reset after exiting deep sleep mode
+    case ESP_RST_BROWNOUT:  return "BrownOut";   //Brownout reset (software or hardware)
+    case ESP_RST_SDIO:      return "SDIO";       //Reset over SDIO
+    default:                return "";
+  }
+}
+
+void print_reset_reason() {
+  Serial.print(F("Last reset reason: "));
+  Serial.println(resetReasonName());
+}
+
 bool system_time_set = false;
 
 bool set_system_time(struct tm *timeInfo) {
@@ -387,7 +412,7 @@ void setup()
 
   settings_obj.begin();
 
-  const char* type = settings_obj.getSettingType("ChanHop");
+  const char* type = settings_obj.getSettingType("Timestamp PCAP files");
 
   if (type == nullptr || type[0] == '\0') {
     Serial.println(F("Current settings format not supported. Installing new default settings..."));

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -79,6 +79,11 @@ CommandLine cli_obj;
   GpsInterface gps_obj;
 #endif
 
+#ifdef HAS_RTC
+  #include "RTC.h"
+  RTC rtc_obj;
+#endif
+
 #ifdef HAS_BATTERY
   BatteryInterface battery_obj;
 #endif
@@ -220,6 +225,41 @@ uint32_t currentTime  = 0;
   SDInterface sd_obj = SDInterface(&sharedSPI, SD_CS);
 #endif
 
+bool system_time_set = false;
+
+bool set_system_time(struct tm *timeInfo) {
+    // struct tm tmp = timeInfo;
+    time_t t = mktime(timeInfo);
+    if (t == (time_t)-1) {
+        log_w("set_system_time: mktime failed");
+        return false;
+    }
+    struct timeval now = { .tv_sec = t, .tv_usec = 0 };
+    if (settimeofday(&now, NULL) != 0) {
+        log_d("settimeofday failed");
+        return false;
+    }
+    system_time_set = true;
+    log_d("system time updated");
+
+    #ifdef HAS_RTC
+      log_d("set_system_time: calling rtc_obj.adjust_rtc");
+      rtc_obj.adjust_rtc(t);
+    #endif
+
+    return true;
+}
+
+bool set_system_time(const String& time_str) {
+    struct tm tm_info = {0};
+    // log_d("set_system_time: '%s'", time_str.c_str());
+    if (strptime(time_str.c_str(), "%F %T", &tm_info) != NULL) {
+        return set_system_time(&tm_info);
+    }
+    log_d("set_system_time: invalid time_str '%s'", time_str.c_str());
+    return false;
+}
+
 void setup()
 {
   randomSeed(esp_random());
@@ -282,6 +322,14 @@ void setup()
 
   //while(!Serial)
   //  delay(10);
+
+  struct tm timeinfo;
+  if (getLocalTime(&timeinfo)) {
+    Serial.print("RTC::setup: ");
+    Serial.println(&timeinfo, "%F %T");
+  } else {
+    log_w("getLocalTime Fail");
+  }
 
   Serial.println("ESP-IDF version is: " + String(esp_get_idf_version()));
 
@@ -358,6 +406,12 @@ void setup()
   #endif
 
   wifi_scan_obj.RunSetup();
+
+  #ifdef HAS_RTC
+    rtc_obj.RunSetup();
+  #else
+    Serial.println(F("RTC NOT Installed"));
+  #endif
 
   #ifdef HAS_SCREEN
     display_obj.tft.setTextColor(TFT_GREEN, TFT_BLACK);

--- a/esp32_marauder/settings.cpp
+++ b/esp32_marauder/settings.cpp
@@ -22,6 +22,8 @@ void Settings::_buildCache() {
       _cache.ForceProbe = json["Settings"][i]["value"].as<bool>();
     else if (strcmp(name, "SavePCAP") == 0)
       _cache.SavePCAP = json["Settings"][i]["value"].as<bool>();
+    else if (strcmp(name, "Timestamp PCAP files") == 0)
+      _cache.TimeStPCAP = json["Settings"][i]["value"].as<bool>();
     else if (strcmp(name, "EnableLED") == 0)
       _cache.EnableLED = json["Settings"][i]["value"].as<bool>();
     else if (strcmp(name, "EPDeauth") == 0)
@@ -145,6 +147,8 @@ template <> bool Settings::loadSetting<bool>(const char* key) {
     return _cache.ForceProbe;
   if (strcmp(key, "SavePCAP") == 0)
     return _cache.SavePCAP;
+  if (strcmp(key, "Timestamp PCAP files") == 0)
+    return _cache.TimeStPCAP;
   if (strcmp(key, "EnableLED") == 0)
     return _cache.EnableLED;
   if (strcmp(key, "EPDeauth") == 0)
@@ -185,6 +189,9 @@ template <> uint8_t Settings::loadSetting<uint8_t>(const char* key) {
 
   if (strcmp(key, "SavePCAP") == 0)
     return (uint8_t)_cache.SavePCAP;
+
+  if (strcmp(key, "Timestamp PCAP files") == 0)
+    return (uint8_t)_cache.TimeStPCAP;
 
   if (strcmp(key, "EnableLED") == 0)
     return (uint8_t)_cache.EnableLED;
@@ -250,6 +257,8 @@ template <> bool Settings::saveSetting<bool>(const char* key, bool value) {
         _cache.ForceProbe = value;
       else if (strcmp(key, "SavePCAP") == 0)
         _cache.SavePCAP = value;
+      else if (strcmp(key, "Timestamp PCAP files") == 0)
+        _cache.TimeStPCAP = value;
       else if (strcmp(key, "EnableLED") == 0)
         _cache.EnableLED = value;
       else if (strcmp(key, "EPDeauth") == 0)
@@ -421,35 +430,41 @@ bool Settings::createDefaultSettings(fs::FS &fs, bool spec, uint8_t index, const
     jsonBuffer["Settings"][2]["range"]["min"] = false;
     jsonBuffer["Settings"][2]["range"]["max"] = true;
 
-    jsonBuffer["Settings"][3]["name"] = "EnableLED";
+    jsonBuffer["Settings"][3]["name"] = "Timestamp PCAP files";
     jsonBuffer["Settings"][3]["type"] = "bool";
     jsonBuffer["Settings"][3]["value"] = true;
     jsonBuffer["Settings"][3]["range"]["min"] = false;
     jsonBuffer["Settings"][3]["range"]["max"] = true;
 
-    jsonBuffer["Settings"][4]["name"] = "EPDeauth";
+    jsonBuffer["Settings"][4]["name"] = "EnableLED";
     jsonBuffer["Settings"][4]["type"] = "bool";
-    jsonBuffer["Settings"][4]["value"] = false;
+    jsonBuffer["Settings"][4]["value"] = true;
     jsonBuffer["Settings"][4]["range"]["min"] = false;
     jsonBuffer["Settings"][4]["range"]["max"] = true;
 
-    jsonBuffer["Settings"][5]["name"] = "ChanHop";
+    jsonBuffer["Settings"][5]["name"] = "EPDeauth";
     jsonBuffer["Settings"][5]["type"] = "bool";
     jsonBuffer["Settings"][5]["value"] = false;
     jsonBuffer["Settings"][5]["range"]["min"] = false;
     jsonBuffer["Settings"][5]["range"]["max"] = true;
 
-    jsonBuffer["Settings"][6]["name"] = "ClientSSID";
-    jsonBuffer["Settings"][6]["type"] = "String";
-    jsonBuffer["Settings"][6]["value"] = "";
-    jsonBuffer["Settings"][6]["range"]["min"] = "";
-    jsonBuffer["Settings"][6]["range"]["max"] = "";
+    jsonBuffer["Settings"][6]["name"] = "ChanHop";
+    jsonBuffer["Settings"][6]["type"] = "bool";
+    jsonBuffer["Settings"][6]["value"] = false;
+    jsonBuffer["Settings"][6]["range"]["min"] = false;
+    jsonBuffer["Settings"][6]["range"]["max"] = true;
 
-    jsonBuffer["Settings"][7]["name"] = "ClientPW";
+    jsonBuffer["Settings"][7]["name"] = "ClientSSID";
     jsonBuffer["Settings"][7]["type"] = "String";
     jsonBuffer["Settings"][7]["value"] = "";
     jsonBuffer["Settings"][7]["range"]["min"] = "";
     jsonBuffer["Settings"][7]["range"]["max"] = "";
+
+    jsonBuffer["Settings"][8]["name"] = "ClientPW";
+    jsonBuffer["Settings"][8]["type"] = "String";
+    jsonBuffer["Settings"][8]["value"] = "";
+    jsonBuffer["Settings"][8]["range"]["min"] = "";
+    jsonBuffer["Settings"][8]["range"]["max"] = "";
 
     serializeJson(jsonBuffer, settingsFile);
     serializeJson(jsonBuffer, settings_string);

--- a/esp32_marauder/settings.h
+++ b/esp32_marauder/settings.h
@@ -30,6 +30,7 @@ class Settings {
       bool  ForcePMKID  = false;
       bool  ForceProbe  = false;
       bool  SavePCAP    = true;
+      bool  TimeStPCAP  = true;
       bool  EnableLED   = true;
       bool  EPDeauth    = false;
       bool  ChanHop     = false;


### PR DESCRIPTION
Time is displayed on the screen if system time is set.

Add commands `date`, `setdate ` and `ntp_sync`  
`setdate ` will update system time and RTC (if detected) 

added `Sync RTC with WiFi` to Wifi->General Menu 

add support for RTC chips PCF8523 and DS1307
(uses [adafruit's RTCliib](https://github.com:adafruit/RTClib) library)

pcap filenames are now timestamp (if system time/date is. set/synced)

system clock and RTC clock can be synced via command line, NTP or GPS (GPS untested)
No timezone support, GMT is assumed ...

Time is displayed in upper right corner, if battery is detected time is displayed below battery.
(RTC is **not** necessary for time display)

<img height="150" alt="s3_clock" src="https://github.com/user-attachments/assets/4e716d06-4d52-445c-9ac5-eed326b70de7" />
<img height="150" alt="JC_clock" src="https://github.com/user-attachments/assets/4a021043-4fa3-4208-b38c-8e363b6ce732" />
<img height="150" alt="feather_clock" src="https://github.com/user-attachments/assets/fc75209a-92a5-42c6-a351-b10af5cf097a" />

