### PR TITLE
Enable direct upload to WDGWars and WiGLE

### DIFF
--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -2616,12 +2616,10 @@ void MenuFunctions::RunSetup()
         display_obj.tft.println("WiFi Credentials Empty.");
         display_obj.tft.println("Returning...");
         display_obj.tft.setTextWrap(false);
-
-        delay(2000);
-
-        this->changeMenu(&uploadLogsMenu, true);
       }
       else {
+        display_obj.clearScreen();
+        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2);
         if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
@@ -2630,10 +2628,6 @@ void MenuFunctions::RunSetup()
           display_obj.tft.println("Could not connect to WiFi.");
           display_obj.tft.println("Returning...");
           display_obj.tft.setTextWrap(false);
-
-          delay(2000);
-
-          this->changeMenu(&uploadLogsMenu, true);
         }
         else {
           delay(1000);
@@ -2642,13 +2636,16 @@ void MenuFunctions::RunSetup()
               Serial.println("Uploading " + sd_obj.sd_files->get(i) + "...");
               if (wifi_scan_obj.uploadFile("/" + sd_obj.sd_files->get(i), true, WIGLE_UPLOAD)) {
                 display_obj.clearScreen();
-                display_obj.tft.drawCentreString("WiGLE OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+                display_obj.showCenterText("WiGLE OK", TFT_HEIGHT / 2);
               } else {
                 display_obj.clearScreen();
-                display_obj.tft.drawCentreString("WiGLE failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+                display_obj.showCenterText("WiGLE failed", TFT_HEIGHT / 2);
               }
             }
           }
+          WiFi.disconnect(true);
+          delay(100);
+          wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
         }
       }
 
@@ -2668,12 +2665,10 @@ void MenuFunctions::RunSetup()
         display_obj.tft.println("WiFi Credentials Empty.");
         display_obj.tft.println("Returning...");
         display_obj.tft.setTextWrap(false);
-
-        delay(2000);
-
-        this->changeMenu(&uploadLogsMenu, true);
       }
       else {
+        display_obj.clearScreen();
+        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2);
         if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
@@ -2682,10 +2677,6 @@ void MenuFunctions::RunSetup()
           display_obj.tft.println("Could not connect to WiFi.");
           display_obj.tft.println("Returning...");
           display_obj.tft.setTextWrap(false);
-
-          delay(2000);
-
-          this->changeMenu(&uploadLogsMenu, true);
         }
         else {
           delay(1000);
@@ -2694,13 +2685,16 @@ void MenuFunctions::RunSetup()
               Serial.println("Uploading " + sd_obj.sd_files->get(i) + "...");
               if (wifi_scan_obj.uploadFile("/" + sd_obj.sd_files->get(i), true, WDG_UPLOAD)) {
                 display_obj.clearScreen();
-                display_obj.tft.drawCentreString("WDG OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+                display_obj.showCenterText("WDG OK", TFT_HEIGHT / 2);
               } else {
                 display_obj.clearScreen();
-                display_obj.tft.drawCentreString("WDG failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+                display_obj.showCenterText("WDG failed", TFT_HEIGHT / 2);
               }
             }
           }
+          WiFi.disconnect(true);
+          delay(100);
+          wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
         }
       }
 
@@ -2720,12 +2714,10 @@ void MenuFunctions::RunSetup()
         display_obj.tft.println("WiFi Credentials Empty.");
         display_obj.tft.println("Returning...");
         display_obj.tft.setTextWrap(false);
-
-        delay(2000);
-
-        this->changeMenu(&uploadLogsMenu, true);
       }
       else {
+        display_obj.clearScreen();
+        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2);
         if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
@@ -2734,10 +2726,6 @@ void MenuFunctions::RunSetup()
           display_obj.tft.println("Could not connect to WiFi.");
           display_obj.tft.println("Returning...");
           display_obj.tft.setTextWrap(false);
-
-          delay(2000);
-
-          this->changeMenu(&uploadLogsMenu, true);
         }
         else {
           delay(1000);
@@ -2746,13 +2734,16 @@ void MenuFunctions::RunSetup()
               Serial.println("Uploading " + sd_obj.sd_files->get(i) + "...");
               if (wifi_scan_obj.uploadFile("/" + sd_obj.sd_files->get(i), true, BOTH_UPLOAD)) {
                 display_obj.clearScreen();
-                display_obj.tft.drawCentreString("Upload OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+                display_obj.showCenterText("Upload OK", TFT_HEIGHT / 2);
               } else {
                 display_obj.clearScreen();
-                display_obj.tft.drawCentreString("Upload failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+                display_obj.showCenterText("Upload failed", TFT_HEIGHT / 2);
               }
             }
           }
+          WiFi.disconnect(true);
+          delay(100);
+          wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
         }
       }
 
@@ -2801,20 +2792,19 @@ void MenuFunctions::RunSetup()
       String ssid = settings_obj.loadSetting<String>("ClientSSID");
       String pw = settings_obj.loadSetting<String>("ClientPW");
 
+      display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+
       if ((ssid == "") && (pw == "")) {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(true);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
-        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
         display_obj.tft.println("WiFi Credentials Empty.");
         display_obj.tft.println("Returning...");
         display_obj.tft.setTextWrap(false);
-
-        delay(2000);
-
-        this->changeMenu(&uploadLogsMenu, true);
       }
       else {
+        display_obj.clearScreen();
+        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2, true);
         if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
@@ -2823,21 +2813,21 @@ void MenuFunctions::RunSetup()
           display_obj.tft.println("Could not connect to WiFi.");
           display_obj.tft.println("Returning...");
           display_obj.tft.setTextWrap(false);
-
-          delay(2000);
-
-          this->changeMenu(&uploadLogsMenu, true);
         }
         else {
           delay(1000);
           Serial.println("Uploading " + sd_obj.selected_file_name + "...");
           if (wifi_scan_obj.uploadFile("/" + sd_obj.selected_file_name, true, WIGLE_UPLOAD)) {
             display_obj.clearScreen();
-            display_obj.tft.drawCentreString("WiGLE OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+            display_obj.showCenterText("WiGLE OK", TFT_HEIGHT / 2, true);
           } else {
             display_obj.clearScreen();
-            display_obj.tft.drawCentreString("WiGLE failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+            display_obj.showCenterText("WiGLE failed", TFT_HEIGHT / 2, true);
           }
+
+          WiFi.disconnect(true);
+          delay(100);
+          wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
         }
       }
 
@@ -2849,43 +2839,41 @@ void MenuFunctions::RunSetup()
       String ssid = settings_obj.loadSetting<String>("ClientSSID");
       String pw = settings_obj.loadSetting<String>("ClientPW");
 
+      display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+
       if ((ssid == "") && (pw == "")) {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(true);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
-        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
         display_obj.tft.println("WiFi Credentials Empty.");
         display_obj.tft.println("Returning...");
         display_obj.tft.setTextWrap(false);
-
-        delay(2000);
-
-        this->changeMenu(&uploadLogsMenu, true);
       }
       else {
+        display_obj.clearScreen();
+        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2, true);
         if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
           display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
-          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
           display_obj.tft.println("Could not connect to WiFi.");
           display_obj.tft.println("Returning...");
           display_obj.tft.setTextWrap(false);
-
-          delay(2000);
-
-          this->changeMenu(&uploadLogsMenu, true);
         }
         else {
           delay(1000);
           Serial.println("Uploading " + sd_obj.selected_file_name + "...");
           if (wifi_scan_obj.uploadFile("/" + sd_obj.selected_file_name, true, WDG_UPLOAD)) {
             display_obj.clearScreen();
-            display_obj.tft.drawCentreString("WDG OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+            display_obj.showCenterText("WDG OK", TFT_HEIGHT / 2, true);
           } else {
             display_obj.clearScreen();
-            display_obj.tft.drawCentreString("WDG failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+            display_obj.showCenterText("WDG failed", TFT_HEIGHT / 2, true);
           }
+
+          WiFi.disconnect(true);
+        delay(100);
+        wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
         }
       }
 
@@ -2897,43 +2885,41 @@ void MenuFunctions::RunSetup()
       String ssid = settings_obj.loadSetting<String>("ClientSSID");
       String pw = settings_obj.loadSetting<String>("ClientPW");
 
+      display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+
       if ((ssid == "") && (pw == "")) {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(true);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
-        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
         display_obj.tft.println("WiFi Credentials Empty.");
         display_obj.tft.println("Returning...");
         display_obj.tft.setTextWrap(false);
-
-        delay(2000);
-
-        this->changeMenu(&uploadLogsMenu, true);
       }
       else {
+        display_obj.clearScreen();
+        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2, true);
         if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
           display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
-          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
           display_obj.tft.println("Could not connect to WiFi.");
           display_obj.tft.println("Returning...");
           display_obj.tft.setTextWrap(false);
-
-          delay(2000);
-
-          this->changeMenu(&uploadLogsMenu, true);
         }
         else {
           delay(1000);
           Serial.println("Uploading " + sd_obj.selected_file_name + "...");
           if (wifi_scan_obj.uploadFile("/" + sd_obj.selected_file_name, true, BOTH_UPLOAD)) {
             display_obj.clearScreen();
-            display_obj.tft.drawCentreString("Upload OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+            display_obj.showCenterText("Upload OK", TFT_HEIGHT / 2, true);
           } else {
             display_obj.clearScreen();
-            display_obj.tft.drawCentreString("Upload failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+            display_obj.showCenterText("Upload failed", TFT_HEIGHT / 2, true);
           }
+
+          WiFi.disconnect(true);
+          delay(100);
+          wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
         }
       }
 

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1494,6 +1494,49 @@ bool MenuFunctions::isKeyPressed(char c)
 }
 #endif
 
+#ifdef HAS_DIRECT_UPLOAD
+  void MenuFunctions::buildUploadFileMenu() {
+    if (sd_obj.supported) {
+      this->setupSDFileList();
+
+      uploadLogsMenu.list->clear();
+      delete uploadLogsMenu.list;
+      uploadLogsMenu.list = new LinkedList<MenuNode>();
+      uploadLogsMenu.name = "Logs";
+
+      uploadLogsMenu.parentMenu = &wifiGeneralMenu;
+
+      this->addNodes(&uploadLogsMenu, "Back", TFTLIGHTGREY, 0, [this]() {
+        this->changeMenu(uploadLogsMenu.parentMenu, true);
+      });
+
+      this->addNodes(&uploadLogsMenu, "Delete Wardrive Logs", TFTORANGE, 0, [this]() {
+        this->changeMenu(&deleteAllMenu, true);
+      });
+
+      this->addNodes(&uploadLogsMenu, "Upload All", TFTGREEN, 0, [this]() {
+        this->changeMenu(&uploadAllMenu, true);
+        
+      });
+
+      for (int i = 0; i < sd_obj.sd_files->size(); i++) {
+        File current_file = sd_obj.getFile("/" + sd_obj.sd_files->get(i));
+        if (sd_obj.sd_files->get(i).startsWith("wardrive_") || sd_obj.sd_files->get(i).startsWith("wigle-")) {
+          this->addNodes(&uploadLogsMenu, sd_obj.sd_files->get(i).c_str(), TFTCYAN, 0, [this, i]() {
+            sd_obj.selected_file_name = sd_obj.sd_files->get(i);
+            Serial.println(sd_obj.sd_files->get(i) + " selected");
+            this->changeMenu(&actionMenu, true);
+          });
+        }
+      }
+
+      Serial.println("Built SD file menu with " + (String)sd_obj.sd_files->size() + " files");
+    } else {
+      Serial.println("SD Card not detected. Skipping menu creation...");
+    }
+  }
+#endif
+
 // Function to build the menus
 void MenuFunctions::RunSetup()
 {
@@ -1567,6 +1610,13 @@ void MenuFunctions::RunSetup()
   clearAPsMenu.list = new LinkedList<MenuNode>();
   saveFileMenu.list = new LinkedList<MenuNode>();
 
+  #ifdef HAS_DIRECT_UPLOAD
+    uploadLogsMenu.list = new LinkedList<MenuNode>();
+    uploadAllMenu.list = new LinkedList<MenuNode>();
+    deleteAllMenu.list = new LinkedList<MenuNode>();
+    actionMenu.list = new LinkedList<MenuNode>();
+  #endif
+
   saveSSIDsMenu.list = new LinkedList<MenuNode>();
   loadSSIDsMenu.list = new LinkedList<MenuNode>();
   saveAPsMenu.list = new LinkedList<MenuNode>();
@@ -1616,6 +1666,14 @@ void MenuFunctions::RunSetup()
   setMacMenu.name = "Set MACs";
   genAPMacMenu.name = "Generate AP MAC";
   wifiStationMenu.name = "Select Stations";
+
+  #ifdef HAS_DIRECT_UPLOAD
+    uploadLogsMenu.name = "Upload Logs";
+    uploadAllMenu.name = "Upload All?";
+    deleteAllMenu.name = "Delete All?";
+    actionMenu.name = "Destination";
+  #endif
+
   #ifdef HAS_GPS
     gpsMenu.name = "GPS"; 
     gpsInfoMenu.name = "GPS Data";
@@ -2528,6 +2586,362 @@ void MenuFunctions::RunSetup()
     wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
     this->changeMenu(current_menu, true);
   });
+  
+  #ifdef HAS_DIRECT_UPLOAD
+    this->addNodes(&wifiGeneralMenu, "Upload Wardrive Logs", TFTGREEN, 0, [this]() {
+      display_obj.clearScreen();
+      display_obj.tft.setTextWrap(false);
+      display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+      display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+      display_obj.tft.println("Loading...");
+
+      this->buildUploadFileMenu();
+
+      this->changeMenu(&uploadLogsMenu, true);
+    });
+
+    uploadAllMenu.parentMenu = &uploadLogsMenu;
+    this->addNodes(&uploadAllMenu, text09, TFTLIGHTGREY, 0, [this]() {
+      this->changeMenu(uploadAllMenu.parentMenu, true);
+    });
+    this->addNodes(&uploadAllMenu, "WiGLE", TFTLIGHTGREY, 0, [this]() {
+      String ssid = settings_obj.loadSetting<String>("ClientSSID");
+      String pw = settings_obj.loadSetting<String>("ClientPW");
+
+      if ((ssid == "") && (pw == "")) {
+        display_obj.clearScreen();
+        display_obj.tft.setTextWrap(true);
+        display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+        display_obj.tft.println("WiFi Credentials Empty.");
+        display_obj.tft.println("Returning...");
+        display_obj.tft.setTextWrap(false);
+
+        delay(2000);
+
+        this->changeMenu(&uploadLogsMenu, true);
+      }
+      else {
+        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+          display_obj.clearScreen();
+          display_obj.tft.setTextWrap(true);
+          display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+          display_obj.tft.println("Could not connect to WiFi.");
+          display_obj.tft.println("Returning...");
+          display_obj.tft.setTextWrap(false);
+
+          delay(2000);
+
+          this->changeMenu(&uploadLogsMenu, true);
+        }
+        else {
+          delay(1000);
+          for (int i = 0; i < sd_obj.sd_files->size(); i++) {
+            if (sd_obj.sd_files->get(i).startsWith("wardrive_") || sd_obj.sd_files->get(i).startsWith("wigle-")) {
+              Serial.println("Uploading " + sd_obj.sd_files->get(i) + "...");
+              if (wifi_scan_obj.uploadFile("/" + sd_obj.sd_files->get(i), true, WIGLE_UPLOAD)) {
+                display_obj.clearScreen();
+                display_obj.tft.drawCentreString("WiGLE OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+              } else {
+                display_obj.clearScreen();
+                display_obj.tft.drawCentreString("WiGLE failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+              }
+            }
+          }
+        }
+      }
+
+      delay(2000);
+
+      this->changeMenu(uploadAllMenu.parentMenu, true);
+    });
+    this->addNodes(&uploadAllMenu, "WDGWars", TFTLIGHTGREY, 0, [this]() {
+      String ssid = settings_obj.loadSetting<String>("ClientSSID");
+      String pw = settings_obj.loadSetting<String>("ClientPW");
+
+      if ((ssid == "") && (pw == "")) {
+        display_obj.clearScreen();
+        display_obj.tft.setTextWrap(true);
+        display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+        display_obj.tft.println("WiFi Credentials Empty.");
+        display_obj.tft.println("Returning...");
+        display_obj.tft.setTextWrap(false);
+
+        delay(2000);
+
+        this->changeMenu(&uploadLogsMenu, true);
+      }
+      else {
+        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+          display_obj.clearScreen();
+          display_obj.tft.setTextWrap(true);
+          display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+          display_obj.tft.println("Could not connect to WiFi.");
+          display_obj.tft.println("Returning...");
+          display_obj.tft.setTextWrap(false);
+
+          delay(2000);
+
+          this->changeMenu(&uploadLogsMenu, true);
+        }
+        else {
+          delay(1000);
+          for (int i = 0; i < sd_obj.sd_files->size(); i++) {
+            if (sd_obj.sd_files->get(i).startsWith("wardrive_") || sd_obj.sd_files->get(i).startsWith("wigle-")) {
+              Serial.println("Uploading " + sd_obj.sd_files->get(i) + "...");
+              if (wifi_scan_obj.uploadFile("/" + sd_obj.sd_files->get(i), true, WDG_UPLOAD)) {
+                display_obj.clearScreen();
+                display_obj.tft.drawCentreString("WDG OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+              } else {
+                display_obj.clearScreen();
+                display_obj.tft.drawCentreString("WDG failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+              }
+            }
+          }
+        }
+      }
+
+      delay(2000);
+
+      this->changeMenu(uploadAllMenu.parentMenu, true);
+    });
+    this->addNodes(&uploadAllMenu, "Both", TFTLIGHTGREY, 0, [this]() {
+      String ssid = settings_obj.loadSetting<String>("ClientSSID");
+      String pw = settings_obj.loadSetting<String>("ClientPW");
+
+      if ((ssid == "") && (pw == "")) {
+        display_obj.clearScreen();
+        display_obj.tft.setTextWrap(true);
+        display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+        display_obj.tft.println("WiFi Credentials Empty.");
+        display_obj.tft.println("Returning...");
+        display_obj.tft.setTextWrap(false);
+
+        delay(2000);
+
+        this->changeMenu(&uploadLogsMenu, true);
+      }
+      else {
+        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+          display_obj.clearScreen();
+          display_obj.tft.setTextWrap(true);
+          display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+          display_obj.tft.println("Could not connect to WiFi.");
+          display_obj.tft.println("Returning...");
+          display_obj.tft.setTextWrap(false);
+
+          delay(2000);
+
+          this->changeMenu(&uploadLogsMenu, true);
+        }
+        else {
+          delay(1000);
+          for (int i = 0; i < sd_obj.sd_files->size(); i++) {
+            if (sd_obj.sd_files->get(i).startsWith("wardrive_") || sd_obj.sd_files->get(i).startsWith("wigle-")) {
+              Serial.println("Uploading " + sd_obj.sd_files->get(i) + "...");
+              if (wifi_scan_obj.uploadFile("/" + sd_obj.sd_files->get(i), true, BOTH_UPLOAD)) {
+                display_obj.clearScreen();
+                display_obj.tft.drawCentreString("Upload OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+              } else {
+                display_obj.clearScreen();
+                display_obj.tft.drawCentreString("Upload failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+              }
+            }
+          }
+        }
+      }
+
+      delay(2000);
+
+      this->changeMenu(uploadAllMenu.parentMenu, true);
+    });
+
+    deleteAllMenu.parentMenu = &uploadLogsMenu;
+    this->addNodes(&deleteAllMenu, "No", TFTLIGHTGREY, 0, [this]() {
+      this->changeMenu(deleteAllMenu.parentMenu, true);
+    });
+    this->addNodes(&deleteAllMenu, "Yes", TFTRED, 0, [this]() {
+      display_obj.clearScreen();
+
+      display_obj.tft.drawCentreString("Deleting Logs...",TFT_WIDTH / 2, TFT_HEIGHT / 2, 2);
+
+      for (int i = 0; i < sd_obj.sd_files->size(); i++) {
+        if (sd_obj.sd_files->get(i).startsWith("wardrive_") || sd_obj.sd_files->get(i).startsWith("wigle-")) {
+          if (sd_obj.removeFile("/" + sd_obj.sd_files->get(i))) {
+            Serial.println("Removed file: " + sd_obj.sd_files->get(i));
+            sd_obj.removeFile("/" + sd_obj.sd_files->get(i) + ".wdg");
+            sd_obj.removeFile("/" + sd_obj.sd_files->get(i) + ".wigle");
+          }
+          else {
+            Serial.println("Could not remove file: " + sd_obj.sd_files->get(i));
+          }
+        }
+      }
+      display_obj.clearScreen();
+
+      display_obj.tft.drawCentreString("Logs removed",TFT_WIDTH / 2, TFT_HEIGHT / 2, 2);
+
+      delay(2000);
+
+      this->buildUploadFileMenu();
+
+      this->changeMenu(&uploadLogsMenu, true);
+    });
+
+    actionMenu.parentMenu = &uploadLogsMenu;
+    this->addNodes(&actionMenu, text09, TFTLIGHTGREY, 0, [this]() {
+      this->changeMenu(actionMenu.parentMenu, true);
+    });
+    this->addNodes(&actionMenu, "WiGLE", TFTLIGHTGREY, 0, [this]() {
+      String ssid = settings_obj.loadSetting<String>("ClientSSID");
+      String pw = settings_obj.loadSetting<String>("ClientPW");
+
+      if ((ssid == "") && (pw == "")) {
+        display_obj.clearScreen();
+        display_obj.tft.setTextWrap(true);
+        display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+        display_obj.tft.println("WiFi Credentials Empty.");
+        display_obj.tft.println("Returning...");
+        display_obj.tft.setTextWrap(false);
+
+        delay(2000);
+
+        this->changeMenu(&uploadLogsMenu, true);
+      }
+      else {
+        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+          display_obj.clearScreen();
+          display_obj.tft.setTextWrap(true);
+          display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+          display_obj.tft.println("Could not connect to WiFi.");
+          display_obj.tft.println("Returning...");
+          display_obj.tft.setTextWrap(false);
+
+          delay(2000);
+
+          this->changeMenu(&uploadLogsMenu, true);
+        }
+        else {
+          delay(1000);
+          Serial.println("Uploading " + sd_obj.selected_file_name + "...");
+          if (wifi_scan_obj.uploadFile("/" + sd_obj.selected_file_name, true, WIGLE_UPLOAD)) {
+            display_obj.clearScreen();
+            display_obj.tft.drawCentreString("WiGLE OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+          } else {
+            display_obj.clearScreen();
+            display_obj.tft.drawCentreString("WiGLE failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+          }
+        }
+      }
+
+      delay(2000);
+
+      this->changeMenu(&actionMenu, true);
+    });
+    this->addNodes(&actionMenu, "WDGWars", TFTLIGHTGREY, 0, [this]() {
+      String ssid = settings_obj.loadSetting<String>("ClientSSID");
+      String pw = settings_obj.loadSetting<String>("ClientPW");
+
+      if ((ssid == "") && (pw == "")) {
+        display_obj.clearScreen();
+        display_obj.tft.setTextWrap(true);
+        display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+        display_obj.tft.println("WiFi Credentials Empty.");
+        display_obj.tft.println("Returning...");
+        display_obj.tft.setTextWrap(false);
+
+        delay(2000);
+
+        this->changeMenu(&uploadLogsMenu, true);
+      }
+      else {
+        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+          display_obj.clearScreen();
+          display_obj.tft.setTextWrap(true);
+          display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+          display_obj.tft.println("Could not connect to WiFi.");
+          display_obj.tft.println("Returning...");
+          display_obj.tft.setTextWrap(false);
+
+          delay(2000);
+
+          this->changeMenu(&uploadLogsMenu, true);
+        }
+        else {
+          delay(1000);
+          Serial.println("Uploading " + sd_obj.selected_file_name + "...");
+          if (wifi_scan_obj.uploadFile("/" + sd_obj.selected_file_name, true, WDG_UPLOAD)) {
+            display_obj.clearScreen();
+            display_obj.tft.drawCentreString("WDG OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+          } else {
+            display_obj.clearScreen();
+            display_obj.tft.drawCentreString("WDG failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+          }
+        }
+      }
+
+      delay(2000);
+
+      this->changeMenu(&actionMenu, true);
+    });
+    this->addNodes(&actionMenu, "Both", TFTLIGHTGREY, 0, [this]() {
+      String ssid = settings_obj.loadSetting<String>("ClientSSID");
+      String pw = settings_obj.loadSetting<String>("ClientPW");
+
+      if ((ssid == "") && (pw == "")) {
+        display_obj.clearScreen();
+        display_obj.tft.setTextWrap(true);
+        display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+        display_obj.tft.println("WiFi Credentials Empty.");
+        display_obj.tft.println("Returning...");
+        display_obj.tft.setTextWrap(false);
+
+        delay(2000);
+
+        this->changeMenu(&uploadLogsMenu, true);
+      }
+      else {
+        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+          display_obj.clearScreen();
+          display_obj.tft.setTextWrap(true);
+          display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+          display_obj.tft.println("Could not connect to WiFi.");
+          display_obj.tft.println("Returning...");
+          display_obj.tft.setTextWrap(false);
+
+          delay(2000);
+
+          this->changeMenu(&uploadLogsMenu, true);
+        }
+        else {
+          delay(1000);
+          Serial.println("Uploading " + sd_obj.selected_file_name + "...");
+          if (wifi_scan_obj.uploadFile("/" + sd_obj.selected_file_name, true, BOTH_UPLOAD)) {
+            display_obj.clearScreen();
+            display_obj.tft.drawCentreString("Upload OK", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+          } else {
+            display_obj.clearScreen();
+            display_obj.tft.drawCentreString("Upload failed", TFT_WIDTH / 2, TFT_WIDTH / 2, 2);
+          }
+        }
+      }
+
+      delay(2000);
+
+      this->changeMenu(&actionMenu, true);
+    });
+  #endif
 
 
   // Menu for generating and setting MAC addrs for AP and STA

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1522,11 +1522,13 @@ bool MenuFunctions::isKeyPressed(char c)
       for (int i = 0; i < sd_obj.sd_files->size(); i++) {
         File current_file = sd_obj.getFile("/" + sd_obj.sd_files->get(i));
         if (sd_obj.sd_files->get(i).startsWith("wardrive_") || sd_obj.sd_files->get(i).startsWith("wigle-")) {
-          this->addNodes(&uploadLogsMenu, sd_obj.sd_files->get(i).c_str(), TFTCYAN, 0, [this, i]() {
-            sd_obj.selected_file_name = sd_obj.sd_files->get(i);
-            Serial.println(sd_obj.sd_files->get(i) + " selected");
-            this->changeMenu(&actionMenu, true);
-          });
+          if (!sd_obj.sd_files->get(i).endsWith(".wdg") && !sd_obj.sd_files->get(i).endsWith(".wigle")) {
+            this->addNodes(&uploadLogsMenu, sd_obj.sd_files->get(i).c_str(), TFTCYAN, 0, [this, i]() {
+              sd_obj.selected_file_name = sd_obj.sd_files->get(i);
+              Serial.println(sd_obj.sd_files->get(i) + " selected");
+              this->changeMenu(&actionMenu, true);
+            });
+          }
         }
       }
 

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -198,10 +198,16 @@ class MenuFunctions
 
     Menu foxHuntMenu;
 
+    #ifdef HAS_DIRECT_UPLOAD
+      Menu deleteAllMenu;
+      Menu uploadAllMenu;
+    #endif
+
     //static void lv_tick_handler();
 
     // Menu icons
 
+    void buildUploadFileMenu();
     void setupSDFileList(bool update = false);
     void buildSDFileMenu(bool update = false);
     void displayMenuButtons();
@@ -263,6 +269,11 @@ class MenuFunctions
 
     Menu infoMenu;
     Menu apInfoMenu;
+
+    #ifdef HAS_DIRECT_UPLOAD
+      Menu uploadLogsMenu;
+      Menu actionMenu;
+    #endif
 
     //Ticker tick;
 

--- a/esp32_marauder/SDInterface.h
+++ b/esp32_marauder/SDInterface.h
@@ -56,6 +56,7 @@ class SDInterface {
     bool supported = false;
 
     String card_sz;
+    String selected_file_name = "";
   
     bool initSD();
 

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1648,10 +1648,13 @@ void WiFiScan::RunSetup() {
             break;
         }
 
-        settings_obj.saveSetting<bool>("wu", contents);
+        if (settings_obj.saveSetting<bool>("wu", contents)) {
+          sd_obj.removeFile("/wigle_api_name.txt");
+          Serial.println("Saved WiGLE API Name: " + contents);
+        } else {
+          Serial.println("Failed to save WiGLE API Name");
+        }
         api_settings_file.close();
-        sd_obj.removeFile("/wigle_api_name.txt");
-        Serial.println("Saved WiGLE API Name: " + contents);
       }
 
       if (SD.exists("/wigle_api_token.txt")) {
@@ -1669,10 +1672,14 @@ void WiFiScan::RunSetup() {
             break;
         }
 
-        settings_obj.saveSetting<bool>("wt", contents);
+        if (settings_obj.saveSetting<bool>("wt", contents)) {
+          sd_obj.removeFile("/wigle_api_token.txt");
+          Serial.println("Saved WiGLE API Token: " + contents);
+        } else {
+          Serial.println("Failed to save WiGLE API Token");
+        }
+
         api_settings_file.close();
-        sd_obj.removeFile("/wigle_api_token.txt");
-        Serial.println("Saved WiGLE API Token: " + contents);
       }
 
       if (SD.exists("/wdg_key.txt")) {
@@ -1690,10 +1697,13 @@ void WiFiScan::RunSetup() {
             break;
         }
 
-        settings_obj.saveSetting<bool>(WDG_KEY_NAME, contents);
+        if (settings_obj.saveSetting<bool>(WDG_KEY_NAME, contents)) {
+          sd_obj.removeFile("/wdg_key.txt");
+          Serial.println("Saved WDG API Token: " + contents);
+        } else {
+          Serial.println("Failed to save WDG API Token");
+        }
         api_settings_file.close();
-        sd_obj.removeFile("/wdg_key.txt");
-        Serial.println("Saved WDG API Token: " + contents);
       }
 
 

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10016,31 +10016,101 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
 }
 
 #ifdef HAS_DIRECT_UPLOAD
+  bool WiFiScan::sidecarExists(String filePath, String service) {
+    return SD.exists(filePath + "." + service);
+  }
+
+  void WiFiScan::writeSidecar(String filePath, String service) {
+    String sidecarPath = filePath + "." + service;
+    File f = SD.open(sidecarPath, FILE_WRITE);
+    if (f) {
+      f.println("uploaded=" + gps_obj.getDatetime());
+      f.close();
+      Serial.println("[UPLOAD] Sidecar written: " + sidecarPath);
+    } else {
+      Serial.println("[UPLOAD] Could not write sidecar: " + sidecarPath);
+    }
+  }
+
+  bool WiFiScan::uploadFile(String filePath, bool retry, uint8_t upload_type) {
+    display_obj.clearScreen();
+    display_obj.showCenterText(String("Uploading " + filePath).c_str(), TFT_HEIGHT / 2);
+    delay(1000);
+    
+    Serial.println("[UPLOAD] uploadFile: " + filePath +
+                (retry ? " (retry)" : ""));
+
+    bool wigle_already = !retry && this->sidecarExists(filePath, "wigle");
+    bool wdg_already   = !retry && this->sidecarExists(filePath, "wdg");
+
+    bool wigle_ok = wigle_already;
+    bool wdg_ok   = wdg_already;
+
+    if ((upload_type == WIGLE_UPLOAD) || (upload_type == BOTH_UPLOAD)) {
+      if (!wigle_already) {
+        Serial.println("[UPLOAD] Uploading to WiGLE: " + filePath);
+        wigle_ok = this->wigleUpload(filePath);
+        if (wigle_ok) {
+          this->writeSidecar(filePath, "wigle");
+          Serial.println("[UPLOAD] WiGLE upload succeeded");
+        } else {
+          Serial.println("[UPLOAD] WiGLE upload failed");
+        }
+      } else {
+        Serial.println("[UPLOAD] WiGLE already uploaded, skipping");
+      }
+    }
+
+    if ((upload_type == WDG_UPLOAD) || (upload_type == BOTH_UPLOAD)) {
+      if (!wdg_already) {
+        Serial.println("[UPLOAD] Uploading to WDG Wars: " + filePath);
+        wdg_ok = this->wdgwarsUpload(filePath);
+        if (wdg_ok) {
+          this->writeSidecar(filePath, "wdg");
+          Serial.println("[UPLOAD] WDG Wars upload succeeded");
+        } else {
+          Serial.println("[UPLOAD] WDG Wars upload failed");
+        }
+      } else {
+        Serial.println("[UPLOAD] WDG Wars already uploaded, skipping");
+      }
+    }
+
+    if (upload_type == WIGLE_UPLOAD)
+      return wigle_ok;
+    else if (upload_type == WDG_UPLOAD)
+      return wdg_ok;
+    else if (upload_type == BOTH_UPLOAD)
+      return wigle_ok && wdg_ok;
+    
+    return false;
+  }
+
   // Upload one log file to WDG Wars.
   // Mirrors backendUpload() but uses X-API-Key auth and wdgwars.pl endpoint.
   bool WiFiScan::wdgwarsUpload(String filePath) {
-    //display.clearScreen();
-    //display.drawCenteredText("WDG Upload...", true);
+    display_obj.clearScreen();
+    display_obj.showCenterText("WDG Upload...", TFT_HEIGHT / 2);
     delay(100);
 
     if (!SD.exists(filePath)) {
-      //display.drawCenteredText(filePath + " not found", true);
+      display_obj.showCenterText(String(filePath + " not found").c_str(), TFT_HEIGHT / 2);
       Serial.println("[WDG] File not found: " + filePath);
       return false;
     }
 
     String apiKey = settings_obj.loadSetting<String>(WDG_KEY_NAME);
     if (apiKey.isEmpty()) {
-      //display.clearScreen();
-      //display.drawCenteredText("No WDG API key", true);
+      display_obj.clearScreen();
+      display_obj.showCenterText("No WDG API key", TFT_HEIGHT / 2);
       Serial.println("[WDG] No WDG Wars API key configured");
       return false;
     }
 
     File fileToUpload = SD.open(filePath);
     if (!fileToUpload) {
-      //display.clearScreen();
-      //display.drawCenteredText("Could not open file", true);
+      display_obj.clearScreen();
+      display_obj.showCenterText("Could not open file", TFT_HEIGHT / 2);
       Serial.println("[WDG] Could not open: " + filePath);
       return false;
     }
@@ -10061,8 +10131,8 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     if (!client->connect("wdgwars.pl", 443)) {
       fileToUpload.close();
       client->stop();
-      //display.clearScreen();
-      //display.drawCenteredText("WDG connect fail", true);
+      display_obj.clearScreen();
+      display_obj.showCenterText("WDG connect fail", TFT_HEIGHT / 2);
       Serial.println("[WDG] Failed to connect to wdgwars.pl");
       return false;
     }
@@ -10092,10 +10162,10 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
       totalSent += n;
       client->write(buf, n);
       pct = (totalSent * 100) / fileToUpload.size();
-      //display.tft->drawRect(0, (TFT_HEIGHT / 3) * 2, TFT_WIDTH, TFT_HEIGHT - (TFT_HEIGHT / 3) * 2, ST77XX_BLACK);
-      //display.tft->setCursor(0, (TFT_HEIGHT / 3) * 2);
+      display_obj.tft.drawRect(0, (TFT_HEIGHT / 3) * 2, TFT_WIDTH, TFT_HEIGHT - (TFT_HEIGHT / 3) * 2, TFT_BLACK);
+      display_obj.tft.setCursor(0, (TFT_HEIGHT / 3) * 2);
       pctStr = String(pct) + "%";
-      //display.drawCenteredText(pctStr, false);
+      display_obj.showCenterText(pctStr.c_str(), TFT_HEIGHT / 2);
     }
 
     client->print(part2);
@@ -10124,8 +10194,8 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     bool ok = response.indexOf("202 Accepted") >= 0 ||
     response.indexOf("\"ok\":true") >= 0;
 
-    //display.clearScreen();
-    //display.drawCenteredText(ok ? "WDG OK" : "WDG Failed", true);
+    display_obj.clearScreen();
+    display_obj.showCenterText(ok ? "WDG OK" : "WDG Failed", TFT_HEIGHT / 2);
     delay(1000);
 
     return ok;
@@ -10133,24 +10203,22 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
 
   // Upload one log file to Wigle
   bool WiFiScan::wigleUpload(String filePath) {
-    //server.begin();
-
-    //display.clearScreen();
-    //display.drawCenteredText("Wigle Upload...", true);
+    display_obj.clearScreen();
+    display_obj.showCenterText("Wigle Upload...", TFT_HEIGHT / 2);
 
     delay(100);
 
     if (!SD.exists(filePath)) {
-      //display.clearScreen();
-      //display.drawCenteredText(filePath + " not found", true);
+      display_obj.clearScreen();
+      display_obj.showCenterText(String(filePath + " not found").c_str(), TFT_HEIGHT / 2);
       Serial.println("File does not exist: " + filePath);
       return false;
     }
 
     File fileToUpload = SD.open(filePath);
     if (!fileToUpload) {
-      //display.clearScreen();
-      //display.drawCenteredText("Could not open file", true);
+      display_obj.clearScreen();
+      display_obj.showCenterText("Could not open file", TFT_HEIGHT / 2);
       Serial.println("Could not open file: " + filePath);
       return false;
     }
@@ -10160,8 +10228,8 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     String token = settings_obj.loadSetting<String>("wt");
     if (username.isEmpty() || token.isEmpty()) {
       fileToUpload.close();
-      //display.clearScreen();
-      //display.drawCenteredText("No wigle creds", true);
+      display_obj.clearScreen();
+      display_obj.showCenterText("No wigle creds", TFT_HEIGHT / 2);
       Serial.println("Missing wigle credentials");
       return false;
     }
@@ -10202,8 +10270,8 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
       fileToUpload.close();
       //delete client;
       client->stop();
-      //display.clearScreen();
-      //display.drawCenteredText("Could not connect", true);
+      display_obj.clearScreen();
+      display_obj.showCenterText("Could not connect", TFT_HEIGHT / 2);
       Serial.println("Failed to connected to api.wigle.net");
       return false;
     }
@@ -10247,10 +10315,10 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
       Serial.print(totalBytesSent);
       Serial.println(" bytes...");
       percent_sent = (totalBytesSent * 100) / fileToUpload.size();
-      //display.tft->drawRect(0, (TFT_HEIGHT / 3) * 2, TFT_WIDTH, TFT_HEIGHT, ST77XX_BLACK);
-      //display.tft->setCursor(0, (TFT_HEIGHT / 3) * 2);
+      display_obj.tft.drawRect(0, (TFT_HEIGHT / 3) * 2, TFT_WIDTH, TFT_HEIGHT, TFT_BLACK);
+      display_obj.tft.setCursor(0, (TFT_HEIGHT / 3) * 2);
       display_percent = (String)percent_sent + "%";
-      //display.drawCenteredText(display_percent, false);
+      display_obj.showCenterText(display_percent.c_str(), TFT_HEIGHT / 2);
       client->write(buffer, bytesRead);
     }
 
@@ -10286,8 +10354,8 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
 
     bool ok = response.indexOf("200 OK") >= 0;
 
-    //display.clearScreen();
-    //display.drawCenteredText(ok ? "WIGLE OK" : "WIGLE Failed", true);
+    display_obj.clearScreen();
+    display_obj.showCenterText(ok ? "WIGLE OK" : "WIGLE Failed", TFT_HEIGHT / 2);
 
     return ok;
   }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1629,6 +1629,77 @@ void WiFiScan::RunSetup() {
 
   settings_obj.loadSetting<bool>("ChanHop");
 
+  File api_settings_file;
+
+  #ifdef HAS_SD
+    if (sd_obj.supported) {
+      if (SD.exists("/wigle_api_name.txt")) {
+        String contents = "";
+        api_settings_file = sd_obj.getFile("/wigle_api_name.txt");
+        while (api_settings_file.available()) {
+          contents+=(char)api_settings_file.read();
+        }
+
+        while (contents.length() > 0) {
+          char c = contents[contents.length() - 1];
+          if (c == '\n' || c == '\r')
+            contents.remove(contents.length() - 1);
+          else
+            break;
+        }
+
+        settings_obj.saveSetting<bool>("wu", contents);
+        api_settings_file.close();
+        sd_obj.removeFile("/wigle_api_name.txt");
+        Serial.println("Saved WiGLE API Name: " + contents);
+      }
+
+      if (SD.exists("/wigle_api_token.txt")) {
+        String contents = "";
+        api_settings_file = sd_obj.getFile("/wigle_api_token.txt");
+        while (api_settings_file.available()) {
+          contents+=(char)api_settings_file.read();
+        }
+
+        while (contents.length() > 0) {
+          char c = contents[contents.length() - 1];
+          if (c == '\n' || c == '\r')
+            contents.remove(contents.length() - 1);
+          else
+            break;
+        }
+
+        settings_obj.saveSetting<bool>("wt", contents);
+        api_settings_file.close();
+        sd_obj.removeFile("/wigle_api_token.txt");
+        Serial.println("Saved WiGLE API Token: " + contents);
+      }
+
+      if (SD.exists("/wdg_key.txt")) {
+        String contents = "";
+        api_settings_file = sd_obj.getFile("/wdg_key.txt");
+        while (api_settings_file.available()) {
+          contents+=(char)api_settings_file.read();
+        }
+
+        while (contents.length() > 0) {
+          char c = contents[contents.length() - 1];
+          if (c == '\n' || c == '\r')
+            contents.remove(contents.length() - 1);
+          else
+            break;
+        }
+
+        settings_obj.saveSetting<bool>(WDG_KEY_NAME, contents);
+        api_settings_file.close();
+        sd_obj.removeFile("/wdg_key.txt");
+        Serial.println("Saved WDG API Token: " + contents);
+      }
+
+
+    }
+  #endif
+
   #ifdef HAS_PSRAM
     mac_history = (struct mac_addr*) ps_malloc(mac_history_len * sizeof(struct mac_addr));
   #endif
@@ -1902,8 +1973,9 @@ bool WiFiScan::joinWiFi(String ssid, String password, bool gui) {
     }
   }
   this->connected_network = ssid;
-  this->setNetworkInfo();  
-  this->showNetworkInfo();
+  this->setNetworkInfo();
+  if (gui) 
+    this->showNetworkInfo();
 
   this->wifi_initialized = true;
   #ifndef HAS_TOUCH
@@ -10033,8 +10105,10 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
   }
 
   bool WiFiScan::uploadFile(String filePath, bool retry, uint8_t upload_type) {
+    #ifdef HAS_SCREEN
     display_obj.clearScreen();
-    display_obj.showCenterText(String("Uploading " + filePath).c_str(), TFT_HEIGHT / 2);
+    display_obj.showCenterText(String("Uploading " + filePath).c_str(), TFT_HEIGHT / 2, true);
+    #endif
     delay(1000);
     
     Serial.println("[UPLOAD] uploadFile: " + filePath +
@@ -10089,28 +10163,41 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
   // Upload one log file to WDG Wars.
   // Mirrors backendUpload() but uses X-API-Key auth and wdgwars.pl endpoint.
   bool WiFiScan::wdgwarsUpload(String filePath) {
+    bool gotAny = false;
+
+    #ifdef HAS_SCREEN
     display_obj.clearScreen();
-    display_obj.showCenterText("WDG Upload...", TFT_HEIGHT / 2);
+    display_obj.showCenterText("WDG Upload...", TFT_HEIGHT / 2, true);
+    #endif
     delay(100);
 
     if (!SD.exists(filePath)) {
-      display_obj.showCenterText(String(filePath + " not found").c_str(), TFT_HEIGHT / 2);
+      #ifdef HAS_SCREEN
+      display_obj.showCenterText(String(filePath + " not found").c_str(), TFT_HEIGHT / 2, true);
+      delay(2000);
+      #endif
       Serial.println("[WDG] File not found: " + filePath);
       return false;
     }
 
     String apiKey = settings_obj.loadSetting<String>(WDG_KEY_NAME);
     if (apiKey.isEmpty()) {
+      #ifdef HAS_SCREEN
       display_obj.clearScreen();
-      display_obj.showCenterText("No WDG API key", TFT_HEIGHT / 2);
+      display_obj.showCenterText("No WDG API key", TFT_HEIGHT / 2, true);
+      delay(2000);
+      #endif
       Serial.println("[WDG] No WDG Wars API key configured");
       return false;
     }
 
     File fileToUpload = SD.open(filePath);
     if (!fileToUpload) {
+      #ifdef HAS_SCREEN
       display_obj.clearScreen();
-      display_obj.showCenterText("Could not open file", TFT_HEIGHT / 2);
+      display_obj.showCenterText("Could not open file", TFT_HEIGHT / 2, true);
+      delay(2000);
+      #endif
       Serial.println("[WDG] Could not open: " + filePath);
       return false;
     }
@@ -10128,11 +10215,16 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     Serial.println("[WDG] Total length: " + String(totalLength));
 
     client->setInsecure();
+    client->setTimeout(5000);
+
     if (!client->connect("wdgwars.pl", 443)) {
       fileToUpload.close();
       client->stop();
+      #ifdef HAS_SCREEN
       display_obj.clearScreen();
-      display_obj.showCenterText("WDG connect fail", TFT_HEIGHT / 2);
+      display_obj.showCenterText("WDG connect fail", TFT_HEIGHT / 2, true);
+      delay(2000);
+      #endif
       Serial.println("[WDG] Failed to connect to wdgwars.pl");
       return false;
     }
@@ -10162,28 +10254,47 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
       totalSent += n;
       client->write(buf, n);
       pct = (totalSent * 100) / fileToUpload.size();
+      #ifdef HAS_SCREEN
       display_obj.tft.drawRect(0, (TFT_HEIGHT / 3) * 2, TFT_WIDTH, TFT_HEIGHT - (TFT_HEIGHT / 3) * 2, TFT_BLACK);
       display_obj.tft.setCursor(0, (TFT_HEIGHT / 3) * 2);
+      #endif
       pctStr = String(pct) + "%";
-      display_obj.showCenterText(pctStr.c_str(), TFT_HEIGHT / 2);
+      int bar_width = (TFT_WIDTH * pct) / 100;
+      #ifdef HAS_SCREEN
+      display_obj.tft.fillRect(0, (TFT_HEIGHT / 4) * 3, bar_width, 20, TFT_GREEN);
+      //display_obj.showCenterText(pctStr.c_str(), TFT_HEIGHT / 2, true);
+      #endif
     }
 
     client->print(part2);
+    client->flush();
     fileToUpload.close();
 
     Serial.println("[WDG] Bytes sent: " + String(totalSent));
+
+    display_obj.showCenterText("Waiting for response...", (TFT_HEIGHT / 3) * 2, true);
 
     // Read response
     String response;
     unsigned long t = millis();
     while (millis() - t < 5000) {
       while (client->available()) {
+        gotAny = true;
         char c = client->read();
+        Serial.print(c);
         response += c;
       }
-      if (!client->connected() && !client->available())
+      //if (!client->connected() && !client->available())
+      //  break;
+      if (gotAny && !client->connected()) {
         break;
+      }
+
+      delay(10);
     }
+
+    Serial.println();
+
     client->stop();
 
     // Capture first 200 chars of response for log viewer
@@ -10193,9 +10304,14 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     // WDG Wars returns 200 on success
     bool ok = response.indexOf("202 Accepted") >= 0 ||
     response.indexOf("\"ok\":true") >= 0;
-
+    #ifdef HAS_SCREEN
     display_obj.clearScreen();
-    display_obj.showCenterText(ok ? "WDG OK" : "WDG Failed", TFT_HEIGHT / 2);
+    display_obj.showCenterText(ok ? "WDG OK" : "WDG Failed", TFT_HEIGHT / 2, true);
+    #endif
+
+    if (!ok)
+      Serial.println(response);
+
     delay(1000);
 
     return ok;
@@ -10203,22 +10319,32 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
 
   // Upload one log file to Wigle
   bool WiFiScan::wigleUpload(String filePath) {
+    bool gotAny = false;
+
+    #ifdef HAS_SCREEN
     display_obj.clearScreen();
-    display_obj.showCenterText("Wigle Upload...", TFT_HEIGHT / 2);
+    display_obj.showCenterText("Wigle Upload...", TFT_HEIGHT / 2, true);
+    #endif
 
     delay(100);
 
     if (!SD.exists(filePath)) {
+      #ifdef HAS_SCREEN
       display_obj.clearScreen();
-      display_obj.showCenterText(String(filePath + " not found").c_str(), TFT_HEIGHT / 2);
+      display_obj.showCenterText(String(filePath + " not found").c_str(), TFT_HEIGHT / 2, true);
+      delay(2000);
+      #endif
       Serial.println("File does not exist: " + filePath);
       return false;
     }
 
     File fileToUpload = SD.open(filePath);
     if (!fileToUpload) {
+      #ifdef HAS_SCREEN
       display_obj.clearScreen();
-      display_obj.showCenterText("Could not open file", TFT_HEIGHT / 2);
+      display_obj.showCenterText("Could not open file", TFT_HEIGHT / 2, true);
+      delay(2000);
+      #endif
       Serial.println("Could not open file: " + filePath);
       return false;
     }
@@ -10228,14 +10354,17 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     String token = settings_obj.loadSetting<String>("wt");
     if (username.isEmpty() || token.isEmpty()) {
       fileToUpload.close();
+      #ifdef HAS_SCREEN
       display_obj.clearScreen();
-      display_obj.showCenterText("No wigle creds", TFT_HEIGHT / 2);
+      display_obj.showCenterText("No wigle creds", TFT_HEIGHT / 2, true);
+      delay(2000);
+      #endif
       Serial.println("Missing wigle credentials");
       return false;
     }
 
-    Serial.println("Username: " + username);
-    Serial.println("Token: " + token);
+    //Serial.println("Username: " + username);
+    //Serial.println("Token: " + token);
 
     String boundary = "----ESP32BOUNDARY";
     String contentType = "multipart/form-data; boundary=" + boundary;
@@ -10261,17 +10390,18 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     Serial.print("File size: ");
     Serial.println(fileToUpload.size());
 
-    // Connect manually via WiFiClientSecure
-    //WiFiClientSecure *client = new WiFiClientSecure();
-    //client.stop();
     client->setInsecure();
+    client->setTimeout(5000);
 
     if (!client->connect("api.wigle.net", 443)) {
       fileToUpload.close();
       //delete client;
       client->stop();
+      #ifdef HAS_SCREEN
       display_obj.clearScreen();
-      display_obj.showCenterText("Could not connect", TFT_HEIGHT / 2);
+      display_obj.showCenterText("Could not connect", TFT_HEIGHT / 2, true);
+      delay(2000);
+      #endif
       Serial.println("Failed to connected to api.wigle.net");
       return false;
     }
@@ -10315,10 +10445,16 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
       Serial.print(totalBytesSent);
       Serial.println(" bytes...");
       percent_sent = (totalBytesSent * 100) / fileToUpload.size();
+      int bar_width = (TFT_WIDTH * percent_sent) / 100;
+      #ifdef HAS_SCREEN
       display_obj.tft.drawRect(0, (TFT_HEIGHT / 3) * 2, TFT_WIDTH, TFT_HEIGHT, TFT_BLACK);
       display_obj.tft.setCursor(0, (TFT_HEIGHT / 3) * 2);
-      display_percent = (String)percent_sent + "%";
-      display_obj.showCenterText(display_percent.c_str(), TFT_HEIGHT / 2);
+      #endif
+      //display_percent = (String)percent_sent + "%";
+      #ifdef HAS_SCREEN
+      display_obj.tft.fillRect(0, (TFT_HEIGHT / 4) * 3, bar_width, 20, TFT_GREEN);
+      //display_obj.showCenterText(display_percent.c_str(), TFT_HEIGHT / 2, true);
+      #endif
       client->write(buffer, bytesRead);
     }
 
@@ -10326,23 +10462,40 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
 
     client->print(part2);
     client->print(part3);
+    client->flush();
 
     Serial.println("Finished sending part2 and part3");
 
-    fileToUpload.close();
+    display_obj.showCenterText("Waiting for response...", (TFT_HEIGHT / 3) * 2, true);
 
+    fileToUpload.close();
 
     // Read response
     String response;
     unsigned long timeout = millis();
     while (millis() - timeout < 5000) {
       while (client->available()) {
+        gotAny = true;
         char c = client->read();
+        Serial.print(c);
         response += c;
       }
+
+      if (gotAny && !client->connected()) {
+        break;
+      }
+
+
+      delay(10);
     }
 
-    if (millis() - timeout > 5000)
+    Serial.println();
+
+    if (!gotAny) {
+      Serial.println("[WIGLE] No response bytes received");
+    }
+
+    if (millis() - timeout >= 5000)
       Serial.println("Timeout reached");
     if (!client->connected())
       Serial.println("Client disconnected");
@@ -10353,9 +10506,13 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     Serial.println("[WIGLE] Response: " + respTrunc);
 
     bool ok = response.indexOf("200 OK") >= 0;
-
+    #ifdef HAS_SCREEN
     display_obj.clearScreen();
-    display_obj.showCenterText(ok ? "WIGLE OK" : "WIGLE Failed", TFT_HEIGHT / 2);
+    display_obj.showCenterText(ok ? "WIGLE OK" : "WIGLE Failed", TFT_HEIGHT / 2, true);
+    #endif
+
+    if (!ok)
+      Serial.println(response);
 
     return ok;
   }

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -70,6 +70,7 @@
 
 #ifdef HAS_DIRECT_UPLOAD
   #include <WiFiClientSecure.h>
+  #include <HTTPClient.h>
   #include "mbedtls/sha256.h"
 #endif
 

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -216,6 +216,10 @@
 #define CLEAR_SSID  7
 #define CLEAR_BLE   8
 
+#define WIGLE_UPLOAD 0
+#define WDG_UPLOAD   1
+#define BOTH_UPLOAD  2
+
 extern EvilPortal evil_portal_obj;
 
 #ifdef HAS_SCREEN
@@ -605,6 +609,8 @@ class WiFiScan
 
     bool wigleUpload(String filePath);
     bool wdgwarsUpload(String filePath);
+    void writeSidecar(String filePath, String service);
+    bool sidecarExists(String filePath, String service); 
 
     void runFoxHunt(uint32_t currentTime);
     void throwThatShitInACircle();
@@ -879,6 +885,7 @@ class WiFiScan
 
     wifi_config_t ap_config;
 
+    bool uploadFile(String filePath, bool retry = false, uint8_t upload_type = WIGLE_UPLOAD);
     String checkEmptyProbe(String essid);
     bool checkFlockOUI(const uint8_t mac[6]);
     bool startWiFi(String ssid, String password, bool gui = true);

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -41,7 +41,7 @@
 
   #define JSON_SETTING_SIZE 2048
 
-  #define MARAUDER_VERSION "v1.13.0"
+  #define MARAUDER_VERSION "v1.14.0"
 
   #define GRAPH_REFRESH   100
 

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -566,7 +566,7 @@
     #define HAS_NIMBLE_2
     #define HAS_IDF_3
     //#define HAS_SIMPLEX_DISPLAY
-    //#define HAS_DIRECT_UPLOAD
+    #define HAS_DIRECT_UPLOAD
   #endif
 
   #if defined(MARAUDER_M5_NANO_C6)

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -494,6 +494,7 @@
     //#define HAS_TEMP_SENSOR
     #define HAS_NIMBLE_2
     #define HAS_IDF_3
+    //#define HAS_DIRECT_UPLOAD
   #endif
 
   #ifdef MARAUDER_V8
@@ -517,6 +518,7 @@
     #define HAS_NIMBLE_2
     #define HAS_IDF_3
     #define HAS_ACT_LED
+    #define HAS_DIRECT_UPLOAD
   #endif
 
   #ifdef MARAUDER_PANCAKE

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -339,7 +339,7 @@ void setup()
 
   settings_obj.begin();
 
-  const char* type = settings_obj.getSettingType("ChanHop");
+  const char* type = settings_obj.getSettingType("wu");
 
   if (type == nullptr || type[0] == '\0') {
     Serial.println(F("Current settings format not supported. Installing new default settings..."));

--- a/esp32_marauder/settings.cpp
+++ b/esp32_marauder/settings.cpp
@@ -468,6 +468,24 @@ bool Settings::createDefaultSettings(fs::FS &fs, bool spec, uint8_t index, const
     jsonBuffer["Settings"][7]["range"]["min"] = "";
     jsonBuffer["Settings"][7]["range"]["max"] = "";
 
+    jsonBuffer["Settings"][8]["name"] = "wu";
+    jsonBuffer["Settings"][8]["type"] = "String";
+    jsonBuffer["Settings"][8]["value"] = "";
+    jsonBuffer["Settings"][8]["range"]["min"] = "";
+    jsonBuffer["Settings"][8]["range"]["max"] = "";
+
+    jsonBuffer["Settings"][9]["name"] = "wt";
+    jsonBuffer["Settings"][9]["type"] = "String";
+    jsonBuffer["Settings"][9]["value"] = "";
+    jsonBuffer["Settings"][9]["range"]["min"] = "";
+    jsonBuffer["Settings"][9]["range"]["max"] = "";
+
+    jsonBuffer["Settings"][10]["name"] = WDG_KEY_NAME;
+    jsonBuffer["Settings"][10]["type"] = "String";
+    jsonBuffer["Settings"][10]["value"] = "";
+    jsonBuffer["Settings"][10]["range"]["min"] = "";
+    jsonBuffer["Settings"][10]["range"]["max"] = "";
+
     serializeJson(jsonBuffer, settingsFile);
     serializeJson(jsonBuffer, settings_string);
   } else {

--- a/esp32_marauder/settings.cpp
+++ b/esp32_marauder/settings.cpp
@@ -32,6 +32,12 @@ void Settings::_buildCache() {
       _cache.ClientSSID = json["Settings"][i]["value"].as<String>();
     else if (strcmp(name, "ClientPW") == 0)
       _cache.ClientPW = json["Settings"][i]["value"].as<String>();
+    else if (strcmp(name, "wu") == 0)
+      _cache.wu = json["Settings"][i]["value"].as<String>();
+    else if (strcmp(name, "wt") == 0)
+      _cache.wt = json["Settings"][i]["value"].as<String>();
+    else if (strcmp(name, WDG_KEY_NAME) == 0)
+      _cache.wdg_key = json["Settings"][i]["value"].as<String>();
   }
 }
 
@@ -107,9 +113,14 @@ template <> int Settings::loadSetting<int>(const char* key) {
 template <> String Settings::loadSetting<String>(const char* key) {
   if (strcmp(key, "ClientSSID") == 0)
     return _cache.ClientSSID;
-
   if (strcmp(key, "ClientPW") == 0)
     return _cache.ClientPW;
+    if (strcmp(key, "wu") == 0)
+    return _cache.wu;
+  if (strcmp(key, "wt") == 0)
+    return _cache.wt;
+  if (strcmp(key, WDG_KEY_NAME) == 0)
+    return _cache.wdg_key;
 
   // Unknown String key: fall back to JSON so the setting can be auto-created.
   DynamicJsonDocument json(JSON_SETTING_SIZE);
@@ -302,6 +313,12 @@ template <> bool Settings::saveSetting<bool>(const char* key, String value) {
         _cache.ClientSSID = value;
       else if (strcmp(key, "ClientPW") == 0)
         _cache.ClientPW = value;
+      else if (strcmp(key, "wu") == 0)
+        _cache.wu = value;
+      else if (strcmp(key, "wt") == 0)
+        _cache.wt = value;
+      else if (strcmp(key, WDG_KEY_NAME) == 0)
+        _cache.wdg_key = value;
 
       this->printJsonSettings(settings_string);
 

--- a/esp32_marauder/settings.h
+++ b/esp32_marauder/settings.h
@@ -27,14 +27,17 @@ class Settings {
     // Flat cache populated once at begin() and kept in sync by saveSetting().
     // All loadSetting<T>() reads hit this struct — zero heap, zero JSON parse.
     struct SettingsCache {
-      bool  ForcePMKID  = false;
-      bool  ForceProbe  = false;
-      bool  SavePCAP    = true;
-      bool  EnableLED   = true;
-      bool  EPDeauth    = false;
-      bool  ChanHop     = false;
-      String ClientSSID = "";
-      String ClientPW   = "";
+      bool  ForcePMKID    = false;
+      bool  ForceProbe    = false;
+      bool  SavePCAP      = true;
+      bool  EnableLED     = true;
+      bool  EPDeauth      = false;
+      bool  ChanHop       = false;
+      String ClientSSID   = "";
+      String ClientPW     = "";
+      String wu           = "";
+      String wt           = "";
+      String wdg_key = "";
     } _cache;
 
     void _buildCache();  // parse json_settings_string -> _cache

--- a/esp32_marauder/settings.h
+++ b/esp32_marauder/settings.h
@@ -37,7 +37,7 @@ class Settings {
       String ClientPW     = "";
       String wu           = "";
       String wt           = "";
-      String wdg_key = "";
+      String wdg_key      = "";
     } _cache;
 
     void _buildCache();  // parse json_settings_string -> _cache


### PR DESCRIPTION
To add your WDG and WiGLE credentials, create the following text files on the root of your SD card:

| File Name | Content |
| ----------- | --------- |
| `wigle_api_name.txt` | Wigle API Name |
| `wigle_api_token.txt` | Wigle API Token |
| `wdg_key.txt` | WDG API Key |

Copy and paste the specified content (and nothing else) into the respective txt file and save. Insert the SD card into your Marauder device and allow the device to boot. The credentials will be saved to the device and the files will automatically be removed from the SD card.

For internet access when uploading your log files, use the `join` CLI command or `Join WiFi` menu option after completing an AP scan. Upon joining WiFi successfully, these WiFi credentials will be saved. Anytime you execute a direct upload to WDG or WiGLE, these credentials will automatically be used to attempt to connect to WiFi and perform the upload.