### PR TITLE
Evil Portal: stop leaking web handlers + DNS/AP netif on every Start

### DIFF
--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -29,6 +29,14 @@ void EvilPortal::setup() {
 void EvilPortal::cleanup() {
   this->ap_index = -1;
 
+  // Free the per-activation network resources so repeated Start/Stop cycles don't
+  // leak: stop the DNS server (frees its UDP pcb) and tear down the SoftAP netif +
+  // DHCP lease pool. Previously cleanup() freed only the PSRAM HTML buffer, so each
+  // cycle leaked the DNS socket + AP netif and the web handlers grew unbounded (see
+  // the register-once guard in startAP()).
+  this->dnsServer.stop();
+  WiFi.softAPdisconnect(true);
+
   #ifdef HAS_PSRAM
     free(index_html);
     index_html = nullptr;
@@ -320,11 +328,21 @@ void EvilPortal::startAP() {
   Serial.print(F("ap ip address: "));
   Serial.println(WiFi.softAPIP());
 
-  this->setupServer();
+  // Register the web-server endpoints + captive handler ONCE for the app lifetime.
+  // setupServer() appends ~12 handlers and addHandler() allocates a
+  // CaptiveRequestHandler; re-running them on every Start leaked those per activation
+  // (server._handlers grew unbounded). They are owned by the global `server` and this
+  // is the singleton evil_portal_obj, so once is enough; server.begin() is idempotent.
+  // The AP + DNS themselves ARE rebuilt each Start (cleanup() tears them down).
+  static bool s_server_registered = false;
+  if (!s_server_registered) {
+    this->setupServer();
+    server.addHandler(new CaptiveRequestHandler()).setFilter(ON_AP_FILTER);
+    server.begin();
+    s_server_registered = true;
+  }
 
   this->dnsServer.start(53, "*", WiFi.softAPIP());
-  server.addHandler(new CaptiveRequestHandler()).setFilter(ON_AP_FILTER);
-  server.begin();
   Serial.println(F("Evil Portal READY"));
   #ifdef HAS_SCREEN
     this->sendToDisplay(F("Evil Portal READY"));


### PR DESCRIPTION
### Problem
`EvilPortal::startAP()` re-runs `setupServer()` (which `server.on(...)`-registers ~12 endpoints) plus `server.addHandler(new CaptiveRequestHandler())` and `dnsServer.start()` on **every** activation, while `cleanup()` frees only the PSRAM HTML buffer. So each Evil Portal Start/Stop cycle leaks:
- the DNS server's UDP pcb (never `.stop()`'d),
- the SoftAP netif + DHCP lease pool (never `softAPdisconnect`'d),
- a `CaptiveRequestHandler` + ~12 handlers appended to `server._handlers` (grows unbounded).

Repeated Start/Stop steadily exhausts internal DRAM.

### Fix
- `startAP()`: register the web endpoints + captive handler **once** (they're owned by the global `AsyncWebServer server` and `EvilPortal` is a singleton). `server.begin()` is idempotent. The AP + DNS are still rebuilt every Start.
- `cleanup()`: `dnsServer.stop()` + `WiFi.softAPdisconnect(true)` to reclaim the per-activation DNS socket + AP netif/DHCP.

Deliberately does **not** touch the AsyncTCP service task (one-time infra; stopping the shared task cross-core races lwIP).

### Testing
Verified on an ESP32-S3: ~21 KB reclaimed on the first Stop and **~0 net DRAM per subsequent Start/Stop cycle** (was ~2 KB leaked every cycle), 0 reboots across 15 cold cycles + 10 with a client connected at teardown. Applies against v1.14.0.

_Draft: opened for review/reproduction; AI-assisted (Claude) — please sanity-check on your target hardware._