### PR TITLE
Add support for ESP32-2432S022 / ESP32-2432S022C CYD

### DIFF
--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -34,6 +34,8 @@ jobs:
           - { name: "Marauder CYD 2432S024 GUITION", flag: "MARAUDER_CYD_GUITION",     fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_2432S024_guition",    tft: true,  tft_file: "User_Setup_cyd_guition.h",           build_dir: "d32",                        addr: "0x1000",   idf_ver: "2.0.11",   nimble_ver: "1.3.8",    esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "Marauder CYD 2432S028 2 USB",   flag: "MARAUDER_CYD_2USB",        fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_2432S028_2usb",       tft: true,  tft_file: "User_Setup_cyd_2usb.h",              build_dir: "d32",                        addr: "0x1000",   idf_ver: "3.3.4",    nimble_ver: "2.3.8",   esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "Marauder CYD 3.5inch",          flag: "MARAUDER_CYD_3_5_INCH",    fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_3_5_inch",            tft: true,  tft_file: "User_Setup_cyd_3_5_inch.h",          build_dir: "d32",                        addr: "0x1000",   idf_ver: "2.0.11",   nimble_ver: "1.3.8",    esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
+          - { name: "Marauder CYD 2432S022",         flag: "CYD_2432S022",             fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_2432S022",            tft: false, tft_file: "",                                   build_dir: "d32",                        addr: "0x1000",   idf_ver: "3.3.4",    nimble_ver: "2.3.8",   esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
+          - { name: "Marauder CYD 2432S022C",        flag: "ESP32_2432S022C",          fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_2432S022C",           tft: false, tft_file: "",                                   build_dir: "d32",                        addr: "0x1000",   idf_ver: "3.3.4",    nimble_ver: "2.3.8",   esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "M5Cardputer",                   flag: "MARAUDER_CARDPUTER",       fbqn: "esp32:esp32:esp32s3:PartitionScheme=min_spiffs,FlashSize=8M,PSRAM=disabled",                    file_name: "m5cardputer",             tft: true,  tft_file: "User_Setup_marauder_m5cardputer.h",  build_dir: "esp32s3",                    addr: "0x1000",   idf_ver: "2.0.11",   nimble_ver: "1.3.8",    esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "M5Cardputer ADV",               flag: "MARAUDER_CARDPUTER_ADV",   fbqn: "esp32:esp32:esp32s3:PartitionScheme=min_spiffs,FlashSize=8M,PSRAM=disabled",                    file_name: "m5cardputer_adv",         tft: true,  tft_file: "User_Setup_marauder_m5cardputer_adv.h",  build_dir: "esp32s3",                addr: "0x1000",   idf_ver: "2.0.11",   nimble_ver: "1.3.8",    esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "ESP32-C5-DevKitC-1",            flag: "MARAUDER_C5",              fbqn: "esp32:esp32:esp32c5:FlashSize=8M,PartitionScheme=min_spiffs,PSRAM=enabled",                     file_name: "esp32c5devkitc1",         tft: false, tft_file: "",                                   build_dir: "esp32c5",                    addr: "0x2000",   idf_ver: "3.3.4",    nimble_ver: "2.3.8",   esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
@@ -112,6 +114,13 @@ jobs:
           repository: ${{ matrix.board.tft_repo || 'Bodmer/TFT_eSPI' }}
           ref: ${{ matrix.board.tft_ref || 'V2.5.34' }}
           path: CustomTFT_eSPI
+
+      - name: Install LovyanGFX
+        uses: actions/checkout@v2
+        with:
+          repository: lovyan03/LovyanGFX
+          ref: 1.2.7
+          path: CustomLovyanGFX
 
       - name: Install XPT2046_Touchscreen
         uses: actions/checkout@v2
@@ -332,6 +341,8 @@ jobs:
             | CYD 2432S028(R) | `_cyd_2432S028.bin` |
             | RL Phantom | `_cyd_2432S024_guition.bin` |
             | CYD 2432S028 2 USB | `_cyd_2432S028_2usb.bin` |
+            | CYD 2432S022 | `_cyd_2432S022.bin` |
+            | CYD 2432S022C | `_cyd_2432S022C.bin` |
             | M5 Cardputer | `_m5cardputer.bin` (Available on M5 Burner) |
             | M5 Cardputer ADV | `_m5cardputer_adv.bin` |
             | ESP32-C5 DevKit | [`_esp32c5_devkit.bin`](https://github.com/justcallmekoko/ESP32Marauder/wiki/ESP32%E2%80%90C5%E2%80%90DevKitC%E2%80%901) |

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -97,6 +97,8 @@ jobs:
           - { name: "Marauder CYD 2432S024 GUITION", flag: "MARAUDER_CYD_GUITION",     fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_2432S024_guition",    tft: true,  tft_file: "User_Setup_cyd_guition.h",           build_dir: "d32",                        addr: "0x1000",   idf_ver: "2.0.11",   nimble_ver: "1.3.8",    esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "Marauder CYD 2432S028 2 USB",   flag: "MARAUDER_CYD_2USB",        fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_2432S028_2usb",       tft: true,  tft_file: "User_Setup_cyd_2usb.h",              build_dir: "d32",                        addr: "0x1000",   idf_ver: "3.3.4",    nimble_ver: "2.3.8",   esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "Marauder CYD 3.5inch",          flag: "MARAUDER_CYD_3_5_INCH",    fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_3_5_inch",            tft: true,  tft_file: "User_Setup_cyd_3_5_inch.h",          build_dir: "d32",                        addr: "0x1000",   idf_ver: "2.0.11",   nimble_ver: "1.3.8",    esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
+          - { name: "Marauder CYD 2432S022",         flag: "CYD_2432S022",             fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_2432S022",            tft: false, tft_file: "",                                   build_dir: "d32",                        addr: "0x1000",   idf_ver: "3.3.4",    nimble_ver: "2.3.8",   esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
+          - { name: "Marauder CYD 2432S022C",        flag: "ESP32_2432S022C",          fbqn: "esp32:esp32:d32:PartitionScheme=min_spiffs",                                                    file_name: "cyd_2432S022C",           tft: false, tft_file: "",                                   build_dir: "d32",                        addr: "0x1000",   idf_ver: "3.3.4",    nimble_ver: "2.3.8",   esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "M5Cardputer",                   flag: "MARAUDER_CARDPUTER",       fbqn: "esp32:esp32:esp32s3:PartitionScheme=min_spiffs,FlashSize=8M,PSRAM=disabled",                    file_name: "m5cardputer",             tft: true,  tft_file: "User_Setup_marauder_m5cardputer.h",  build_dir: "esp32s3",                    addr: "0x1000",   idf_ver: "2.0.11",   nimble_ver: "1.3.8",    esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "M5Cardputer ADV",               flag: "MARAUDER_CARDPUTER_ADV",   fbqn: "esp32:esp32:esp32s3:PartitionScheme=min_spiffs,FlashSize=8M,PSRAM=disabled",                    file_name: "m5cardputer_adv",         tft: true,  tft_file: "User_Setup_marauder_m5cardputer_adv.h",  build_dir: "esp32s3",                addr: "0x1000",   idf_ver: "2.0.11",   nimble_ver: "1.3.8",    esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
           - { name: "ESP32-C5-DevKitC-1",            flag: "MARAUDER_C5",              fbqn: "esp32:esp32:esp32c5:FlashSize=8M,PartitionScheme=min_spiffs,PSRAM=enabled",                     file_name: "esp32c5devkitc1",         tft: false, tft_file: "",                                   build_dir: "esp32c5",                    addr: "0x2000",   idf_ver: "3.3.4",    nimble_ver: "2.3.8",   esp_async: "bigbrodude6119/ESPAsyncWebServer",    esp_async_ver: "master" }
@@ -165,6 +167,13 @@ jobs:
           repository: Bodmer/TFT_eSPI
           ref: V2.5.34
           path: CustomTFT_eSPI
+
+      - name: Install LovyanGFX
+        uses: actions/checkout@v2
+        with:
+          repository: lovyan03/LovyanGFX
+          ref: 1.2.7
+          path: CustomLovyanGFX
           
       - name: Install XPT2046_Touchscreen
         uses: actions/checkout@v2
@@ -423,10 +432,11 @@ jobs:
             | CYD 2432S028(R) | `_cyd_2432S028.bin` |
             | RL Phantom | `_cyd_2432S024_guition.bin` |
             | CYD 2432S028 2 USB | `_cyd_2432S028_2usb.bin` |
+            | CYD 2432S022 | `_cyd_2432S022.bin` |
+            | CYD 2432S022C | `_cyd_2432S022C.bin` |
             | M5 Cardputer | `_m5cardputer.bin` (Available on M5 Burner) |
             | M5 Cardputer ADV | `_m5cardputer_adv.bin` |
             | ESP32-C5 DevKit | [`_esp32c5_devkit.bin`](https://github.com/justcallmekoko/ESP32Marauder/wiki/ESP32%E2%80%90C5%E2%80%90DevKitC%E2%80%901) |
             | AWOK V2/V3 screen (white usb) | `_v6_1.bin` |
             | AWOK V2 flipper (orange usb) | `_flipper.bin` |
             | AWOK V3 flipper (orange usb) | `_marauder_dev_board_pro.bin` |
-

--- a/esp32_marauder/Display.cpp
+++ b/esp32_marauder/Display.cpp
@@ -42,7 +42,13 @@ int8_t Display::menuButton(uint16_t *x, uint16_t *y, bool pressed, bool check_ho
 uint8_t Display::updateTouch(uint16_t *x, uint16_t *y, uint16_t threshold) {
   #ifdef HAS_ILI9341
     if (!this->headless_mode) {
-      #ifdef HAS_CAP_TOUCH
+      #if defined(CYD_2432S022)
+        #if defined(CYD_2432S022C_TOUCH)
+          return this->tft.getTouch(x, y) ? 1 : 0;
+        #else
+          return 0;
+        #endif
+      #elif defined(HAS_CAP_TOUCH)
         // FT6336 capacitive touch: rotation-aware + edge exclusion
         {
           uint16_t raw_x, raw_y;
@@ -152,13 +158,17 @@ bool Display::isTouchHeld(uint16_t threshold) {
 void Display::init() {
   tft.init();
 
+  #if defined(CYD_2432S022)
+    tft.setBrightness(255);
+  #endif
+
   #if defined(HAS_DUAL_BAND) && !defined(MARAUDER_MINI_V3)
     digitalWrite(TFT_BL, HIGH);
   #endif
 }
 
 void Display::setCalData(bool landscape) {
-  #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH)
+  #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH) && !defined(HAS_LGFX_DISPLAY)
     if (!landscape) {
       #ifdef TFT_SHIELD
         uint16_t calData[5] = { 275, 3494, 361, 3528, 4 }; // tft.setRotation(0); // Portrait with TFT Shield
@@ -214,13 +224,17 @@ void Display::RunSetup() {
   
   tft.init();
 
+  #if defined(CYD_2432S022)
+    tft.setBrightness(255);
+  #endif
+
   tft.setRotation(SCREEN_ORIENTATION);
 
   tft.setCursor(0, 0);
 
   #ifdef HAS_ILI9341
 
-    #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH)
+    #if !defined(HAS_CYD_TOUCH) && !defined(HAS_CAP_TOUCH) && !defined(HAS_LGFX_DISPLAY)
       this->setCalData();
     #endif
 
@@ -550,7 +564,7 @@ void Display::scrollScreenBuffer(bool down) {
 }
 #endif
 
-void Display::processAndPrintString(TFT_eSPI& tft, const String& originalString) {
+void Display::processAndPrintString(MarauderTFT& tft, const String& originalString) {
   // Define colors
   uint16_t text_color = TFT_GREEN; // Default text color
   uint16_t background_color = TFT_BLACK; // Default background color

--- a/esp32_marauder/Display.h
+++ b/esp32_marauder/Display.h
@@ -14,7 +14,7 @@
 #include "SPIFFS.h"
 #include "Assets.h"
 
-#include <TFT_eSPI.h>
+#include "MarauderDisplayCompat.h"
 
 #ifdef HAS_CYD_TOUCH
   #include <XPT2046_Touchscreen.h>
@@ -82,12 +82,12 @@ class Display
     #ifdef SCREEN_BUFFER
       void scrollScreenBuffer(bool down = false);
     #endif
-    void processAndPrintString(TFT_eSPI& tft, const String& originalString);
+    void processAndPrintString(MarauderTFT& tft, const String& originalString);
 
   public:
     Display();
-    TFT_eSPI tft = TFT_eSPI();
-    TFT_eSPI_Button key[BUTTON_ARRAY_LEN + 4];
+    MarauderTFT tft = MarauderTFT();
+    MarauderButton key[BUTTON_ARRAY_LEN + 4];
     const String PROGMEM version_number = MARAUDER_VERSION;
 
     #ifdef HAS_CYD_TOUCH

--- a/esp32_marauder/LGFX_ESP32_2432S022.h
+++ b/esp32_marauder/LGFX_ESP32_2432S022.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#define LGFX_USE_V1
+
+#include <LovyanGFX.hpp>
+
+class LGFX_ESP32_2432S022 : public lgfx::LGFX_Device
+{
+  lgfx::Panel_ST7789 panel_instance_;
+  lgfx::Bus_Parallel8 bus_instance_;
+  lgfx::Light_PWM light_instance_;
+
+  #if defined(CYD_2432S022C_TOUCH)
+    lgfx::Touch_CST816S touch_instance_;
+  #endif
+
+public:
+  using lgfx::LGFX_Device::drawXBitmap;
+  using lgfx::LGFX_Device::setTextColor;
+
+  template <typename T1, typename T2>
+  void setTextColor(T1 fgcolor, T2 bgcolor, bool)
+  {
+    lgfx::LGFX_Device::setTextColor(fgcolor, bgcolor);
+  }
+
+  template <typename T1, typename T2>
+  void drawXBitmap(int32_t x, int32_t y, const uint8_t* bitmap, int32_t w, int32_t h,
+                   const T1& fgcolor, const T2& bgcolor)
+  {
+    lgfx::LGFX_Device::drawXBitmap(x, y, bitmap, w, h,
+                                   static_cast<uint32_t>(fgcolor),
+                                   static_cast<uint32_t>(bgcolor));
+  }
+
+  LGFX_ESP32_2432S022(void)
+  {
+    {
+      auto cfg = bus_instance_.config();
+
+      cfg.i2s_port = I2S_NUM_0;
+      cfg.freq_write = 25000000;
+      cfg.pin_wr = 4;    // WR, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_rd = 2;    // RD, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_rs = 16;   // DC/RS, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_d0 = 15;   // D0, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_d1 = 13;   // D1, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_d2 = 12;   // D2, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_d3 = 14;   // D3, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_d4 = 27;   // D4, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_d5 = 25;   // D5, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_d6 = 33;   // D6, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_d7 = 32;   // D7, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+
+      bus_instance_.config(cfg);
+      panel_instance_.setBus(&bus_instance_);
+    }
+
+    {
+      auto cfg = panel_instance_.config();
+
+      cfg.pin_cs = 17;        // CS, openHASP #606 / TFT_eSPI #3281 / Sunton JSON.
+      cfg.pin_rst = -1;       // RST not connected, openHASP #606 / Sunton JSON.
+      cfg.pin_busy = -1;
+      cfg.panel_width = 240;  // ESP32-2432S022 panel size.
+      cfg.panel_height = 320; // ESP32-2432S022 panel size.
+      cfg.offset_x = 0;
+      cfg.offset_y = 0;
+      cfg.offset_rotation = CYD_2432S022_OFFSET_ROTATION;
+      cfg.dummy_read_pixel = 8;
+      cfg.dummy_read_bits = 1;
+      cfg.readable = false;
+      cfg.invert = false;
+      cfg.rgb_order = false;
+      cfg.dlen_16bit = false;
+      cfg.bus_shared = true;
+
+      panel_instance_.config(cfg);
+    }
+
+    {
+      auto cfg = light_instance_.config();
+
+      cfg.pin_bl = 0;        // TFT_BL, TFT_eSPI #3281 / Sunton JSON DISPLAY_BCKL=0.
+      cfg.invert = false;   // TFT_eSPI #3281 reports active-high backlight.
+      cfg.freq = 44100;
+      cfg.pwm_channel = 7;
+
+      light_instance_.config(cfg);
+      panel_instance_.setLight(&light_instance_);
+    }
+
+    #if defined(CYD_2432S022C_TOUCH)
+      {
+        auto cfg = touch_instance_.config();
+
+        cfg.i2c_port = 0;
+        cfg.i2c_addr = 0x15; // CST816S address, Sunton JSON / openHASP #606.
+        cfg.pin_sda = 21;    // TOUCH_SDA, Sunton JSON / openHASP #606.
+        cfg.pin_scl = 22;    // TOUCH_SCL, Sunton JSON / openHASP #606.
+        cfg.pin_int = -1;    // INT not connected in Sunton JSON.
+        cfg.pin_rst = -1;    // RST not connected in Sunton JSON.
+        cfg.freq = 400000;
+        cfg.x_min = 0;
+        cfg.x_max = 239;
+        cfg.y_min = 0;
+        cfg.y_max = 319;
+        cfg.offset_rotation = CYD_2432S022_TOUCH_OFFSET_ROTATION;
+
+        touch_instance_.config(cfg);
+        panel_instance_.setTouch(&touch_instance_);
+      }
+    #endif
+
+    setPanel(&panel_instance_);
+  }
+};

--- a/esp32_marauder/MarauderDisplayCompat.h
+++ b/esp32_marauder/MarauderDisplayCompat.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "configs.h"
+
+#if defined(CYD_2432S022)
+  #include "LGFX_ESP32_2432S022.h"
+
+  using MarauderTFT = LGFX_ESP32_2432S022;
+
+  class MarauderButton : public LGFX_Button
+  {
+  public:
+    using LGFX_Button::drawButton;
+    using LGFX_Button::initButton;
+
+    template <typename T1, typename T2, typename T3>
+    void initButton(lgfx::LovyanGFX *gfx, int16_t x, int16_t y, uint16_t w, uint16_t h,
+                    const T1& outline, const T2& fill, const T3& textcolor,
+                    const char *label, float textsize_x = 1.0f, float textsize_y = 0.0f)
+    {
+      LGFX_Button::initButton(gfx, x, y, w, h,
+                              static_cast<uint32_t>(outline),
+                              static_cast<uint32_t>(fill),
+                              static_cast<uint32_t>(textcolor),
+                              label, textsize_x, textsize_y);
+    }
+
+    void drawButton(bool inverted, const String& long_name)
+    {
+      LGFX_Button::drawButton(inverted, long_name.c_str());
+    }
+  };
+#else
+  #include <TFT_eSPI.h>
+
+  using MarauderTFT = TFT_eSPI;
+  using MarauderButton = TFT_eSPI_Button;
+#endif

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -537,6 +537,61 @@ void MenuFunctions::main(uint32_t currentTime)
         }
       }*/
 
+      #if defined(CYD_2432S022) && defined(CYD_2432S022C_TOUCH)
+        static int8_t cyd_touched_menu_row = -1;
+        bool cyd_handled_menu_row_touch = false;
+
+        if ((wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF) ||
+            (wifi_scan_obj.currentScanMode == WIFI_CONNECTED) ||
+            (wifi_scan_obj.currentScanMode == OTA_UPDATE)) {
+          int visible_rows = current_menu->list->size() - this->menu_start_index;
+          if (visible_rows > BUTTON_SCREEN_LIMIT)
+            visible_rows = BUTTON_SCREEN_LIMIT;
+
+          int8_t touched_row = -1;
+          for (uint8_t b = 0; b < visible_rows; b++) {
+            bool row_pressed = pressed && display_obj.key[b].contains(t_x, t_y);
+            display_obj.key[b].press(row_pressed);
+            if (row_pressed)
+              touched_row = b;
+          }
+
+          if (pressed && touched_row >= 0) {
+            int target_index = this->menu_start_index + touched_row;
+            cyd_handled_menu_row_touch = true;
+
+            if (current_menu->selected != target_index) {
+              int previous_index = current_menu->selected;
+              current_menu->selected = target_index;
+              if (previous_index >= this->menu_start_index &&
+                  previous_index < this->menu_start_index + BUTTON_SCREEN_LIMIT) {
+                this->buttonNotSelected(previous_index - this->menu_start_index, previous_index);
+              }
+              this->buttonSelected(touched_row, target_index);
+            }
+
+            cyd_touched_menu_row = touched_row;
+          }
+          else if (!pressed && cyd_touched_menu_row >= 0) {
+            int target_index = this->menu_start_index + cyd_touched_menu_row;
+            if (target_index >= 0 && target_index < current_menu->list->size() &&
+                display_obj.key[cyd_touched_menu_row].justReleased()) {
+              current_menu->selected = target_index;
+              current_menu->list->get(current_menu->selected).callable();
+              cyd_handled_menu_row_touch = true;
+            }
+
+            cyd_touched_menu_row = -1;
+          }
+        }
+
+        if (cyd_handled_menu_row_touch) {
+          x = -1;
+          y = -1;
+          return;
+        }
+      #endif
+
       // Detect up, down, select
       uint8_t menu_button = display_obj.menuButton(&t_x, &t_y, pressed);
 

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -9,7 +9,7 @@
   #include "Keyboard.h"
 #endif
 
-#ifdef HAS_TOUCH
+#if defined(HAS_TOUCH) || defined(HAS_SCREEN)
   #include "TouchKeyboard.h"
 #endif
 

--- a/esp32_marauder/SDInterface.cpp
+++ b/esp32_marauder/SDInterface.cpp
@@ -21,7 +21,7 @@ bool SDInterface::initSD() {
     pinMode(SD_CS, OUTPUT);
 
     delay(10);
-    #if (defined(MARAUDER_M5STICKC)) || (defined(HAS_CYD_TOUCH)) || (defined(MARAUDER_CARDPUTER)) || (defined(MARAUDER_CARDPUTER_ADV))
+    #if (defined(MARAUDER_M5STICKC)) || (defined(HAS_CYD_TOUCH)) || (defined(HAS_SEPARATE_SD)) || (defined(MARAUDER_CARDPUTER)) || (defined(MARAUDER_CARDPUTER_ADV))
       /* Set up SPI SD Card using external pin header
       StickCPlus Header - SPI SD Card Reader
                   3v3   -   3v3

--- a/esp32_marauder/SDInterface.h
+++ b/esp32_marauder/SDInterface.h
@@ -36,7 +36,7 @@ extern Settings settings_obj;
 class SDInterface {
 
   private:
-  #if (defined(MARAUDER_M5STICKC) || defined(HAS_CYD_TOUCH) || defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV))
+  #if (defined(MARAUDER_M5STICKC) || defined(HAS_CYD_TOUCH) || defined(HAS_SEPARATE_SD) || defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV))
     SPIClass *spiExt;
   #elif defined(HAS_C5_SD)
     SPIClass* _spi;

--- a/esp32_marauder/TouchKeyboard.h
+++ b/esp32_marauder/TouchKeyboard.h
@@ -2,10 +2,11 @@
 
 #include "configs.h"
 
+#include <stddef.h>
+
 #ifdef HAS_TOUCH
 
 #include "Display.h"
-#include <stddef.h>
 #include <stdint.h>
 
 enum KeyboardResult {
@@ -27,5 +28,12 @@ enum KeyboardResult {
  * @return true if user pressed OK, false if user pressed CANCEL (or if buffer invalid).
  */
 bool keyboardInput(char *buffer, size_t bufLen, const char *title = nullptr);
+
+#else
+
+inline bool keyboardInput(char *, size_t, const char * = nullptr)
+{
+  return false;
+}
 
 #endif

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10881,7 +10881,11 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     String sidecarPath = filePath + "." + service;
     File f = SD.open(sidecarPath, FILE_WRITE);
     if (f) {
-      f.println("uploaded=" + gps_obj.getDatetime());
+      #ifdef HAS_GPS
+        f.println("uploaded=" + gps_obj.getDatetime());
+      #else
+        f.println("uploaded=");
+      #endif
       f.close();
       Serial.println("[UPLOAD] Sidecar written: " + sidecarPath);
     } else {

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -29,6 +29,8 @@
   //#define MARAUDER_CYD_2USB // Another 2432S028 but it has tWo UsBs OoOoOoO
   //#define MARAUDER_CYD_GUITION // ESP32-2432S024 GUITION
   //#define MARAUDER_CYD_3_5_INCH
+  //#define CYD_2432S022 // ESP32-2432S022, ST7789 240x320 parallel/i80 via LovyanGFX
+  //#define CYD_2432S022C_TOUCH // Optional ESP32-2432S022C CST816S I2C touch
   //#define MARAUDER_C5
   //#define MARAUDER_CARDPUTER
   //#define MARAUDER_CARDPUTER_ADV
@@ -38,6 +40,14 @@
   //#define MARAUDER_M5_NANO_C6
   //#define DUAL_MINI_C5
   //// END BOARD TARGETS
+
+  #if (defined(ESP32_2432S022) || defined(ESP32_2432S022N) || defined(ESP32_2432S022C)) && !defined(CYD_2432S022)
+    #define CYD_2432S022
+  #endif
+
+  #if defined(ESP32_2432S022C) && !defined(CYD_2432S022C_TOUCH)
+    #define CYD_2432S022C_TOUCH
+  #endif
 
   #define JSON_SETTING_SIZE 2048
 
@@ -88,6 +98,8 @@
     #define HARDWARE_NAME "CYD 3.5inch"
   #elif defined(MARAUDER_CYD_GUITION)
     #define HARDWARE_NAME "CYD 2432S024 GUITION"
+  #elif defined(CYD_2432S022)
+    #define HARDWARE_NAME "CYD 2432S022"
   #elif defined(MARAUDER_KIT)
     #define HARDWARE_NAME "Marauder Kit"
   #elif defined(MARAUDER_FLIPPER)
@@ -378,6 +390,30 @@
     #define HAS_DIRECT_UPLOAD
   #endif
 
+  #ifdef CYD_2432S022
+    #if defined(CYD_2432S022C_TOUCH)
+      #define HAS_TOUCH
+    #endif
+    //#define FLIPPER_ZERO_HAT
+    //#define HAS_BATTERY
+    #define HAS_BT
+    #define HAS_BT_REMOTE
+    //#define HAS_BUTTONS
+    //#define HAS_NEOPIXEL_LED
+    //#define HAS_PWR_MGMT
+    #define HAS_SCREEN
+    #define HAS_FULL_SCREEN
+    #define HAS_SD
+    #define USE_SD
+    #define HAS_SEPARATE_SD
+    //#define HAS_TEMP_SENSOR
+    //#define HAS_GPS
+    #define HAS_LGFX_DISPLAY
+    #define HAS_NIMBLE_2
+    #define HAS_IDF_3
+    #define HAS_DIRECT_UPLOAD
+  #endif
+
   #ifdef MARAUDER_KIT
     #define HAS_TOUCH
     //#define FLIPPER_ZERO_HAT
@@ -613,7 +649,7 @@
       #include "AXP192.h"
     #endif
 
-    #ifdef MARAUDER_M5STICKCP2 
+    #ifdef MARAUDER_M5STICKCP2
         // Prevent StickCP2 from turning off when disconnect USB cable
         #define POWER_HOLD_PIN 4
     #endif
@@ -787,7 +823,7 @@
       #define U_PULL true
       #define R_PULL true
       #define D_PULL true
-    #endif  
+    #endif
 
     #ifdef MARAUDER_CYD_MICRO
       #define L_BTN -1
@@ -957,24 +993,24 @@
       #define BUTTON_ARRAY_LEN BUTTON_SCREEN_LIMIT
       #define STATUS_BAR_WIDTH (TFT_HEIGHT/16)
       #define LVGL_TICK_PERIOD 6
-    
+
       #define FRAME_X 100
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
 
     #endif
@@ -1107,24 +1143,24 @@
       #define BUTTON_ARRAY_LEN 100
       #define STATUS_BAR_WIDTH (SCREEN_HEIGHT/16)
       #define LVGL_TICK_PERIOD 6
-    
+
       #define FRAME_X 100
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
 
     #endif
@@ -1176,26 +1212,26 @@
       #define BUTTON_ARRAY_LEN BUTTON_SCREEN_LIMIT
       #define STATUS_BAR_WIDTH 16
       #define LVGL_TICK_PERIOD 6
-    
+
       #define FRAME_X 100
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -1204,7 +1240,7 @@
 
       #define SCREEN_CHAR_WIDTH 40
       #define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1216,7 +1252,7 @@
       #endif
 
       #ifndef MARAUDER_CYD_MICRO
-        #define TFT_DIY      
+        #define TFT_DIY
       #endif
 
       #define GRAPH_VERT_LIM TFT_HEIGHT/2 - 1
@@ -1228,7 +1264,7 @@
       #define MAX_SCREEN_BUFFER 21
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1254,21 +1290,21 @@
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -1277,7 +1313,7 @@
 
       #define SCREEN_CHAR_WIDTH 40
       #define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1302,7 +1338,7 @@
       #define MAX_SCREEN_BUFFER 21
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1328,30 +1364,30 @@
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
-    #endif 
+    #endif
 
     #if defined(MARAUDER_PANCAKE)
       #define CHAN_PER_PAGE 7
 
       #define SCREEN_CHAR_WIDTH 40
       #define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1371,7 +1407,7 @@
       #define MAX_SCREEN_BUFFER 26
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1397,21 +1433,21 @@
       #define FRAME_Y 64
       #define FRAME_W TFT_WIDTH / 2
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -1420,7 +1456,7 @@
 
       #define SCREEN_CHAR_WIDTH 40
       #define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1440,7 +1476,7 @@
       #define MAX_SCREEN_BUFFER 21
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1466,21 +1502,21 @@
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -1490,7 +1526,7 @@
       #define SCREEN_CHAR_WIDTH 40
       #define HAS_ILI9341
       #define HAS_ST7789
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1510,7 +1546,7 @@
       #define MAX_SCREEN_BUFFER 21
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1536,21 +1572,21 @@
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -1560,7 +1596,7 @@
       #define SCREEN_CHAR_WIDTH 40
       #define HAS_ILI9341
       #define HAS_ST7796
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1582,7 +1618,7 @@
       #define MAX_SCREEN_BUFFER 33
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1608,21 +1644,21 @@
       #define FRAME_Y 64
       #define FRAME_W TFT_WIDTH / 2
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -1631,7 +1667,7 @@
 
       #define SCREEN_CHAR_WIDTH 40
       #define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1653,7 +1689,7 @@
       #define MAX_SCREEN_BUFFER 21
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1679,21 +1715,115 @@
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
+      #define KIT_LED_BUILTIN 13
+    #endif
+
+    #if defined(CYD_2432S022)
+      #define CHAN_PER_PAGE 7
+
+      #define SCREEN_CHAR_WIDTH 40
+      #define HAS_ILI9341
+      #define HAS_ST7789
+
+      #define BANNER_TEXT_SIZE 2
+
+      #ifndef TFT_WIDTH
+        #define TFT_WIDTH 240
+      #endif
+
+      #ifndef TFT_HEIGHT
+        #define TFT_HEIGHT 320
+      #endif
+
+      #define TFT_CS 17
+      #define TFT_DC 16
+      #define TFT_WR 4
+      #define TFT_RD 2
+      #define TFT_D0 15
+      #define TFT_D1 13
+      #define TFT_D2 12
+      #define TFT_D3 14
+      #define TFT_D4 27
+      #define TFT_D5 25
+      #define TFT_D6 33
+      #define TFT_D7 32
+      #ifndef TFT_BL
+        #define TFT_BL 0
+      #endif
+
+      #ifndef CYD_2432S022_OFFSET_ROTATION
+        #define CYD_2432S022_OFFSET_ROTATION 0
+      #endif
+
+      #ifndef CYD_2432S022_TOUCH_OFFSET_ROTATION
+        #define CYD_2432S022_TOUCH_OFFSET_ROTATION 0
+      #endif
+
+      #define GRAPH_VERT_LIM TFT_HEIGHT/2 - 1
+
+      #define EXT_BUTTON_WIDTH 30
+
+      #define SCREEN_BUFFER
+
+      #define MAX_SCREEN_BUFFER 21
+
+      #define SCREEN_ORIENTATION 0
+
+      #define CHAR_WIDTH 12
+      #define SCREEN_WIDTH TFT_WIDTH
+      #define SCREEN_HEIGHT TFT_HEIGHT
+      #define HEIGHT_1 TFT_WIDTH
+      #define WIDTH_1 TFT_HEIGHT
+      #define STANDARD_FONT_CHAR_LIMIT (TFT_WIDTH/6) // number of characters on a single line with normal font
+      #define TEXT_HEIGHT 16 // Height of text to be printed and scrolled
+      #define BOT_FIXED_AREA 0 // Number of lines in bottom fixed area (lines counted from bottom of screen)
+      #define TOP_FIXED_AREA 48 // Number of lines in top fixed area (lines counted from top of screen)
+      #define YMAX 320 // Bottom of screen area
+      #define minimum(a,b)     (((a) < (b)) ? (a) : (b))
+      //#define MENU_FONT NULL
+      #define MENU_FONT &FreeMono9pt7b // Winner
+      //#define MENU_FONT &FreeMonoBold9pt7b
+      //#define MENU_FONT &FreeSans9pt7b
+      //#define MENU_FONT &FreeSansBold9pt7b
+      #define BUTTON_SCREEN_LIMIT 12
+      #define BUTTON_ARRAY_LEN BUTTON_SCREEN_LIMIT
+      #define STATUS_BAR_WIDTH 16
+      #define LVGL_TICK_PERIOD 6
+
+      #define FRAME_X 100
+      #define FRAME_Y 64
+      #define FRAME_W 120
+      #define FRAME_H 50
+
+      // Red zone size
+      #define REDBUTTON_X FRAME_X
+      #define REDBUTTON_Y FRAME_Y
+      #define REDBUTTON_W (FRAME_W/2)
+      #define REDBUTTON_H FRAME_H
+
+      // Green zone size
+      #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
+      #define GREENBUTTON_Y FRAME_Y
+      #define GREENBUTTON_W (FRAME_W/2)
+      #define GREENBUTTON_H FRAME_H
+
+      #define STATUSBAR_COLOR 0x4A49
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -1702,7 +1832,7 @@
 
       #define SCREEN_CHAR_WIDTH 40
       //#define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1724,7 +1854,7 @@
       #define EXT_BUTTON_WIDTH 0
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1750,21 +1880,21 @@
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -1773,7 +1903,7 @@
 
       #define SCREEN_CHAR_WIDTH 40
       //#define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1795,7 +1925,7 @@
       #define EXT_BUTTON_WIDTH 0
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1821,21 +1951,21 @@
       #define FRAME_Y 64
       #define FRAME_W 120
       #define FRAME_H 50
-    
+
       // Red zone size
       #define REDBUTTON_X FRAME_X
       #define REDBUTTON_Y FRAME_Y
       #define REDBUTTON_W (FRAME_W/2)
       #define REDBUTTON_H FRAME_H
-    
+
       // Green zone size
       #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -1844,7 +1974,7 @@
 
       #define SCREEN_CHAR_WIDTH 40
       #define HAS_ILI9341
-    
+
       #define BANNER_TEXT_SIZE 2
 
       #ifndef TFT_WIDTH
@@ -1867,7 +1997,7 @@
       #define MAX_SCREEN_BUFFER 21
 
       #define SCREEN_ORIENTATION 0
-    
+
       #define CHAR_WIDTH 12
       #define SCREEN_WIDTH TFT_WIDTH
       #define SCREEN_HEIGHT TFT_HEIGHT
@@ -1905,12 +2035,12 @@
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
-    
+
       #define KIT_LED_BUILTIN 13
     #endif
-  
+
     #ifdef MARAUDER_MINI
       #define CHAN_PER_PAGE 7
 
@@ -1982,7 +2112,7 @@
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
     #endif
 
@@ -2057,7 +2187,7 @@
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
     #endif
 
@@ -2132,7 +2262,7 @@
       #define GREENBUTTON_Y FRAME_Y
       #define GREENBUTTON_W (FRAME_W/2)
       #define GREENBUTTON_H FRAME_H
-    
+
       #define STATUSBAR_COLOR 0x4A49
     #endif
 
@@ -2142,9 +2272,9 @@
   //// MENU DEFINITIONS
   #ifdef MARAUDER_V4
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -2161,9 +2291,9 @@
 
   #if defined(MARAUDER_V6) || defined(MARAUDER_V6_1)
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -2198,9 +2328,9 @@
 
   #if defined(MARAUDER_V8)
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -2217,9 +2347,9 @@
 
   #if defined(MARAUDER_PANCAKE)
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 160 // Centre of key
     #define KEY_Y 59
@@ -2236,9 +2366,9 @@
 
   #if defined(MARAUDER_CYD_MICRO)
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -2255,9 +2385,9 @@
 
   #if defined(MARAUDER_CYD_2USB)
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -2274,9 +2404,9 @@
 
   #if defined(MARAUDER_CYD_3_5_INCH)
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 160 // Centre of key
     #define KEY_Y 50
@@ -2293,9 +2423,28 @@
 
   #if defined(MARAUDER_CYD_GUITION)
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
+    // Keypad start position, key sizes and spacing
+    #define KEY_X 120 // Centre of key
+    #define KEY_Y 50
+    #define KEY_W 240 // Width and height
+    #define KEY_H 22
+    #define KEY_SPACING_X 0 // X and Y gap
+    #define KEY_SPACING_Y 1
+    #define KEY_TEXTSIZE 1   // Font size multiplier
+    #define ICON_W 22
+    #define ICON_H 22
+    #define BUTTON_PADDING 22
+    //#define BUTTON_ARRAY_LEN 5
+  #endif
+
+  #if defined(CYD_2432S022)
+    #define BANNER_TIME 100
+
+    #define COMMAND_PREFIX "!"
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -2312,9 +2461,9 @@
 
   #ifdef MARAUDER_V7
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -2331,9 +2480,9 @@
 
   #ifdef MARAUDER_V7_1
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -2350,9 +2499,9 @@
 
   #ifdef MARAUDER_KIT
     #define BANNER_TIME 100
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X 120 // Centre of key
     #define KEY_Y 50
@@ -2366,12 +2515,12 @@
     #define BUTTON_PADDING 22
     //#define BUTTON_ARRAY_LEN 5
   #endif
-  
+
   #ifdef MARAUDER_MINI
     #define BANNER_TIME 50
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X (TFT_WIDTH/2) // Centre of key
     #define KEY_Y (TFT_HEIGHT/4.5)
@@ -2387,9 +2536,9 @@
 
   #ifdef MARAUDER_REV_FEATHER
     #define BANNER_TIME 50
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X (TFT_WIDTH/2) // Centre of key
     #define KEY_Y (TFT_HEIGHT/4.5)
@@ -2405,9 +2554,9 @@
 
   #ifdef MARAUDER_M5STICKC
     #define BANNER_TIME 50
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X (TFT_WIDTH/2) // Centre of key
     #define KEY_Y (TFT_HEIGHT/5)
@@ -2441,9 +2590,9 @@
 
   #ifdef MARAUDER_MINI_V3
     #define BANNER_TIME 50
-    
+
     #define COMMAND_PREFIX "!"
-    
+
     // Keypad start position, key sizes and spacing
     #define KEY_X (TFT_WIDTH/2) // Centre of key
     #define KEY_Y (TFT_HEIGHT/4.5)
@@ -2486,6 +2635,10 @@
     #endif
 
     #ifdef MARAUDER_CYD_GUITION
+      #define SD_CS 5
+    #endif
+
+    #ifdef CYD_2432S022
       #define SD_CS 5
     #endif
 
@@ -2643,6 +2796,8 @@
     #define MEM_LOWER_LIM 10000
   #elif defined(MARAUDER_CYD_GUITION)
     #define MEM_LOWER_LIM 10000
+  #elif defined(CYD_2432S022)
+    #define MEM_LOWER_LIM 10000
   #elif defined(MARAUDER_KIT)
     #define MEM_LOWER_LIM 10000
   #elif defined(GENERIC_ESP32)
@@ -2670,9 +2825,9 @@
   #endif
   //// END MEMORY LOWER LIMIT STUFF
 
-  //// NEOPIXEL STUFF  
+  //// NEOPIXEL STUFF
   #ifdef HAS_NEOPIXEL_LED
-    
+
     #if defined(ESP32_LDDB)
       #define PIN 17
     #elif defined(MARAUDER_DEV_BOARD_PRO)
@@ -2698,7 +2853,7 @@
     #else
       #define PIN 25
     #endif
-  
+
   #endif
   //// END NEOPIXEL STUFF
 
@@ -2816,7 +2971,7 @@
   //// BATTERY STUFF
   #ifdef HAS_BATTERY
 
-    #if defined(MARAUDER_M5STICKC) || defined(MARAUDER_M5STICKCP2) 
+    #if defined(MARAUDER_M5STICKC) || defined(MARAUDER_M5STICKCP2)
       #define I2C_SDA 33
       #define I2C_SCL 22
 
@@ -2940,6 +3095,8 @@
     #define MARAUDER_TITLE_BYTES 13578
   #elif defined(MARAUDER_CYD_GUITION)
     #define MARAUDER_TITLE_BYTES 13578
+  #elif defined(CYD_2432S022)
+    #define MARAUDER_TITLE_BYTES 13578
   #elif defined(MARAUDER_KIT)
     #define MARAUDER_TITLE_BYTES 13578
   #elif defined(MARAUDER_MINI)
@@ -2964,7 +3121,7 @@
   //// END MARAUDER TITLE STUFF
 
   //// PCAP BUFFER STUFF
-  
+
   #ifdef HAS_PSRAM
     #define BUF_SIZE 8 * 1024 // Had to reduce buffer size to save RAM. GG @spacehuhn
     #define SNAP_LEN 1 * 4096 // max len of each recieved packet
@@ -3005,6 +3162,12 @@
     #endif
 
     #ifdef MARAUDER_CYD_3_5_INCH
+      #define SD_MISO      19
+      #define SD_MOSI      23
+      #define SD_SCK       18
+    #endif
+
+    #ifdef CYD_2432S022
       #define SD_MISO      19
       #define SD_MOSI      23
       #define SD_SCK       18


### PR DESCRIPTION
## Summary

Adds new board targets for the **ESP32-2432S022 / ESP32-2432S022C Cheap Yellow Display**
(ESP32, ST7789 240×320 display, 8-bit parallel/i80 bus, optional CST816S-family capacitive touch).

This board uses a parallel ST7789 display path rather than the existing SPI ILI9341 CYD/TFT_eSPI path, so this PR introduces a LovyanGFX-backed display target plus a thin compatibility layer for the existing Marauder UI drawing calls.

No WiFi/Bluetooth behavior is changed; this PR is limited to board support, display/touch/SD integration, build matrix entries, and documentation.

## What's included

- **`configs.h`**: new `CYD_2432S022` / `ESP32_2432S022C` target blocks, hardware name, capability flags, screen layout, SD pins, and menu/keypad constants.
- **`LGFX_ESP32_2432S022.h`**: LovyanGFX configuration for the ST7789 240×320 parallel display, backlight, and optional CST816S-compatible I2C touch.
- **`MarauderDisplayCompat.h`**: small compatibility layer so existing UI code can keep using familiar TFT-style methods/types.
- **`Display.{h,cpp}` / `MenuFunctions.{h,cpp}`**: hooks for LovyanGFX display/touch handling and direct menu row selection on the S022C touch variant.
- **`SDInterface.{h,cpp}`**: enables the existing separate-SD SPI path for this target.
- **`WiFiScan.cpp`**: fixes direct-upload sidecar timestamp handling for non-GPS boards.
- **CI workflows**: matrix entries for both S022 and S022C in `build_parallel.yml` and `nightly_build.yml`.

## Build

Same Arduino CLI / GitHub Actions style as the other ESP32 `d32` targets:

```text
FQBN: esp32:esp32:d32:PartitionScheme=min_spiffs
flag: -DCYD_2432S022
display: LovyanGFX ST7789 parallel/i80
```

For the capacitive-touch board variant:

```text
FQBN: esp32:esp32:d32:PartitionScheme=min_spiffs
flag: -DESP32_2432S022C
display: LovyanGFX ST7789 parallel/i80
touch: CST816S-family I2C, optional via CYD_2432S022C_TOUCH
```

Local compile commands tested:

```sh
arduino-cli compile --fqbn "esp32:esp32:d32:PartitionScheme=min_spiffs" --warnings none --build-property "compiler.cpp.extra_flags=-DCYD_2432S022" --build-property "compiler.c.elf.extra_flags=-Wl,-zmuldefs" esp32_marauder
arduino-cli compile --fqbn "esp32:esp32:d32:PartitionScheme=min_spiffs,UploadSpeed=115200" --warnings none --build-property "compiler.cpp.extra_flags=-DESP32_2432S022C" --build-property "compiler.c.elf.extra_flags=-Wl,-zmuldefs" esp32_marauder
```

## Tested on hardware

Flashed on a real ESP32-2432S022C board:

- ✅ Boots, Marauder UI renders correctly
- ✅ Backlight works
- ✅ Touch navigation and menu selection work
- ✅ Device Info screen renders correctly
- ✅ SD card mounts and reports capacity
- ✅ WiFi/Bluetooth menus remain available

## Known limitations / follow-ups

- GPS, battery gauge, RGB LED, and physical button support are not enabled because no safe S022 pin mapping is confirmed for those features.
- Touch is enabled only for the S022C-style capacitive variant.
- Display/touch rotation offsets are build-time configurable if another board revision needs adjustment.

## CI

Matrix entries for the new targets are included in both:

- `.github/workflows/build_parallel.yml`
- `.github/workflows/nightly_build.yml`

This produces release/nightly artifacts:

```text
_cyd_2432S022.bin
_cyd_2432S022C.bin
```