### PR TITLE
Beacon spam: remove redundant per-frame delay(1) in broadcastSetSSID

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -7951,8 +7951,8 @@ void WiFiScan::broadcastSetSSID(uint32_t current_time, const char* ESSID, uint8_
   }
 
   this->changeChannel(set_channel);
-
-  delay(1);  
+  // (changeChannel() already delay(1)'d for the channel switch to settle; the extra
+  // delay here was a redundant per-frame block on the beacon-spam path.)
 
   // Randomize SRC MAC
   if(!legit) {


### PR DESCRIPTION
### Problem
`broadcastSetSSID()` calls `this->changeChannel(set_channel)` — which already does `esp_wifi_set_channel(...)` followed by `delay(1)` to let the channel switch settle — and then immediately does a **second** bare `delay(1)` before the TX. The channel is already settled by `changeChannel()`, so the second delay is redundant per-frame loop-blocking on the beacon-spam path.

### Fix
Remove the redundant `delay(1)`. Roughly halves the per-send block with no behavioral change (channel still settles via `changeChannel`).

_Draft: minor perf; AI-assisted (Claude). Trivial + low-risk, but please sanity-check on hardware._