### PR TITLE
Fix cross-task UAF on AccessPoint essid/man (POD char[])

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -167,7 +167,7 @@ void CommandLine::filterAccessPoints(String filter) {
             (ssidEquals.charAt(0) == '\'' && ssidEquals.charAt(ssidEquals.length() - 1) == '\'' && ssidEquals.length() > 1)) {
           ssidEquals = ssidEquals.substring(1, ssidEquals.length() - 1);
         }
-        if (access_point.essid.equalsIgnoreCase(ssidEquals)) {
+        if (strcasecmp(access_point.essid, ssidEquals.c_str()) == 0) {
           matchesFilter = true;
           break;
         }
@@ -1714,7 +1714,7 @@ void CommandLine::runCommand(String input) {
         essid = cmd_args.get(essid_sw + 1);
 
       AccessPoint ap;
-      ap.essid = essid;
+      strlcpy(ap.essid, essid.c_str(), sizeof(ap.essid));
       ap.channel = channel;
       memcpy(ap.bssid, mac, 6);
       ap.selected = true;
@@ -1725,7 +1725,7 @@ void CommandLine::runCommand(String input) {
       ap.packets = 0;
       ap.sec = 0;
       ap.wps = false;
-      ap.man = "";
+      ap.man[0] = 0;
       ap.has_msg_1 = false;
       ap.has_msg_2 = false;
       ap.has_msg_3 = false;

--- a/esp32_marauder/EvilPortal.h
+++ b/esp32_marauder/EvilPortal.h
@@ -53,7 +53,13 @@ struct ssid {
 };
 
 struct AccessPoint {
-  String essid;
+  // essid/man are fixed char[] (were Arduino String). access_points is mutated from
+  // sniffer RX callbacks (WiFi task) and copied by-value by the main-task UI/attack
+  // readers (get() returns AccessPoint by value); a String field would free+realloc its
+  // heap buffer during that copy -> a cross-task use-after-free / heap over-read. POD
+  // char[] makes the by-value copy a plain memcpy (a torn copy = garbled text for one
+  // frame, never a heap fault). 33 = 32-char SSID + NUL.
+  char essid[33];
   uint8_t channel;
   uint8_t bssid[6];
   bool selected;
@@ -64,7 +70,7 @@ struct AccessPoint {
   uint16_t packets;
   uint8_t sec;
   bool wps;
-  String man;
+  char man[33];
   bool has_msg_1;
   bool has_msg_2;
   bool has_msg_3;

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -2020,7 +2020,7 @@ void MenuFunctions::RunSetup()
     // Get AP list ready
     for (int i = 0; i < access_points->size(); i++) {
       // This is the menu node
-      this->addNodes(&wifiAPMenu, access_points->get(i).essid.c_str(), TFTCYAN, 255, [this, i](){
+      this->addNodes(&wifiAPMenu, access_points->get(i).essid, TFTCYAN, 255, [this, i](){
         if (evil_portal_obj.setAP(access_points->get(i).essid)) {
           AccessPoint new_ap = access_points->get(i);
           new_ap.selected = true;
@@ -2316,7 +2316,7 @@ void MenuFunctions::RunSetup()
       // Populate the menu with buttons
       for (int i = 0; i < access_points->size(); i++) {
         // This is the menu node
-        this->addNodes(&wifiAPMenu, access_points->get(i).essid.c_str(), TFTCYAN, 255, [this, i](){
+        this->addNodes(&wifiAPMenu, access_points->get(i).essid, TFTCYAN, 255, [this, i](){
         AccessPoint new_ap = access_points->get(i);
         new_ap.selected = !access_points->get(i).selected;
 
@@ -2343,7 +2343,7 @@ void MenuFunctions::RunSetup()
       // Populate the menu with buttons
       for (int i = 0; i < access_points->size(); i++) {
         // This is the menu node
-        this->addNodes(&wifiAPMenu, access_points->get(i).essid.c_str(), TFTCYAN, 255, [this, i](){
+        this->addNodes(&wifiAPMenu, access_points->get(i).essid, TFTCYAN, 255, [this, i](){
           this->changeMenu(&apInfoMenu, true);
           wifi_scan_obj.RunAPInfo(i);
         });
@@ -2381,7 +2381,7 @@ void MenuFunctions::RunSetup()
 
       for (int i = 0; i < menu_limit; i++) {
         wifiStationMenu.list->clear();
-        this->addNodes(&wifiAPMenu, access_points->get(i).essid.c_str(), TFTCYAN, 255, [this, i](){
+        this->addNodes(&wifiAPMenu, access_points->get(i).essid, TFTCYAN, 255, [this, i](){
 
           wifiStationMenu.list->clear();
 
@@ -2449,7 +2449,7 @@ void MenuFunctions::RunSetup()
       // Populate the menu with buttons
       for (int i = 0; i < access_points->size(); i++) {
         // This is the menu node
-        this->addNodes(&wifiAPMenu, access_points->get(i).essid.c_str(), TFTCYAN, 255, [this, i](){
+        this->addNodes(&wifiAPMenu, access_points->get(i).essid, TFTCYAN, 255, [this, i](){
           // Join WiFi using mini keyboard
           #ifdef HAS_MINI_KB
             this->changeMenu(&miniKbMenu, true);
@@ -2497,7 +2497,7 @@ void MenuFunctions::RunSetup()
         // Populate the menu with buttons
         for (int i = 0; i < access_points->size(); i++) {
           // This is the menu node
-          this->addNodes(&wifiAPMenu, access_points->get(i).essid.c_str(), TFTCYAN, 255, [this, i](){
+          this->addNodes(&wifiAPMenu, access_points->get(i).essid, TFTCYAN, 255, [this, i](){
             // Join WiFi using mini keyboard
             #ifdef HAS_MINI_KB
               this->changeMenu(&miniKbMenu, true);
@@ -2972,7 +2972,7 @@ void MenuFunctions::RunSetup()
       // Populate the menu with buttons
       for (int i = 0; i < access_points->size(); i++) {
         // This is the menu node
-        this->addNodes(&wifiAPMenu, access_points->get(i).essid.c_str(), TFTLIME, 255, [this, i](){
+        this->addNodes(&wifiAPMenu, access_points->get(i).essid, TFTLIME, 255, [this, i](){
           this->changeMenu(&genAPMacMenu, true);
           wifi_scan_obj.RunSetMac(access_points->get(i).bssid, true);
         });

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -3432,7 +3432,7 @@ void WiFiScan::RunLoadAPList() {
     for (JsonObject obj : array) {
       AccessPoint ap;
 
-      ap.essid   = obj.containsKey("essid")   ? obj["essid"].as<String>()      : "";
+      strlcpy(ap.essid, obj.containsKey("essid") ? obj["essid"].as<String>().c_str() : "", sizeof(ap.essid));
       ap.channel = obj.containsKey("channel") ? obj["channel"].as<uint8_t>()   : 1;
       ap.selected = false;
 
@@ -3442,7 +3442,7 @@ void WiFiScan::RunLoadAPList() {
       } else {
         memset(ap.bssid, 0, 6); // Zero BSSID if missing
       }
-      Serial.println("Got: " + ap.essid);
+      Serial.println(String("Got: ") + ap.essid);
 
       ap.stations = new LinkedList<uint16_t>();
 
@@ -3464,7 +3464,7 @@ void WiFiScan::RunLoadAPList() {
       ap.packets  = obj.containsKey("packet") ? obj["packet"].as<uint32_t>()   : 0;
       ap.sec      = obj.containsKey("sec")    ? obj["sec"].as<uint8_t>()       : 0;
       ap.wps      = obj.containsKey("wps")    ? obj["wps"].as<bool>()          : false;
-      ap.man      = obj.containsKey("man")    ? obj["man"].as<String>()        : "Unknown";
+      strlcpy(ap.man, obj.containsKey("man") ? obj["man"].as<String>().c_str() : "Unknown", sizeof(ap.man));
       ap.has_msg_1 = false;
       ap.has_msg_2 = false;
       ap.has_msg_3 = false;
@@ -6049,7 +6049,7 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
 
       if ((index > 0) && (!access_point.wps)) {
         //new_ap.wps = true;
-        access_point.man = man;
+        strlcpy(access_point.man, man.c_str(), sizeof(access_point.man));
         access_points->set(index, access_point);
       }
       //}
@@ -6123,7 +6123,7 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
         if (wifi_scan_obj.checkMem()) {
 
           AccessPoint ap;
-          ap.essid = essid;
+          strlcpy(ap.essid, essid.c_str(), sizeof(ap.essid));
           ap.channel = snifferPacket->rx_ctrl.channel;
           ap.bssid[0] = snifferPacket->payload[10];
           ap.bssid[1] = snifferPacket->payload[11];
@@ -6159,7 +6159,7 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
 
           ap.packets = 0;
 
-          ap.man = "";
+          ap.man[0] = 0;
 
           access_points->add(ap);
         }
@@ -8004,8 +8004,8 @@ void WiFiScan::broadcastCustomBeacon(uint32_t current_time, AccessPoint custom_s
   }
 
   // Figure out ESSID stuff and lengths based on attack type
-  char ESSID[custom_ssid.essid.length() + 1] = {};
-  custom_ssid.essid.toCharArray(ESSID, custom_ssid.essid.length() + 1);
+  char ESSID[strlen(custom_ssid.essid) + 1] = {};   // AccessPoint overload: essid is char[]
+  strlcpy(ESSID, custom_ssid.essid, sizeof(ESSID));
 
   int realLen = strlen(ESSID);
   int ssidLen = realLen;
@@ -8277,13 +8277,13 @@ void WiFiScan::sendProbeAttack(uint32_t currentTime) {
       prob_req_packet[15] = random(256);
 
       // Set SSID length
-      int ssidLen = access_point.essid.length();
+      int ssidLen = strlen(access_point.essid);
       int fullLen = ssidLen;
       prob_req_packet[25] = fullLen;
 
       // Insert ESSID
-      char buf[access_point.essid.length() + 1] = {};
-      access_point.essid.toCharArray(buf, access_point.essid.length() + 1);
+      char buf[strlen(access_point.essid) + 1] = {};
+      strlcpy(buf, access_point.essid, strlen(access_point.essid) + 1);
       
       for(int i = 0; i < ssidLen; i++)
         prob_req_packet[26 + i] = buf[i];
@@ -8646,7 +8646,7 @@ void WiFiScan::sendAssocSleepAttack(uint32_t currentTime, bool all) {
       AccessPoint access_point = access_points->get(i);
       for (int x = 0; x < access_point.stations->size(); x++) {
         if (stations->get(access_point.stations->get(x)).selected) {
-          this->sendAssociationSleep(access_point.essid.c_str(), access_point.bssid,
+          this->sendAssociationSleep(access_point.essid, access_point.bssid,
                                   access_point.channel,
                                   stations->get(access_point.stations->get(x)).mac);
         }
@@ -8658,7 +8658,7 @@ void WiFiScan::sendAssocSleepAttack(uint32_t currentTime, bool all) {
       AccessPoint access_point = access_points->get(i);
       if (access_point.selected) {
         for (int x = 0; x < access_point.stations->size(); x++) {
-          this->sendAssociationSleep(access_point.essid.c_str(), access_point.bssid,
+          this->sendAssociationSleep(access_point.essid, access_point.bssid,
                                   access_point.channel,
                                   stations->get(access_point.stations->get(x)).mac);
         }
@@ -8986,7 +8986,7 @@ void WiFiScan::eapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
         uint8_t security_type = wifi_scan_obj.getSecurityType(snifferPacket->payload, len);
 
         AccessPoint ap;
-        ap.essid = essid;
+        strlcpy(ap.essid, essid.c_str(), sizeof(ap.essid));
         ap.channel = snifferPacket->rx_ctrl.channel;
         ap.bssid[0] = snifferPacket->payload[10];
         ap.bssid[1] = snifferPacket->payload[11];
@@ -9838,9 +9838,9 @@ void WiFiScan::renderPacketRate() {
     AccessPoint access_point = access_points->get(i);
     if (access_point.selected) {
       #ifdef HAS_SCREEN
-        display_obj.tft.println(access_point.essid + ": " + (String)access_point.packets);
+        display_obj.tft.println(String(access_point.essid) + ": " + (String)access_point.packets);
       #endif
-      Serial.println(access_point.essid + ": " + (String)access_point.packets);
+      Serial.println(String(access_point.essid) + ": " + (String)access_point.packets);
     }
   }
   for (int i = 0; i < stations->size(); i++) {
@@ -10800,9 +10800,9 @@ void WiFiScan::runFoxHunt(uint32_t currentTime) {
           display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
 
           #ifdef HAS_MINI_SCREEN
-            display_obj.showCenterText(access_points->get(i).essid.c_str(), (TFT_HEIGHT / 4), true);
+            display_obj.showCenterText(access_points->get(i).essid, (TFT_HEIGHT / 4), true);
           #else
-            display_obj.showCenterText(access_points->get(i).essid.c_str(), (TFT_HEIGHT / 4), false, 2);
+            display_obj.showCenterText(access_points->get(i).essid, (TFT_HEIGHT / 4), false, 2);
           #endif
 
           #ifdef HAS_MINI_SCREEN
@@ -11033,7 +11033,7 @@ void WiFiScan::main(uint32_t currentTime)
 
             int8_t rssi = access_point.rssi;
 
-            display_obj.tft.print(access_point.essid + ": ");
+            display_obj.tft.print(String(access_point.essid) + ": ");
             display_obj.tft.setTextColor(this->rssiToColor(rssi), TFT_BLACK);
             display_obj.tft.println((String)rssi);
             display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);


### PR DESCRIPTION
access_points/stations are mutated from promiscuous-RX sniffer callbacks (WiFi task) while the main task copies AccessPoint **by value**; the String essid/man fields free+realloc their heap buffer during that copy -> cross-task use-after-free / heap over-read. Make essid/man fixed `char[33]` (POD) so the by-value copy is a plain memcpy. All String-idiom sites converted to char-array ops; ssid/Station/ProbeReqSsid keep their String fields.

Opening as **draft** to let the CI matrix compile it across all boards (the change touches MenuFunctions/WiFiScan/CommandLine display paths). Part of a cross-task-concurrency audit; companion PRs: SAE token, Evil Portal creds, analyzer name, PCAP Buffer, channel_activity OOB (#1376).