### PR TITLE
Add GT911 capacitive touch support for ESP32-3248S035C

### DIFF
--- a/MODIFICATIONS_GT911.md
+++ b/MODIFICATIONS_GT911.md
@@ -1,0 +1,54 @@
+# ESP32 Marauder v1.13.0: ESP32-3248S035C GT911 support
+
+This is a community modification of `justcallmekoko/ESP32Marauder` tag `v1.13.0` for the 3.5-inch ESP32-3248S035C board.
+
+## Hardware target
+
+- ESP32-D0WD-V3, 4 MB flash
+- ST7796 display, 320 x 480
+- GT911 capacitive touch
+- GT911 SDA: GPIO33
+- GT911 SCL: GPIO32
+- GT911 INT: GPIO21
+- GT911 RST is documented as GPIO25; the tested code does not actively toggle it
+
+## Code changes
+
+`esp32_marauder/configs.h`
+
+- adds `HAS_GT911_TOUCH` to the official `MARAUDER_CYD_3_5_INCH` target;
+- defines the GT911 I2C and interrupt pins.
+
+`esp32_marauder/Display.cpp`
+
+- adds SensorLib's `TouchDrvGT911` driver;
+- probes GT911 at I2C addresses `0x5D` and `0x14`;
+- maps native 320 x 480 coordinates for display rotations 0-3;
+- bypasses TFT_eSPI resistive-touch calibration;
+- prints a clear serial success or failure message;
+- adds a 100 ms release debounce.
+
+## Why the debounce is required
+
+SensorLib's GT911 `getPoint()` clears the controller data-ready frame. A rapid poll immediately afterward may return zero even while the finger is still on the screen. Marauder can interpret that zero as a release and process the same physical tap twice. The final build retains the last valid point for 100 ms, making one physical tap produce one menu action.
+
+## TFT_eSPI build configuration
+
+- TFT_eSPI 2.5.34
+- `User_Setup_cyd_3_5_inch.h`
+- ST7796 driver
+- 320 x 480 resolution
+- resistive `TOUCH_CS 33` disabled because GPIO33 is GT911 SDA
+- complete upstream `User_Setup_Select.h` retained; only the selected setup include is changed
+
+## Tested build
+
+- Marauder version: v1.13.0
+- ESP32 Arduino core: 2.0.11
+- FQBN: `esp32:esp32:d32:PartitionScheme=min_spiffs`
+- SensorLib: 0.2.2
+- final sketch size: 1,360,937 bytes
+- final global memory: 76,892 bytes
+- full flash and application-only update tested successfully
+
+This is not an official ESP32Marauder release. Preserve the upstream and third-party license notices when redistributing it.

--- a/esp32_marauder/Display.cpp
+++ b/esp32_marauder/Display.cpp
@@ -3,6 +3,14 @@
 
 #ifdef HAS_SCREEN
 
+#ifdef HAS_GT911_TOUCH
+  #include <Wire.h>
+  #include <TouchDrvGT911.hpp>
+
+  static TouchDrvGT911 cyd_gt911;
+  static bool cyd_gt911_ready = false;
+#endif
+
 Display::Display()
 #ifdef HAS_CYD_TOUCH
   : touchscreenSPI(VSPI),
@@ -42,7 +50,94 @@ int8_t Display::menuButton(uint16_t *x, uint16_t *y, bool pressed, bool check_ho
 uint8_t Display::updateTouch(uint16_t *x, uint16_t *y, uint16_t threshold) {
   #ifdef HAS_ILI9341
     if (!this->headless_mode) {
-      #ifdef HAS_CAP_TOUCH
+      #ifdef HAS_GT911_TOUCH
+        /*
+         * GT911 only reports a new data frame periodically. getPoint()
+         * clears that frame, so an immediate second poll may return zero
+         * even though the finger is still touching the panel.
+         *
+         * Keep the touch logically pressed across short gaps. A genuine
+         * release is reported only after no GT911 frame has arrived for
+         * GT911_RELEASE_MS.
+         */
+        static bool gt911_down = false;
+        static uint32_t gt911_last_frame = 0;
+        static uint16_t gt911_last_x = 0;
+        static uint16_t gt911_last_y = 0;
+
+        constexpr uint32_t GT911_RELEASE_MS = 100;
+
+        if (!cyd_gt911_ready) {
+          gt911_down = false;
+          return 0;
+        }
+
+        int16_t gt_x[1] = {0};
+        int16_t gt_y[1] = {0};
+
+        const uint8_t point_count =
+          cyd_gt911.getPoint(gt_x, gt_y, 1);
+
+        if (point_count > 0) {
+          const int32_t raw_x = gt_x[0];
+          const int32_t raw_y = gt_y[0];
+
+          uint16_t screen_x = 0;
+          uint16_t screen_y = 0;
+
+          switch (this->tft.getRotation()) {
+            case 0:
+              screen_x = raw_x;
+              screen_y = raw_y;
+              break;
+
+            case 1:
+              screen_x = raw_y;
+              screen_y = (TFT_WIDTH - 1) - raw_x;
+              break;
+
+            case 2:
+              screen_x = (TFT_WIDTH - 1) - raw_x;
+              screen_y = (TFT_HEIGHT - 1) - raw_y;
+              break;
+
+            case 3:
+              screen_x = (TFT_HEIGHT - 1) - raw_y;
+              screen_y = raw_x;
+              break;
+
+            default:
+              gt911_down = false;
+              return 0;
+          }
+
+          gt911_last_x = screen_x;
+          gt911_last_y = screen_y;
+          gt911_last_frame = millis();
+          gt911_down = true;
+
+          *x = screen_x;
+          *y = screen_y;
+          return 1;
+        }
+
+        /*
+         * Ignore short zero-report gaps between valid GT911 frames.
+         * Keep returning the most recent coordinate while the debounce
+         * interval has not expired.
+         */
+        if (gt911_down &&
+            static_cast<uint32_t>(millis() - gt911_last_frame)
+              < GT911_RELEASE_MS) {
+          *x = gt911_last_x;
+          *y = gt911_last_y;
+          return 1;
+        }
+
+        gt911_down = false;
+        return 0;
+
+      #elif defined(HAS_CAP_TOUCH)
         // FT6336 capacitive touch: rotation-aware + edge exclusion
         {
           uint16_t raw_x, raw_y;
@@ -158,7 +253,7 @@ void Display::init() {
 }
 
 void Display::setCalData(bool landscape) {
-  #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH)
+  #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH) && !defined(HAS_GT911_TOUCH)
     if (!landscape) {
       #ifdef TFT_SHIELD
         uint16_t calData[5] = { 275, 3494, 361, 3528, 4 }; // tft.setRotation(0); // Portrait with TFT Shield
@@ -216,11 +311,32 @@ void Display::RunSetup() {
 
   tft.setRotation(SCREEN_ORIENTATION);
 
+  #ifdef HAS_GT911_TOUCH
+    cyd_gt911.setPins(-1, TOUCH_INT);
+
+    cyd_gt911_ready =
+      cyd_gt911.begin(Wire, 0x5D, TOUCH_SDA, TOUCH_SCL);
+
+    if (!cyd_gt911_ready) {
+      cyd_gt911_ready =
+        cyd_gt911.begin(Wire, 0x14, TOUCH_SDA, TOUCH_SCL);
+    }
+
+    if (cyd_gt911_ready) {
+      cyd_gt911.setMaxCoordinates(TFT_WIDTH, TFT_HEIGHT);
+      cyd_gt911.setSwapXY(false);
+      cyd_gt911.setMirrorXY(false, false);
+      Serial.println("GT911 capacitive touch initialized");
+    } else {
+      Serial.println("ERROR: GT911 not detected at 0x5D or 0x14");
+    }
+  #endif
+
   tft.setCursor(0, 0);
 
   #ifdef HAS_ILI9341
 
-    #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH)
+    #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH) && !defined(HAS_GT911_TOUCH)
       this->setCalData();
     #endif
 

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -326,6 +326,13 @@
 
   #ifdef MARAUDER_CYD_3_5_INCH
     #define HAS_TOUCH
+    #define HAS_GT911_TOUCH
+
+    // ESP32-3248S035C GT911 capacitive touch
+    #define TOUCH_SDA 33
+    #define TOUCH_SCL 32
+    #define TOUCH_INT 21
+    #define TOUCH_RST 25
     #define HAS_FLIPPER_LED
     //#define FLIPPER_ZERO_HAT
     //#define HAS_BATTERY


### PR DESCRIPTION
## Summary

This draft PR adds GT911 capacitive-touch support for the ESP32-3248S035C 3.5-inch CYD board.

Tested hardware:

- ESP32-D0WD-V3
- 4 MB flash
- ST7796 display, 320 × 480
- GT911 capacitive-touch controller
- GT911 SDA: GPIO33
- GT911 SCL: GPIO32
- GT911 INT: GPIO21
- GT911 detected at either `0x5D` or `0x14`

## Implemented changes

- Adds a `HAS_GT911_TOUCH` configuration.
- Defines the GT911 I2C pins for ESP32-3248S035C.
- Initializes GT911 over I2C.
- Tries both common controller addresses, `0x5D` and `0x14`.
- Adds rotation-aware touch-coordinate conversion.
- Skips TFT_eSPI resistive-touch calibration for the GT911 build.
- Adds a 100 ms touch-release debounce.

## Why the debounce is needed

`TouchDrvGT911::getPoint()` clears the controller's current data-ready frame after reading it.

A rapid following poll may therefore temporarily report no touch even while the finger is still physically touching the screen. Marauder can interpret that temporary empty frame as a release, causing one physical tap to activate two menu actions.

The patch keeps the previous valid touch position active for 100 ms after the last GT911 frame. This fixed the duplicate-menu-action problem on the tested board.

## Test results

The following were tested successfully on physical hardware:

- firmware compilation;
- full bootloader, partition table, boot_app0 and application flash;
- application-only update at `0x10000`;
- ST7796 display initialization;
- GT911 initialization;
- touch-coordinate alignment;
- main-menu navigation;
- submenu navigation;
- one physical tap producing one menu action.

Tested build environment:

- ESP32 Marauder base: v1.13.0
- ESP32 Arduino core: 2.0.11
- Board FQBN: `esp32:esp32:d32:PartitionScheme=min_spiffs`
- TFT_eSPI: 2.5.34
- SensorLib: 0.2.2

## Compatibility considerations

The existing `MARAUDER_CYD_3_5_INCH` target does not currently have a GT911-specific flag and appears to represent the resistive-touch variant.

Its TFT_eSPI setup defines GPIO33 as resistive `TOUCH_CS`, while the capacitive ESP32-3248S035C uses GPIO33 as GT911 SDA.

This draft adds GT911 support directly to `MARAUDER_CYD_3_5_INCH`.

For upstream integration, the maintainers may prefer to:

1. keep GT911 under the existing `MARAUDER_CYD_3_5_INCH` target;
2. create a separate target such as `MARAUDER_CYD_3_5_INCH_CAP`;
3. select the touch controller through a separate build flag.

A separate capacitive target would preserve the existing resistive 3.5-inch build unchanged.

## Build-system dependency

This implementation uses:

```cpp
#include <TouchDrvGT911.hpp>
```

from SensorLib.

The GitHub Actions workflow will therefore need to install a compatible SensorLib revision for the capacitive target. The current upstream build workflow does not appear to install SensorLib.

## Scope of this contribution

This branch is provided as a working, hardware-tested implementation for the ESP32-3248S035C capacitive-touch variant.

It was developed and tested against ESP32 Marauder v1.13.0. I am sharing the code so the maintainers can review, adapt, split into a separate target, or cherry-pick the relevant changes as they prefer.

The branch is based on v1.13.0 rather than the latest `master`, and the upstream build workflow does not currently install SensorLib.

This PR is opened as a draft because it is primarily a tested code contribution and reference implementation, rather than a merge-ready upstream integration.