### PR TITLE
Add LCDWiki 2.8" ESP32-S3 Display board (MARAUDER_LCDWIKI_28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .vscode/c_cpp_properties.json
 .vscode/settings.json
 esp32_marauder/.vscode/settings.json
+
+# PlatformIO build output (local dev only)
+.pio/

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -38,6 +38,7 @@
 //#include <User_Setup_marauder_m5cardputer_adv.h>
 //#include <User_Setup_cyd_3_5_inch.h>
 //#include <User_Setup_marauder_pancake.h>
+//#include <User_Setup_marauder_lcdwiki_28.h>    // LCDWiki 2.8" ESP32-S3 (ILI9341V + FT6336)
 
 //#include <User_Setups/Setup1_ILI9341.h>  // Setup file configured for my ILI9341
 //#include <User_Setups/Setup2_ST7735.h>   // Setup file configured for my ST7735

--- a/User_Setup_marauder_lcdwiki_28.h
+++ b/User_Setup_marauder_lcdwiki_28.h
@@ -1,0 +1,64 @@
+//                            USER DEFINED SETTINGS
+//   TFT_eSPI setup for the LCDWiki 2.8" ESP32-S3 Display (MARAUDER_LCDWIKI_28)
+//   https://www.lcdwiki.com/2.8inch_ESP32-S3_Display
+//   ESP32-S3-WROOM-1 N16R8, 2.8" 240x320 ILI9341V panel, FT6336 capacitive touch.
+//
+//   Arduino IDE board settings for this module:
+//     Board:  ESP32S3 Dev Module
+//     Flash Size: 16MB (128Mb)    PSRAM: OPI PSRAM
+//     USB CDC On Boot: Enabled    USB Mode: Hardware CDC and JTAG
+
+// ##################################################################################
+// Section 1. Driver
+// ##################################################################################
+
+#define ILI9341_DRIVER
+
+// Panel native resolution (portrait)
+#define TFT_WIDTH  240
+#define TFT_HEIGHT 320
+
+// This panel uses BGR sub-pixel order. If red/blue look swapped, use TFT_RGB.
+#define TFT_RGB_ORDER TFT_BGR
+
+// Use the ESP32-S3 FSPI (SPI2) peripheral. This keeps the TFT off the SD card's
+// bus (the Marauder SD code defaults to HSPI/SPI3); sharing a bus makes SD init
+// clobber the display. It also avoids an S3 SPI-register crash in TFT_eSPI when
+// the port is left at its default.
+#define USE_FSPI_PORT
+
+// If colours are inverted (whites show as black) uncomment one of these.
+// #define TFT_INVERSION_ON
+// #define TFT_INVERSION_OFF
+
+// ##################################################################################
+// Section 2. Pins (ESP32-S3)
+// ##################################################################################
+
+#define TFT_MISO 13
+#define TFT_MOSI 11
+#define TFT_SCLK 12
+#define TFT_CS   10    // Chip select
+#define TFT_DC   46    // Data/command
+#define TFT_RST  -1    // Panel reset is tied to the module reset
+#define TFT_BL   45    // Backlight (PWM brightness handled by the firmware)
+#define TFT_BACKLIGHT_ON HIGH
+
+#define TOUCH_CS -1    // No SPI touch chip; FT6336 is I2C (handled in firmware)
+
+// ##################################################################################
+// Section 3. Fonts
+// ##################################################################################
+
+#define LOAD_GLCD
+#define LOAD_FONT2
+#define LOAD_FONT4
+#define LOAD_GFXFF
+#define SMOOTH_FONT
+
+// ##################################################################################
+// Section 4. SPI speed
+// ##################################################################################
+
+#define SPI_FREQUENCY       20000000
+#define SPI_READ_FREQUENCY  16000000

--- a/docs/boards/LCDWiki_2.8inch_ESP32-S3.md
+++ b/docs/boards/LCDWiki_2.8inch_ESP32-S3.md
@@ -1,0 +1,118 @@
+# ESP32 Marauder — LCDWiki 2.8" ESP32‑S3 Display
+
+Support for the **LCDWiki 2.8‑inch ESP32‑S3 Display** module.
+
+- Product / wiki: <https://www.lcdwiki.com/2.8inch_ESP32-S3_Display>
+- Build target: `MARAUDER_LCDWIKI_28` (in `esp32_marauder/configs.h`)
+- TFT_eSPI setup: `User_Setup_marauder_lcdwiki_28.h`
+
+## Hardware
+
+| | |
+|---|---|
+| MCU | ESP32‑S3‑WROOM‑1 **N16R8** (Xtensa LX7 dual‑core, 240 MHz) |
+| Flash / PSRAM | 16 MB flash + 8 MB **OPI** PSRAM |
+| Display | 2.8" IPS **240×320**, driver **ILI9341V**, 4‑wire SPI |
+| Touch | **FT6336** capacitive, I²C (addr `0x38`) |
+| microSD | **SDIO‑wired** slot (used here in SPI mode — see notes) |
+| RGB LED | 1× **WS2812** addressable |
+| USB | native USB‑C (ESP32‑S3 USB, appears as a CDC serial port) |
+| Radios | Wi‑Fi 2.4 GHz b/g/n, BT 5 (LE) |
+
+## Pinout
+
+### Display — ILI9341V (SPI, FSPI/SPI2)
+| Signal | GPIO |
+|---|---|
+| SCLK | **12** |
+| MOSI | **11** |
+| MISO | **13** |
+| CS | **10** |
+| DC / RS | **46** |
+| RST | tied to module reset (`-1`) |
+| Backlight (BL) | **45** (PWM brightness) |
+
+Colour order **BGR**, portrait native (240×320), `SCREEN_ORIENTATION 0`.
+
+### Touch — FT6336 (I²C `0x38`)
+| Signal | GPIO |
+|---|---|
+| SDA | **16** |
+| SCL | **15** |
+| RST | **18** |
+| INT | 17 *(not used by firmware)* |
+
+### microSD — SDIO slot, driven over SPI
+| SPI role | SDIO line | GPIO |
+|---|---|---|
+| SCK | CLK | **38** |
+| MOSI | CMD | **40** |
+| MISO | DAT0 | **39** |
+| CS | DAT3 | **47** |
+| — | DAT1 | 41 *(held high in SPI mode)* |
+| — | DAT2 | 48 *(held high in SPI mode)* |
+
+> The card **must be formatted FAT32** (the Arduino `SD` library can’t mount exFAT / >32 GB default formats).
+
+### Other on‑board
+| Function | GPIO |
+|---|---|
+| RGB LED (WS2812) | **42** (firmware turns it off) |
+| BOOT button (used as center/select) | **0** |
+| RESET | chip EN |
+| USB D+ / D‑ | 20 / 19 |
+
+## Broken‑out / available pins
+
+Everything the module brings out to a header, and whether it's free with this firmware:
+
+| Connector | GPIO(s) | Status with `MARAUDER_LCDWIKI_28` |
+|---|---|---|
+| **Expansion header** | **IO2, IO3, IO14, IO21** | **Free** — general‑purpose, use for anything |
+| **I²C header** | **IO16 (SDA) / IO15 (SCL)** | Usable, but it's the **same bus as the FT6336 touch** (`0x38`) — add‑ons must use a different address |
+| **UART header** | **IO44 (TX) / IO43 (RX)** | Assigned to **GPS** here (`GPS_TX=44`, `GPS_RX=43`); free if you don't attach/use GPS |
+
+So, with the current build, the immediately free pins are **IO2, IO3, IO14, IO21** (plus the
+I²C and UART headers if you don't need touch add‑ons / GPS).
+
+> Any GPIO not listed here or in the pinout tables above is taken by flash/PSRAM (26–37), USB
+> (19/20), or an on‑board peripheral — treat it as unavailable.
+
+## Building (Arduino IDE)
+
+1. In `esp32_marauder/configs.h`, uncomment the board target:
+   ```c
+   #define MARAUDER_LCDWIKI_28
+   ```
+   (make sure every other `MARAUDER_*` target is commented out).
+2. Copy `User_Setup_marauder_lcdwiki_28.h` into your **TFT_eSPI** library folder and
+   enable it in `User_Setup_Select.h` (uncomment its `#include`, comment the others).
+3. Arduino IDE **Tools** settings:
+   - **Board:** ESP32S3 Dev Module
+   - **Flash Size:** 16MB (128Mb)
+   - **PSRAM:** OPI PSRAM
+   - **USB CDC On Boot:** Enabled
+   - **USB Mode:** Hardware CDC and JTAG
+4. Build & flash. If flashing fails, hold **BOOT**, tap **RESET**, release **BOOT** to enter download mode.
+
+## Notes & gotchas
+
+- **Powers up on a charger/powerbank too.** With USB‑CDC as the console the firmware no
+  longer blocks boot waiting for a serial host, so the board runs untethered.
+- **Backlight is PWM** on IO45 (Device → *Brightness*, or hold the top/bottom edge). The
+  firmware owns IO45 via `ledcAttach`; don’t drive it with `digitalWrite`.
+- **SPI bus split:** the TFT is pinned to **FSPI/SPI2** so it doesn’t share a bus with the
+  SD card (which uses HSPI/SPI3). Sharing a bus blanks the display when the SD initialises.
+- **SD needs FAT32** (see above).
+
+### Re‑calibrating the touch panel
+
+The FT6336’s raw range is baked in via `LCDWIKI_TCAL_X0/X1/Y0/Y1` in `configs.h`. To
+re‑measure for your unit, build once with `-DTOUCH_CAL` (or add `#define TOUCH_CAL`),
+flash, and follow the on‑screen 2‑dot calibration; it prints the new constants over serial:
+
+```
+[TOUCHCAL] -DLCDWIKI_TCAL_X0=… -DLCDWIKI_TCAL_X1=… -DLCDWIKI_TCAL_Y0=… -DLCDWIKI_TCAL_Y1=…
+```
+
+Paste those values into `configs.h` and rebuild without `TOUCH_CAL`.

--- a/esp32_marauder/Display.cpp
+++ b/esp32_marauder/Display.cpp
@@ -48,6 +48,23 @@ uint8_t Display::updateTouch(uint16_t *x, uint16_t *y, uint16_t threshold) {
           uint16_t raw_x, raw_y;
           if (!ft6336_read_raw(&raw_x, &raw_y)) return 0;
 
+          #ifdef MARAUDER_LCDWIKI_28
+            // Linear touch calibration (raw panel coords -> screen pixels).
+            // Defaults are identity; the TOUCH_CAL routine prints measured values.
+            #ifndef LCDWIKI_TCAL_X0
+              #define LCDWIKI_TCAL_X0 0
+              #define LCDWIKI_TCAL_X1 (TFT_WIDTH - 1)
+              #define LCDWIKI_TCAL_Y0 0
+              #define LCDWIKI_TCAL_Y1 (TFT_HEIGHT - 1)
+            #endif
+            {
+              long _mx = map((long)raw_x, (long)LCDWIKI_TCAL_X0, (long)LCDWIKI_TCAL_X1, 0, TFT_WIDTH - 1);
+              long _my = map((long)raw_y, (long)LCDWIKI_TCAL_Y0, (long)LCDWIKI_TCAL_Y1, 0, TFT_HEIGHT - 1);
+              raw_x = (uint16_t)constrain(_mx, 0, TFT_WIDTH - 1);
+              raw_y = (uint16_t)constrain(_my, 0, TFT_HEIGHT - 1);
+            }
+          #endif
+
           // Discard touches within PANCAKE_TOUCH_MARGIN pixels of any panel edge
           #define PANCAKE_PANEL_W TFT_WIDTH
           #define PANCAKE_PANEL_H TFT_HEIGHT
@@ -215,6 +232,65 @@ void Display::RunSetup() {
   tft.init();
 
   tft.setRotation(SCREEN_ORIENTATION);
+
+  #ifdef MARAUDER_LCDWIKI_28
+    // Turn off the onboard RGB LED (WS2812 on IO42) via the core built-in.
+    neopixelWrite(42, 0, 0, 0);
+    // NOTE: backlight (IO45) is owned by the PWM brightness system (brightnessInit
+    // -> ledcAttach(TFT_BL)), which runs right after RunSetup — do not drive it
+    // with digitalWrite here or it fights the PWM dimming.
+  #endif
+
+  #if defined(MARAUDER_LCDWIKI_28) && defined(TOUCH_CAL)
+    // Interactive 2-point capacitive touch calibration. Prints the map constants
+    // to serial; bake them in as -DLCDWIKI_TCAL_X0.. then rebuild without TOUCH_CAL.
+    {
+      pinMode(TFT_BL, OUTPUT); digitalWrite(TFT_BL, HIGH);
+      const int M = 24;
+      int sx[2] = { M, TFT_WIDTH - 1 - M };
+      int sy[2] = { M, TFT_HEIGHT - 1 - M };
+      uint16_t rx[2] = {0, 0}, ry[2] = {0, 0};
+      for (int i = 0; i < 2; i++) {
+        tft.fillScreen(TFT_BLACK);
+        tft.setFreeFont(NULL); tft.setTextSize(1);
+        tft.setTextColor(TFT_WHITE, TFT_BLACK);
+        tft.drawCentreString("TOUCH CALIBRATION", TFT_WIDTH / 2, 40, 1);
+        tft.drawCentreString(i == 0 ? "tap the GREEN dot (top-left)"
+                                    : "tap the GREEN dot (bot-right)", TFT_WIDTH / 2, 60, 1);
+        tft.drawLine(sx[i] - 12, sy[i], sx[i] + 12, sy[i], TFT_RED);
+        tft.drawLine(sx[i], sy[i] - 12, sx[i], sy[i] + 12, TFT_RED);
+        tft.fillCircle(sx[i], sy[i], 3, TFT_GREEN);
+        delay(500); // debounce previous release
+        // Wait for a stable tap: average 10 raw samples
+        uint32_t ax = 0, ay = 0; int n = 0;
+        while (n < 10) {
+          uint16_t a, b;
+          if (ft6336_read_raw(&a, &b)) { ax += a; ay += b; n++; }
+          delay(8);
+        }
+        rx[i] = ax / n; ry[i] = ay / n;
+        tft.fillCircle(sx[i], sy[i], 3, TFT_BLUE);
+        // Wait for release
+        uint16_t a, b; while (ft6336_read_raw(&a, &b)) delay(8);
+      }
+      float slopeX = (float)(rx[1] - rx[0]) / (float)(sx[1] - sx[0]);
+      float slopeY = (float)(ry[1] - ry[0]) / (float)(sy[1] - sy[0]);
+      long X0 = lround(rx[0] - slopeX * sx[0]);
+      long X1 = lround(rx[1] + slopeX * ((TFT_WIDTH - 1) - sx[1]));
+      long Y0 = lround(ry[0] - slopeY * sy[0]);
+      long Y1 = lround(ry[1] + slopeY * ((TFT_HEIGHT - 1) - sy[1]));
+      tft.fillScreen(TFT_BLACK);
+      tft.drawCentreString("CAL DONE", TFT_WIDTH / 2, TFT_HEIGHT / 2 - 10, 1);
+      tft.drawCentreString("see serial log", TFT_WIDTH / 2, TFT_HEIGHT / 2 + 6, 1);
+      while (true) {
+        Serial.printf("[TOUCHCAL] raw TL=(%u,%u) BR=(%u,%u)\n", rx[0], ry[0], rx[1], ry[1]);
+        Serial.printf("[TOUCHCAL] -DLCDWIKI_TCAL_X0=%ld -DLCDWIKI_TCAL_X1=%ld -DLCDWIKI_TCAL_Y0=%ld -DLCDWIKI_TCAL_Y1=%ld\n",
+                      X0, X1, Y0, Y1);
+        Serial.flush();
+        delay(1500);
+      }
+    }
+  #endif
 
   tft.setCursor(0, 0);
 

--- a/esp32_marauder/SDInterface.cpp
+++ b/esp32_marauder/SDInterface.cpp
@@ -21,7 +21,7 @@ bool SDInterface::initSD() {
     pinMode(SD_CS, OUTPUT);
 
     delay(10);
-    #if (defined(MARAUDER_M5STICKC)) || (defined(HAS_CYD_TOUCH)) || (defined(MARAUDER_CARDPUTER)) || (defined(MARAUDER_CARDPUTER_ADV))
+    #if (defined(MARAUDER_M5STICKC)) || (defined(HAS_CYD_TOUCH)) || (defined(MARAUDER_CARDPUTER)) || (defined(MARAUDER_CARDPUTER_ADV)) || (defined(HAS_SEPARATE_SD))
       /* Set up SPI SD Card using external pin header
       StickCPlus Header - SPI SD Card Reader
                   3v3   -   3v3
@@ -44,6 +44,12 @@ bool SDInterface::initSD() {
         this->spiExt = new SPIClass(FSPI);
       #endif
       Serial.println(F("Using external SPI configuration..."));
+      #ifdef MARAUDER_LCDWIKI_28
+        // SDIO-wired slot driven in SPI mode: hold the unused DAT1/DAT2 high so
+        // they don't float and confuse the card during SPI init.
+        pinMode(41, INPUT_PULLUP); // SD DAT1
+        pinMode(48, INPUT_PULLUP); // SD DAT2
+      #endif
       this->spiExt->begin(SPI_SCK, SPI_MISO, SPI_MOSI, SD_CS);
       if (!SD.begin(SD_CS, *(this->spiExt))) {
     #elif defined(HAS_C5_SD)

--- a/esp32_marauder/SDInterface.h
+++ b/esp32_marauder/SDInterface.h
@@ -36,7 +36,7 @@ extern Settings settings_obj;
 class SDInterface {
 
   private:
-  #if (defined(MARAUDER_M5STICKC) || defined(HAS_CYD_TOUCH) || defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV))
+  #if (defined(MARAUDER_M5STICKC) || defined(HAS_CYD_TOUCH) || defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV) || defined(HAS_SEPARATE_SD))
     SPIClass *spiExt;
   #elif defined(HAS_C5_SD)
     SPIClass* _spi;

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -37,6 +37,7 @@
   //#define MARAUDER_MINI_V3
   //#define MARAUDER_M5_NANO_C6
   //#define DUAL_MINI_C5
+  //#define MARAUDER_LCDWIKI_28 // LCDWiki 2.8" ESP32-S3 Display (240x320 ILI9341V + FT6336 cap touch)
   //// END BOARD TARGETS
 
   #define JSON_SETTING_SIZE 2048
@@ -112,6 +113,8 @@
     #define HARDWARE_NAME "Dual Mini C5"
   #elif defined(MARAUDER_M5_NANO_C6)
     #define HARDWARE_NAME "M5 Nano C6"
+  #elif defined(MARAUDER_LCDWIKI_28)
+    #define HARDWARE_NAME "LCDWiki ESP32-S3 2.8"
   #else
     #define HARDWARE_NAME "ESP32"
   #endif
@@ -605,6 +608,31 @@
     #define HAS_IDF_3
     //#define HAS_DIRECT_UPLOAD
   #endif
+
+  #ifdef MARAUDER_LCDWIKI_28
+    #define HAS_TOUCH
+    #define HAS_CAP_TOUCH       // FT6336 capacitive touch (I2C) via ft6336.h
+    //#define HAS_FLIPPER_LED   // board has a single WS2812 RGB on IO42, not a 3-pin RGB LED
+    //#define FLIPPER_ZERO_HAT
+    //#define HAS_BATTERY
+    #define HAS_BT
+    #define HAS_BT_REMOTE
+    #define HAS_BUTTONS
+    //#define HAS_NEOPIXEL_LED  // WS2812 RGB is on IO42; left off (turned dark in Display.cpp via neopixelWrite)
+    //#define HAS_PWR_MGMT
+    #define HAS_SCREEN
+    #define HAS_FULL_SCREEN
+    #define HAS_SD
+    #define USE_SD
+    #define HAS_SEPARATE_SD     // microSD on its own SPI bus (pins below)
+    #define HAS_CYD_PORTRAIT
+    #define HAS_TEMP_SENSOR
+    #define HAS_GPS
+    #define HAS_PSRAM           // N16R8: 8MB OPI PSRAM (set Arduino "PSRAM: OPI PSRAM")
+    #define HAS_NIMBLE_2
+    #define HAS_IDF_3
+    #define HAS_DIRECT_UPLOAD
+  #endif
   //// END BOARD FEATURES
 
   //// POWER MANAGEMENT
@@ -888,6 +916,26 @@
       #define HAS_R
       #define HAS_U
       #define HAS_D
+      #define HAS_C
+
+      #define L_PULL true
+      #define C_PULL true
+      #define U_PULL true
+      #define R_PULL true
+      #define D_PULL true
+    #endif
+
+    #ifdef MARAUDER_LCDWIKI_28
+      #define L_BTN -1
+      #define C_BTN 0    // BOOT button
+      #define U_BTN -1
+      #define R_BTN -1
+      #define D_BTN -1
+
+      //#define HAS_L
+      //#define HAS_R
+      //#define HAS_U
+      //#define HAS_D
       #define HAS_C
 
       #define L_PULL true
@@ -1480,7 +1528,87 @@
       #define GREENBUTTON_H FRAME_H
     
       #define STATUSBAR_COLOR 0x4A49
-    
+
+      #define KIT_LED_BUILTIN 13
+    #endif
+
+    #if defined(MARAUDER_LCDWIKI_28)
+      #define CHAN_PER_PAGE 7
+
+      #define SCREEN_CHAR_WIDTH 40
+      #define HAS_ILI9341        // ILI9341V panel
+
+      #define BANNER_TEXT_SIZE 2
+
+      #ifndef TFT_WIDTH
+        #define TFT_WIDTH 240
+      #endif
+
+      #ifndef TFT_HEIGHT
+        #define TFT_HEIGHT 320
+      #endif
+
+      // FT6336G capacitive touch (I2C @0x38). INT (IO17) unused.
+      #define CTP_SDA 16
+      #define CTP_SCL 15
+      #define CTP_RST 18
+
+      // Touch calibration (measured via TOUCH_CAL: raw panel range -> screen px)
+      #define LCDWIKI_TCAL_X0 10
+      #define LCDWIKI_TCAL_X1 220
+      #define LCDWIKI_TCAL_Y0 11
+      #define LCDWIKI_TCAL_Y1 318
+
+      #define GRAPH_VERT_LIM TFT_HEIGHT/2 - 1
+
+      #define EXT_BUTTON_WIDTH 30
+
+      #define SCREEN_BUFFER
+
+      #define MAX_SCREEN_BUFFER 21
+
+      #define SCREEN_ORIENTATION 0
+
+      #define CHAR_WIDTH 12
+      #define SCREEN_WIDTH TFT_WIDTH
+      #define SCREEN_HEIGHT TFT_HEIGHT
+      #define HEIGHT_1 TFT_WIDTH
+      #define WIDTH_1 TFT_HEIGHT
+      #define STANDARD_FONT_CHAR_LIMIT (TFT_WIDTH/6) // number of characters on a single line with normal font
+      #define TEXT_HEIGHT 16 // Height of text to be printed and scrolled
+      #define BOT_FIXED_AREA 0 // Number of lines in bottom fixed area (lines counted from bottom of screen)
+      #define TOP_FIXED_AREA 48 // Number of lines in top fixed area (lines counted from top of screen)
+      #define YMAX 320 // Bottom of screen area
+      #define minimum(a,b)     (((a) < (b)) ? (a) : (b))
+      //#define MENU_FONT NULL
+      #define MENU_FONT &FreeMono9pt7b // Winner
+      //#define MENU_FONT &FreeMonoBold9pt7b
+      //#define MENU_FONT &FreeSans9pt7b
+      //#define MENU_FONT &FreeSansBold9pt7b
+      #define BUTTON_SCREEN_LIMIT 12
+      #define BUTTON_ARRAY_LEN BUTTON_SCREEN_LIMIT
+      #define STATUS_BAR_WIDTH 16
+      #define LVGL_TICK_PERIOD 6
+
+      #define FRAME_X 100
+      #define FRAME_Y 64
+      #define FRAME_W 120
+      #define FRAME_H 50
+
+      // Red zone size
+      #define REDBUTTON_X FRAME_X
+      #define REDBUTTON_Y FRAME_Y
+      #define REDBUTTON_W (FRAME_W/2)
+      #define REDBUTTON_H FRAME_H
+
+      // Green zone size
+      #define GREENBUTTON_X (REDBUTTON_X + REDBUTTON_W)
+      #define GREENBUTTON_Y FRAME_Y
+      #define GREENBUTTON_W (FRAME_W/2)
+      #define GREENBUTTON_H FRAME_H
+
+      #define STATUSBAR_COLOR 0x4A49
+
       #define KIT_LED_BUILTIN 13
     #endif
 
@@ -2178,6 +2306,24 @@
     //#define BUTTON_ARRAY_LEN 5
   #endif
 
+  #if defined(MARAUDER_LCDWIKI_28)
+    #define BANNER_TIME 100
+
+    #define COMMAND_PREFIX "!"
+
+    // Keypad start position, key sizes and spacing (240x320 portrait)
+    #define KEY_X 120 // Centre of key
+    #define KEY_Y 50
+    #define KEY_W 240 // Width and height
+    #define KEY_H 22
+    #define KEY_SPACING_X 0 // X and Y gap
+    #define KEY_SPACING_Y 1
+    #define KEY_TEXTSIZE 1   // Font size multiplier
+    #define ICON_W 22
+    #define ICON_H 22
+    #define BUTTON_PADDING 22
+  #endif
+
   // Status bar right-side icon x-positions (SCREEN_WIDTH-relative)
   // V8 (240px): SD=170 WiFi=154 Force=138 Touch=186 Bat=204
   // Pancake (320px): SD=250 WiFi=234 Force=218 Touch=266 Bat=284
@@ -2557,6 +2703,10 @@
       #define SD_CS 10
     #endif
 
+    #ifdef MARAUDER_LCDWIKI_28
+      #define SD_CS 47    // D3 line used as chip-select in SPI mode
+    #endif
+
   #endif
   //// END SD DEFINITIONS
 
@@ -2738,6 +2888,12 @@
       #define GPS_SERIAL_INDEX 2
       #define GPS_TX 21
       #define GPS_RX 25
+    #elif defined(MARAUDER_LCDWIKI_28)
+      // GPS on the broken-out UART header: TXD0=IO44 (board TX -> GPS RX),
+      // RXD0=IO43 (board RX <- GPS TX). NOT 11/12 (those are TFT MOSI/SCLK).
+      #define GPS_SERIAL_INDEX 1
+      #define GPS_TX 44
+      #define GPS_RX 43
     #elif defined(MARAUDER_CYD_GUITION)
       #define GPS_SERIAL_INDEX 2
       #define GPS_TX 21 // Fits the extended I/O
@@ -3026,6 +3182,13 @@
       #define SD_MISO TFT_MISO
       #define SD_MOSI TFT_MOSI
       #define SD_SCK  TFT_SCLK
+    #endif
+
+    #ifdef MARAUDER_LCDWIKI_28
+      // Dedicated microSD bus (SDIO pins driven in SPI mode)
+      #define SD_MISO 39
+      #define SD_MOSI 40
+      #define SD_SCK  38
     #endif
 
     #ifdef MARAUDER_V4

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -240,8 +240,16 @@ void setup()
     digitalWrite(ACT_LED_PIN, LOW);
   #endif
 
-  while(!Serial)
-    delay(10);
+  #if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+    // Native-USB CDC serial: don't hang forever waiting for a host to open the
+    // port (otherwise the board never boots off a powerbank/charger), and make
+    // prints non-blocking so a full TX buffer with no host can't stall boot.
+    Serial.setTxTimeoutMs(0);
+    { unsigned long _t0 = millis(); while (!Serial && (millis() - _t0 < 1500)) delay(10); }
+  #else
+    while(!Serial)
+      delay(10);
+  #endif
 
   #ifdef HAS_C5_SD
     sharedSPI.begin(SD_SCK, SD_MISO, SD_MOSI);


### PR DESCRIPTION
## Summary

Adds a new board target, **`MARAUDER_LCDWIKI_28`**, for the **LCDWiki 2.8" ESP32‑S3 Display**
module — an inexpensive all‑in‑one ESP32‑S3 board with a 240×320 IPS panel and capacitive touch.

- Board / wiki: https://www.lcdwiki.com/2.8inch_ESP32-S3_Display
- Full board guide added at `docs/boards/LCDWiki_2.8inch_ESP32-S3.md`

## Hardware

| | |
|---|---|
| MCU | ESP32‑S3‑WROOM‑1 **N16R8** (16 MB flash, 8 MB OPI PSRAM) |
| Display | 2.8" 240×320 IPS, **ILI9341V**, SPI |
| Touch | **FT6336** capacitive, I²C `0x38` (uses the existing `ft6336.h`) |
| microSD | SDIO‑wired slot, driven over SPI |
| Extras | WS2812 RGB LED, native USB‑C, broken‑out UART + GPIO headers |

## What's included

- **`configs.h`** – new `MARAUDER_LCDWIKI_28` target: features, BOOT button, display block,
  touch / SD / GPS pins, menu geometry, and baked FT6336 touch‑calibration constants.
- **`User_Setup_marauder_lcdwiki_28.h`** + **`User_Setup_Select.h`** – TFT_eSPI setup
  (ILI9341 driver, board pins, `USE_FSPI_PORT`, BGR).
- **`Display.cpp`** – FT6336 touch‑coordinate calibration map, turn the on‑board WS2812 (IO42)
  off, and an optional 2‑point touch‑calibration screen (`-DTOUCH_CAL`) that prints fresh
  constants over serial.
- **`SDInterface.cpp/.h`** – make the existing `HAS_SEPARATE_SD` flag actually select the
  dedicated‑SPI‑bus init, and hold the SDIO `DAT1/DAT2` lines high while using the slot in SPI mode.
- **`esp32_marauder.ino`** – when the console is USB‑CDC, don't block boot forever waiting for a
  host to open the port (so the board also runs off a powerbank/charger).
- **`docs/`** – board guide with the full pinout, free pins, build steps and gotchas.

## Pinout

**Display (SPI/FSPI):** SCLK 12 · MOSI 11 · MISO 13 · CS 10 · DC 46 · RST –1 · BL 45
**Touch (I²C):** SDA 16 · SCL 15 · RST 18 · INT 17(nc)
**microSD (SPI on the SDIO slot):** SCK 38 · MOSI 40 · MISO 39 · CS 47 (DAT1 41 / DAT2 48 held high)
**Other:** WS2812 RGB → 42 · BOOT → 0 · USB D+/D‑ → 20/19
**Broken out & free:** IO2, IO3, IO14, IO21 · I²C header 16/15 (shared with touch) · UART header 44/43 (GPS here)

## Tested on hardware

Verified on the actual module:

- ✅ Display draws correctly (colours/orientation OK)
- ✅ Capacitive touch — accurate after the baked calibration; menu navigation works
- ✅ Backlight PWM brightness control (Device → Brightness / edge‑hold)
- ✅ Wi‑Fi scan
- ✅ microSD read/write (card must be **FAT32**)
- ✅ Boots on a powerbank/charger (no USB host) as well as on a PC
- ✅ On‑board RGB LED turned off

## Notes for reviewers

- The `while(!Serial)` change in `esp32_marauder.ino` is gated on `ARDUINO_USB_CDC_ON_BOOT`,
  so it only affects native‑USB‑CDC boards; UART‑console boards keep the original behaviour.
- Adding `HAS_SEPARATE_SD` to the `SDInterface` guards makes that flag finally reach the
  dedicated‑SPI‑bus path. This **also enables it for `MARAUDER_CYD_3_5_INCH`** (which already
  defines `HAS_SEPARATE_SD`); it looked like the outer guard just missed it, but worth a check
  on that board.
- The board is SDIO‑wired but works fine over SPI once the card is FAT32.

## Build (Arduino IDE)

1. Uncomment `#define MARAUDER_LCDWIKI_28` in `esp32_marauder/configs.h`.
2. Copy `User_Setup_marauder_lcdwiki_28.h` into the TFT_eSPI library and enable it in
   `User_Setup_Select.h`.
3. Tools → **ESP32S3 Dev Module**, Flash **16MB**, PSRAM **OPI PSRAM**, **USB CDC On Boot: Enabled**.
