### PR TITLE
Fix cross-task use-after-free on analyzer_name_string

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -9,6 +9,21 @@
 static const uint8_t *g_filter_bssid = nullptr;
 uint8_t *current_act = nullptr;
 
+// Guards analyzer_name_string (fixed char[33]) between the Channel-Analyzer RX callback
+// (WiFi task) and the main-task display readers -> no cross-task String use-after-free.
+static portMUX_TYPE analyzer_name_mux = portMUX_INITIALIZER_UNLOCKED;
+void WiFiScan::setAnalyzerName(const char *s) {
+  portENTER_CRITICAL(&analyzer_name_mux);
+  strlcpy(this->analyzer_name_string, s ? s : "", sizeof(this->analyzer_name_string));
+  portEXIT_CRITICAL(&analyzer_name_mux);
+}
+void WiFiScan::getAnalyzerName(char *out, size_t n) {
+  if (!out || n == 0) return;
+  portENTER_CRITICAL(&analyzer_name_mux);
+  strlcpy(out, this->analyzer_name_string, n);
+  portEXIT_CRITICAL(&analyzer_name_mux);
+}
+
 MacEntry WiFiScan::mac_entries[mac_history_len_half];
 uint8_t WiFiScan::mac_entry_state[mac_history_len_half];
 WiFiEventId_t WiFiScan::eventId;
@@ -626,7 +641,7 @@ extern "C" {
                 display_string.concat(advertisedDevice->getAddress().toString().c_str());
 
               wifi_scan_obj.analyzer_frames_recvd = 0;
-              wifi_scan_obj.analyzer_name_string = display_string;
+              wifi_scan_obj.setAnalyzerName(display_string.c_str());
               wifi_scan_obj.analyzer_name_update = true;
             }
           }
@@ -1299,7 +1314,7 @@ extern "C" {
                 display_string.concat(mac);
 
               wifi_scan_obj.analyzer_frames_recvd = 0;
-              wifi_scan_obj.analyzer_name_string = display_string;
+              wifi_scan_obj.setAnalyzerName(display_string.c_str());
               wifi_scan_obj.analyzer_name_update = true;
             }
           }
@@ -2564,7 +2579,7 @@ void WiFiScan::StopScan(uint8_t scan_mode) {
       for (int i = 0; i < TFT_WIDTH; i++) {
         this->_analyzer_values[i] = 0;
       }
-      this->analyzer_name_string = "";
+      this->setAnalyzerName("");
       this->analyzer_name_update = true;
       this->mgmt_frames = 0;
       this->data_frames = 0;
@@ -2624,7 +2639,7 @@ void WiFiScan::StopScan(uint8_t scan_mode) {
         for (int i = 0; i < TFT_WIDTH; i++) {
           this->_analyzer_values[i] = 0;
         }
-        this->analyzer_name_string = "";
+        this->setAnalyzerName("");
         this->analyzer_name_update = true;
       #endif
 
@@ -8785,7 +8800,7 @@ void WiFiScan::wifiSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type) 
             }
           }
         }
-        wifi_scan_obj.analyzer_name_string = display_string;
+        wifi_scan_obj.setAnalyzerName(display_string.c_str());
         wifi_scan_obj.analyzer_frames_recvd = 0;
         wifi_scan_obj.analyzer_name_update = true;
       }
@@ -9514,7 +9529,7 @@ void WiFiScan::signalAnalyzerLoop(uint32_t tick) {
         #endif
         this->_analyzer_value = 0;
         if (this->analyzer_name_update) {
-          this->displayAnalyzerString(this->analyzer_name_string);
+          { char _an[33]; this->getAnalyzerName(_an, sizeof(_an)); this->displayAnalyzerString(_an); }
           this->analyzer_name_update = false;
         }
       }
@@ -9688,7 +9703,7 @@ void WiFiScan::channelActivityLoop(uint32_t tick) {
       this->addAnalyzerValue(this->_analyzer_value * BASE_MULTIPLIER, -72, this->_analyzer_values, TFT_WIDTH);
       this->_analyzer_value = 0;
       if (this->analyzer_name_update) {
-        this->displayAnalyzerString(this->analyzer_name_string);
+        { char _an[33]; this->getAnalyzerName(_an, sizeof(_an)); this->displayAnalyzerString(_an); }
         this->analyzer_name_update = false;
       }
     }

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -826,7 +826,12 @@ class WiFiScan
 
     uint8_t activity_page = 1;
 
-    String analyzer_name_string = "";
+    // Fixed buffer (not Arduino String) written by the Channel-Analyzer RX callback
+    // (WiFi task) and read by the main-task display path via the guarded
+    // setAnalyzerName/getAnalyzerName accessors -> no cross-task String use-after-free.
+    char analyzer_name_string[33] = "";
+    void setAnalyzerName(const char *s);
+    void getAnalyzerName(char *out, size_t n);
     
     uint8_t analyzer_frames_recvd = 0;
 


### PR DESCRIPTION
The Channel Analyzer's wifiSnifferCallback (promiscuous RX callback, WiFi-driver task) reassigns the Arduino String analyzer_name_string (String::operator= frees the old heap buffer and mallocs a new one), while the main-task display path (displayAnalyzerString) reads it. A concurrent read can dereference the freed buffer -> garbled name or crash on screen'd boards.

Make it a fixed char[33] behind guarded setAnalyzerName()/getAnalyzerName() accessors (portMUX spinlock analyzer_name_mux). Writers/resets go through setAnalyzerName; the display path snapshots under the lock before rendering.