### PR TITLE
Buffer::createFile: check open(), bound the name search, use a /pcaps subdir

### DIFF
--- a/esp32_marauder/Buffer.cpp
+++ b/esp32_marauder/Buffer.cpp
@@ -1,36 +1,70 @@
 #include "Buffer.h"
 #include "lang_var.h"
+#include <Preferences.h>   // persist the pcap name-index hint (avoids an O(N^2) rescan)
 
 Buffer::Buffer(){
   bufA = (uint8_t*)malloc(BUF_SIZE);
   bufB = (uint8_t*)malloc(BUF_SIZE);
 }
 
+// Directory-entry safety cap on the verify scan: set well above what a FAT16 /pcaps
+// subdir can hold (~30k after LFN), so the exists()-verify can always find a real gap.
+#define PCAP_MAX_INDEX 65536
+
 void Buffer::createFile(const char* name, bool is_pcap, bool is_gpx){
-  int i=0;
-  if (is_pcap) {
-    do{
-      fileName = "/"+String(name)+"_"+(String)i+".pcap";
-      i++;
-    } while(fs->exists(fileName));
-  }
-  else if ((!is_pcap) && (!is_gpx)) {
-    do{
-      fileName = "/"+String(name)+"_"+(String)i+".log";
-      i++;
-    } while(fs->exists(fileName));
-  }
-  else {
-    do{
-      fileName = "/"+String(name)+"_"+(String)i+".gpx";
-      i++;
-    } while(fs->exists(fileName));
+  const char* ext = is_pcap ? ".pcap" : (is_gpx ? ".gpx" : ".log");
+
+  if (!is_pcap) {
+    // logs/gpx keep the historical SD-root path + a simple bounded, checked search.
+    bool found = false;
+    for (int i = 0; i < PCAP_MAX_INDEX; i++) {
+      fileName = "/" + String(name) + "_" + (String)i + ext;
+      if (!fs->exists(fileName)) { found = true; break; }
+    }
+    if (!found) { Serial.println("createFile: directory full - not saving"); return; }
+    Serial.println(fileName);
+    file = fs->open(fileName, FILE_WRITE);
+    if (!file) { Serial.println("createFile: open failed - not saving"); return; }
+    file.close();
+    return;
   }
 
+  // --- pcap ---------------------------------------------------------------------
+  // 1) Write into a /pcaps/ subdirectory, not the SD ROOT. The root is the most
+  //    entry-limited region on FAT (FAT16 root is a hard ~512-entry cap), so a busy
+  //    card stops accepting new root files; a subdir grows to the ~65k FAT ceiling
+  //    and keeps the card tidy.
+  // 2) Pick the next name from a PERSISTED index hint instead of scanning from 0
+  //    every time. The old "increment i from 0 while fs->exists()" is ~O(N^2) because
+  //    each fs->exists() linearly scans the directory -- it does not scale to the tens
+  //    of thousands a subdir can hold.
+  // 3) VERIFY the hint with fs->exists() and advance on collision. The hint lives in
+  //    the board's NVS but the files live on the SD card, so a card swap can desync
+  //    them; verifying means we can NEVER truncate/overwrite an existing capture.
+  //    Creating /pcaps (fresh/empty/swapped card) resets the hint so each card
+  //    numbers cleanly from _0.
+  // 4) CHECK fs->open()'s return. The old code ignored it and wrote the pcap header
+  //    into an invalid File on a full dir/card -- a silent capture loss.
+  Preferences prefs;
+  prefs.begin("pcap", false);
+  uint32_t hint;
+  if (!fs->exists("/pcaps")) { fs->mkdir("/pcaps"); hint = 0; }
+  else                       { hint = prefs.getULong("next", 0); }
+
+  bool found = false;
+  uint32_t idx = hint;
+  for (int scanned = 0; scanned < PCAP_MAX_INDEX; scanned++, idx++) {
+    fileName = "/pcaps/" + String(name) + "_" + String(idx) + ext;
+    if (!fs->exists(fileName)) { found = true; break; }   // usually the first probe
+  }
+  if (!found) { prefs.end(); Serial.println("createFile: /pcaps full - not saving"); return; }
+
   Serial.println(fileName);
-  
   file = fs->open(fileName, FILE_WRITE);
+  if (!file) { prefs.end(); Serial.println("createFile: open failed (SD/dir full) - not saving"); return; }
   file.close();
+  prefs.putULong("next", idx + 1);   // advance the hint past the name we just claimed
+  prefs.end();
 }
 
 void Buffer::open(bool is_pcap){


### PR DESCRIPTION
### Problem
`Buffer::createFile()` picked a filename with an **unbounded** loop that increments from 0, then opened it **without checking the result**, writing to the **SD root**:
```cpp
do { fileName = "/"+String(name)+"_"+(String)i+".pcap"; i++; } while(fs->exists(fileName));
file = fs->open(fileName, FILE_WRITE);   // return value ignored
file.close();
```
Three issues:
1. **Unchecked `open()`** — when the directory can't accept an entry (FAT16 root is a hard ~512-entry cap; LFN amplifies it) or the card is full, `open()` returns an invalid `File`. The code closed it and later wrote the pcap header into it → **silent capture loss, no user feedback.**
2. **Root directory** — the most entry-limited region on FAT; a busy card stops accepting new root files at a few hundred captures.
3. **~O(N²) naming** — scanning from `_0` while `fs->exists()` (which itself linearly scans the directory) means finding a free name in a directory with N files costs ~O(N²). It doesn't scale to the tens of thousands a subdirectory can hold; capture-start would hang for seconds→minutes.

### Fix
- **`/pcaps/` subdirectory** (`mkdir` once) instead of the root — grows to the ~65k FAT ceiling, off the root cap, tidier card.
- **Persisted name-index hint** (`Preferences`) so the next name is O(1) instead of an O(N²) rescan from 0.
- **`exists()`-verify the hint and advance on collision.** The hint lives in the board's NVS but the files live on the SD card, so a **card swap** can desync them — verifying means a stale hint can **never truncate/overwrite an existing capture**. Creating `/pcaps` (fresh/swapped card) resets the hint so each card numbers cleanly from `_0`.
- **Check `fs->open()`** and bail with a logged reason on failure.

`.log`/`.gpx` keep their historical root path (now bounded + checked). Uses ESP32 `Preferences` (already a core dependency for this target).

### Testing (hardware, ESP32-S3, downstream fork carrying this change)
- **Directory full** → capture reports the failure and writes nothing (was: silent no-file).
- **Normal ×2** → `raw_0` then `raw_1`; the hint advances, O(1), no rescan.
- **Card-swap simulation** — card pre-loaded with `raw_0..raw_5`, board hint stale at `1`: the new capture lands on `raw_6` and **`raw_0..raw_5` are all left intact** (the `exists()`-verify prevents the overwrite a bare counter would cause).

A downstream variant also surfaces the failure in the UI (a persistent "not saved — SD full / too many files" notice); upstream keeps the `Serial` log to stay minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)