### PR TITLE
Add GT911 capacitive touch support for CYD 3.5" (3248S035C)

### DIFF
--- a/esp32_marauder/Display.cpp
+++ b/esp32_marauder/Display.cpp
@@ -81,6 +81,44 @@ uint8_t Display::updateTouch(uint16_t *x, uint16_t *y, uint16_t threshold) {
           }
           return 1;
         }
+      #elif defined(HAS_GT911_TOUCH)
+        // GT911 capacitive touch. Rotation 0 (startup portrait) and
+        // rotation 1 (landscape, used by Packet Monitor) are both
+        // hardware-verified. Rotation 2 is currently unreachable dead
+        // code - grep the whole project, nothing ever calls
+        // setRotation(2) - so it's a logical best-effort (mirrors
+        // rotation 0 on both axes) rather than a tested value. Rotation
+        // 3 is real but Pancake-only (HAS_CAP_TOUCH path above), so it
+        // never executes for this board either.
+        {
+          uint16_t raw_x, raw_y;
+          if (!gt911_read_raw(&raw_x, &raw_y)) return 0;
+
+          uint8_t rot = this->tft.getRotation();
+          switch (rot) {
+            case 0: // Portrait, startup default - verified
+              *x = raw_x;
+              *y = raw_y;
+              break;
+            case 1: // Landscape, e.g. Packet Monitor - verified
+              *x = raw_y;
+              *y = (TFT_WIDTH - 1) - raw_x;
+              break;
+            case 2: // Unreachable currently - untested
+              *x = (TFT_WIDTH - 1) - raw_x;
+              *y = (TFT_HEIGHT - 1) - raw_y;
+              break;
+            case 3: // Pancake-only in practice - untested for this board
+              *x = (TFT_HEIGHT - 1) - raw_y;
+              *y = raw_x;
+              break;
+            default:
+              *x = raw_x;
+              *y = raw_y;
+              break;
+          }
+          return 1;
+        }
       #elif !defined(HAS_CYD_TOUCH)
         return this->tft.getTouch(x, y, threshold);
       #else
@@ -158,7 +196,7 @@ void Display::init() {
 }
 
 void Display::setCalData(bool landscape) {
-  #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH)
+  #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH) && !defined(HAS_GT911_TOUCH)
     if (!landscape) {
       #ifdef TFT_SHIELD
         uint16_t calData[5] = { 275, 3494, 361, 3528, 4 }; // tft.setRotation(0); // Portrait with TFT Shield
@@ -211,7 +249,11 @@ void Display::RunSetup() {
   #ifdef HAS_CAP_TOUCH
     ft6336_init();
   #endif
-  
+
+  #ifdef HAS_GT911_TOUCH
+    gt911_init();
+  #endif
+
   tft.init();
 
   tft.setRotation(SCREEN_ORIENTATION);
@@ -220,7 +262,7 @@ void Display::RunSetup() {
 
   #ifdef HAS_ILI9341
 
-    #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH)
+    #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH) && !defined(HAS_GT911_TOUCH)
       this->setCalData();
     #endif
 

--- a/esp32_marauder/Display.h
+++ b/esp32_marauder/Display.h
@@ -24,6 +24,10 @@
   #include "ft6336.h"
 #endif
 
+#ifdef HAS_GT911_TOUCH
+  #include "gt911.h"
+#endif
+
 // WiFi stuff
 #define OTA_UPDATE 100
 #define SHOW_INFO 101

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -351,6 +351,17 @@
     #define HAS_TEMP_SENSOR
     #define HAS_GPS
     //#define HAS_CYD_TOUCH
+    #define HAS_GT911_TOUCH // 3248S035C capacitive variant; leave undefined for the 035R resistive variant
+    #ifdef HAS_GT911_TOUCH
+      // Own I2C pins - does NOT share the I2C_SDA/I2C_SCL bus defined
+      // elsewhere for this board (that one's gated under HAS_BATTERY,
+      // which this board doesn't set, and is for the temp sensor anyway).
+      // Values per community CYD Marauder port (Fr4nkFletcher), not yet
+      // confirmed against every 3248S035C board revision.
+      #define GT911_SDA 33
+      #define GT911_SCL 32
+      #define GT911_INT 21
+    #endif
     #define HAS_SEPARATE_SD
     #define HAS_CYD_PORTRAIT
     //#define HAS_NIMBLE_2
@@ -1599,7 +1610,7 @@
       //#define MENU_FONT &FreeMonoBold9pt7b
       //#define MENU_FONT &FreeSans9pt7b
       //#define MENU_FONT &FreeSansBold9pt7b
-      #define BUTTON_SCREEN_LIMIT 12
+      #define BUTTON_SCREEN_LIMIT 18 // was 12; (480-50)/23px_per_row = 18.7, so 18 rows still fits
       #define BUTTON_ARRAY_LEN BUTTON_SCREEN_LIMIT
       #define STATUS_BAR_WIDTH 16
       #define LVGL_TICK_PERIOD 6
@@ -2274,9 +2285,9 @@
 
   #if defined(MARAUDER_CYD_3_5_INCH)
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 160 // Centre of key
     #define KEY_Y 50

--- a/esp32_marauder/gt911.h
+++ b/esp32_marauder/gt911.h
@@ -1,0 +1,100 @@
+#pragma once
+#ifndef gt911_h
+#define gt911_h
+
+#ifdef HAS_GT911_TOUCH
+
+#include <Wire.h>
+
+#define GT911_ADDR1      0x5D
+#define GT911_ADDR2      0x14
+#define GT911_POINT_INFO 0x814E
+#define GT911_POINT_1    0x814F
+
+static uint8_t _gt911_addr = GT911_ADDR1;
+
+static bool _gt911_read_block(uint16_t reg, uint8_t *buf, uint8_t len) {
+    Wire.beginTransmission(_gt911_addr);
+    Wire.write((uint8_t)(reg >> 8));
+    Wire.write((uint8_t)(reg & 0xFF));
+    if (Wire.endTransmission(false) != 0) return false;
+    Wire.requestFrom((int)_gt911_addr, (int)len);
+    for (uint8_t i = 0; i < len; i++)
+        buf[i] = Wire.available() ? Wire.read() : 0;
+    return true;
+}
+
+static bool _gt911_write_reg(uint16_t reg, uint8_t val) {
+    Wire.beginTransmission(_gt911_addr);
+    Wire.write((uint8_t)(reg >> 8));
+    Wire.write((uint8_t)(reg & 0xFF));
+    Wire.write(val);
+    return Wire.endTransmission() == 0;
+}
+
+static void gt911_init() {
+    pinMode(GT911_INT, INPUT);
+    Wire.begin(GT911_SDA, GT911_SCL, 400000U);
+
+    // GT911's I2C address depends on the INT pin level during the chip's
+    // own power-on reset, which we don't control here, so probe both.
+    uint8_t probe;
+    _gt911_addr = GT911_ADDR1;
+    if (!_gt911_read_block(GT911_POINT_INFO, &probe, 1)) {
+        _gt911_addr = GT911_ADDR2;
+    }
+    Serial.printf("[Touch] GT911 @ 0x%02X\n", _gt911_addr);
+}
+
+static uint16_t _gt911_last_x = 0;
+static uint16_t _gt911_last_y = 0;
+static bool _gt911_last_touched = false;
+
+// Reads raw panel coordinates as reported by the GT911 (native panel
+// space, before any rotation/axis mapping). Call this when you need to
+// apply a rotation-specific transform, same convention as ft6336_read_raw().
+//
+// The GT911 only raises its "new data" bit once per its own internal scan
+// cycle. Our main loop polls faster than that, so a naive "not ready yet
+// -> not touched" read flickers true/false many times over a single
+// physical touch, which the button widget's edge-detection reads as
+// several rapid taps. We hold the last known touched state across any
+// "not ready" poll and only update it when the chip reports fresh data.
+static uint8_t gt911_read_raw(uint16_t *raw_x, uint16_t *raw_y) {
+    uint8_t status;
+    if (!_gt911_read_block(GT911_POINT_INFO, &status, 1)) {
+        *raw_x = _gt911_last_x;
+        *raw_y = _gt911_last_y;
+        return _gt911_last_touched ? 1 : 0;
+    }
+
+    if ((status & 0x80) == 0) {
+        // No fresh sample since our last ack - not a release, just an
+        // in-between poll. Report the last known state instead of 0.
+        *raw_x = _gt911_last_x;
+        *raw_y = _gt911_last_y;
+        return _gt911_last_touched ? 1 : 0;
+    }
+
+    uint8_t touches = status & 0x0F;
+    if (touches == 0) {
+        _gt911_write_reg(GT911_POINT_INFO, 0);
+        _gt911_last_touched = false;
+        return 0;
+    }
+
+    uint8_t data[7];
+    _gt911_read_block(GT911_POINT_1, data, 7);
+    _gt911_write_reg(GT911_POINT_INFO, 0);  // ack so the chip prepares the next sample
+
+    _gt911_last_x = data[1] | ((uint16_t)data[2] << 8);
+    _gt911_last_y = data[3] | ((uint16_t)data[4] << 8);
+    _gt911_last_touched = true;
+
+    *raw_x = _gt911_last_x;
+    *raw_y = _gt911_last_y;
+    return 1;
+}
+
+#endif // HAS_GT911_TOUCH
+#endif // gt911_h


### PR DESCRIPTION
## Summary
- The `cyd_3_5_inch` build only wires up XPT2046 (resistive) touch, but the 3248S035C variant of this board uses a GT911 capacitive touch controller, so touch never worked on it. Adds a minimal GT911 driver (`gt911.h`, mirrors the existing `ft6336.h` pattern, no external library) behind a new `HAS_GT911_TOUCH` flag, wired in alongside the existing touch paths in `Display.h`/`Display.cpp`.
- Fixes a debounce issue where polling faster than the GT911's own internal scan rate made one physical tap fire the button widget's release-edge detection dozens of times - fixed by latching the last known touch state across the chip's "not ready yet" polls instead of treating that as a release.
- Bumps `BUTTON_SCREEN_LIMIT` 12 -> 18 for this board specifically - at the existing 22px row height there was room for far more rows than were ever drawn, leaving most of the 480px-tall screen blank on short menus.
- Fixes the `HAS_GT911_TOUCH` rotation-2 case to mirror both axes (was left as an inconsistent passthrough copy-pasted from rotation 0, from before the rotation-0 flip direction was corrected against real hardware).

## Known unverified
- `GT911_SDA`/`GT911_SCL`/`GT911_INT` (33/32/21, borrowed from the community Fr4nkFletcher CYD fork's proven mapping) confirmed working on one physical unit via I2C probe ack at `0x5D`; not confirmed across other 3248S035C revisions, which are known to vary silently on these boards.
- The `GT911_ADDR2` (`0x14`) fallback path in `gt911_init()` has never actually been exercised - this unit always resolves at `0x5D`.
- Rotation 2 is dead code project-wide as of this PR (nothing calls `setRotation(2)` anywhere), so that fix is a logical correction, not a hardware-tested one. Rotation 3 is real but Pancake-only (`HAS_CAP_TOUCH`), so it never executes for this board.

## Test plan
- [x] Menu navigation (top-level menu, submenus)
- [x] On-screen keyboard (WiFi password entry via Join WiFi)
- [x] Packet Monitor - all buttons (X/Y zoom +/-, channel +/-, exit), rotation 1
- [x] Menus with more than 12 items, with the new `BUTTON_SCREEN_LIMIT`
- [ ] Other 3248S035C board revisions (only tested on one unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)