### PR TITLE
CI: publish authoritative stable installer manifests

### DIFF
--- a/.github/workflows/build_installer_manifests.yml
+++ b/.github/workflows/build_installer_manifests.yml
@@ -1,0 +1,321 @@
+name: Build Installer Manifests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/build_installer_manifests.yml"
+      - ".github/workflows/build_parallel.yml"
+      - "installer/**"
+      - "tools/installer_manifest.py"
+      - "tools/test_installer_manifest.py"
+  push:
+    branches:
+      - develop
+    paths:
+      - ".github/workflows/build_installer_manifests.yml"
+      - ".github/workflows/build_parallel.yml"
+      - "installer/**"
+      - "tools/installer_manifest.py"
+      - "tools/test_installer_manifest.py"
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Validate tooling and export normal build matrix
+    if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+
+      - name: Validate target registry
+        run: python3 tools/installer_manifest.py --validate-registry
+
+      - name: Test manifest generation
+        run: python3 -m unittest tools/test_installer_manifest.py -v
+
+      - name: Export matrix from normal release workflow
+        id: matrix
+        run: |
+          MATRIX=$(python3 tools/installer_manifest.py --export-build-matrix)
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: installer ${{ matrix.board.name }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ${{ fromJSON(needs.prepare.outputs.matrix).include }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+
+      - name: Record source commit
+        run: echo "SOURCE_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Install Arduino CLI
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
+          echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+          export PATH="$PATH:$GITHUB_WORKSPACE/bin"
+          arduino-cli version
+
+      - name: Build TestFile with ESP32 v${{ matrix.board.idf_ver }}
+        uses: ArminJo/arduino-test-compile@v3.2.1
+        with:
+          sketch-names: TestFile.ino
+          arduino-board-fqbn: esp32:esp32:esp32s2
+          arduino-platform: esp32:esp32@${{ matrix.board.idf_ver }}
+          platform-url: https://github.com/espressif/arduino-esp32/releases/download/${{ matrix.board.idf_ver }}/package_esp32_dev_index.json
+
+      - name: Install ESP32Ping
+        uses: actions/checkout@v4
+        with:
+          repository: marian-craciunescu/ESP32Ping
+          ref: 1.6
+          path: CustomESP32Ping
+
+      - name: Install AsyncTCP
+        uses: actions/checkout@v4
+        with:
+          repository: ESP32Async/AsyncTCP
+          ref: v3.4.8
+          path: CustomAsyncTCP
+
+      - name: Install MicroNMEA
+        uses: actions/checkout@v4
+        with:
+          repository: stevemarple/MicroNMEA
+          ref: v2.0.6
+          path: CustomMicroNMEA
+
+      - name: Install ESPAsyncWebServer
+        uses: actions/checkout@v4
+        with:
+          repository: ESP32Async/ESPAsyncWebServer
+          ref: v3.8.1
+          path: CustomESPAsyncWebServer
+
+      - name: Install TFT_eSPI
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.board.tft_repo || 'Bodmer/TFT_eSPI' }}
+          ref: ${{ matrix.board.tft_ref || 'V2.5.34' }}
+          path: CustomTFT_eSPI
+
+      - name: Install XPT2046_Touchscreen
+        uses: actions/checkout@v4
+        with:
+          repository: PaulStoffregen/XPT2046_Touchscreen
+          ref: v1.4
+          path: CustomXPT2046_Touchscreen
+
+      - name: Install lv_arduino
+        uses: actions/checkout@v4
+        with:
+          repository: lvgl/lv_arduino
+          ref: 3.0.0
+          path: Customlv_arduino
+
+      - name: Install JPEGDecoder
+        uses: actions/checkout@v4
+        with:
+          repository: Bodmer/JPEGDecoder
+          ref: 1.8.0
+          path: CustomJPEGDecoder
+
+      - name: Install NimBLE-Arduino
+        uses: actions/checkout@v4
+        with:
+          repository: h2zero/NimBLE-Arduino
+          ref: ${{ matrix.board.nimble_ver }}
+          path: CustomNimBLE-Arduino
+
+      - name: Install Adafruit_NeoPixel
+        uses: actions/checkout@v4
+        with:
+          repository: adafruit/Adafruit_NeoPixel
+          ref: 1.12.0
+          path: CustomAdafruit_NeoPixel
+
+      - name: Install ArduinoJson
+        uses: actions/checkout@v4
+        with:
+          repository: bblanchon/ArduinoJson
+          ref: v6.18.2
+          path: CustomArduinoJson
+
+      - name: Install LinkedList
+        uses: actions/checkout@v4
+        with:
+          repository: ivanseidel/LinkedList
+          ref: v1.3.3
+          path: CustomLinkedList
+
+      - name: Install EspSoftwareSerial
+        uses: actions/checkout@v4
+        with:
+          repository: plerup/espsoftwareserial
+          ref: 8.1.0
+          path: CustomEspSoftwareSerial
+
+      - name: Install Adafruit_BusIO
+        uses: actions/checkout@v4
+        with:
+          repository: adafruit/Adafruit_BusIO
+          ref: 1.15.0
+          path: CustomAdafruit_BusIO
+
+      - name: Install Adafruit_MAX1704X
+        uses: actions/checkout@v4
+        with:
+          repository: adafruit/Adafruit_MAX1704X
+          ref: 1.0.2
+          path: CustomAdafruit_MAX1704X
+
+      - name: Install Adafruit_TCA8418
+        run: cp -r libraries/Adafruit_TCA8418 CustomAdafruit_TCA8418
+
+      - name: Configure TFT_eSPI
+        run: |
+          rm -f CustomTFT_eSPI/User_Setup_Select.h
+          cp User*.h CustomTFT_eSPI/
+          if [[ ${{ matrix.board.tft }} == true ]]; then
+            sed -i 's/^\/\/#include <${{ matrix.board.tft_file }}>/#include <${{ matrix.board.tft_file }}>/' CustomTFT_eSPI/User_Setup_Select.h
+          fi
+
+      - name: Install Esptool
+        run: pip install esptool
+
+      - name: Apply core compatibility flags
+        run: |
+          if [[ ${{ matrix.board.idf_ver }} == "2.0.11" ]]; then
+            for i in $(find /home/runner/.arduino15/packages/esp32/hardware/esp32/ -name "platform.txt"); do
+              sed -i 's/compiler.c.elf.libs.esp32c3=/compiler.c.elf.libs.esp32c3=-zmuldefs /' "$i"
+              sed -i 's/compiler.c.elf.libs.esp32s3=/compiler.c.elf.libs.esp32s3=-zmuldefs /' "$i"
+              sed -i 's/compiler.c.elf.libs.esp32s2=/compiler.c.elf.libs.esp32s2=-zmuldefs /' "$i"
+              sed -i 's/compiler.c.elf.libs.esp32=/compiler.c.elf.libs.esp32=-zmuldefs /' "$i"
+              sed -i 's/-fexceptions/-fno-exceptions/g' "$i"
+            done
+          fi
+
+          if [[ ${{ matrix.board.idf_ver }} == "3.3.4" ]]; then
+            for i in $(find /home/runner/.arduino15/packages/esp32/hardware/esp32/ -name "platform.txt"); do
+              sed -i 's/compiler.c.elf.extra_flags=/compiler.c.elf.extra_flags=-Wl,-zmuldefs /' "$i"
+            done
+            for f in $(find /home/runner/.arduino15/packages/esp32/tools/esp32-arduino-libs/ -name "cpp_flags"); do
+              sed -i 's/-fexceptions/-fno-exceptions/g' "$f"
+            done
+          fi
+
+      - name: Build Marauder for ${{ matrix.board.name }}
+        uses: ArminJo/arduino-test-compile@v3.3.0
+        with:
+          sketch-names: esp32_marauder.ino
+          arduino-board-fqbn: ${{ matrix.board.fbqn }}
+          set-build-path: true
+          extra-arduino-cli-args: "--warnings none --build-property compiler.cpp.extra_flags='-D${{ matrix.board.flag }}'"
+          arduino-platform: esp32:esp32@${{ matrix.board.idf_ver }}
+          platform-url: https://github.com/espressif/arduino-esp32/releases/download/${{ matrix.board.idf_ver }}/package_esp32_dev_index.json
+
+      - name: Generate authoritative installer assets
+        run: |
+          VERSION_DOT=$(grep '#define MARAUDER_VERSION' ./esp32_marauder/configs.h | sed -E 's/.*"v([^"]+)"/v\1/')
+          DATE=$(date +%Y%m%d)
+          BUILD_DIR=./esp32_marauder/build
+
+          if [[ "${{ github.event_name }}" == "release" && "$VERSION_DOT" != "${{ github.event.release.tag_name }}" ]]; then
+            echo "Release tag ${{ github.event.release.tag_name }} does not match firmware version $VERSION_DOT" >&2
+            exit 1
+          fi
+
+          arduino-cli compile \
+            --fqbn "${{ matrix.board.fbqn }}" \
+            --build-path "$BUILD_DIR" \
+            --show-properties=expanded \
+            ./esp32_marauder > "$BUILD_DIR/arduino-build-properties.txt"
+
+          python3 tools/installer_manifest.py \
+            --generate-target \
+            --build-flag "${{ matrix.board.flag }}" \
+            --build-dir "$BUILD_DIR" \
+            --version "$VERSION_DOT" \
+            --release-date "$DATE" \
+            --source-commit "$SOURCE_COMMIT" \
+            --output-dir release-assets
+
+      - name: Upload installer target artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-${{ matrix.board.file_name }}
+          path: release-assets
+          if-no-files-found: error
+          retention-days: 5
+
+  combine:
+    name: Combine authoritative installer manifest
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+
+      - name: Download target artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Combine and validate release manifest
+        run: |
+          python3 tools/installer_manifest.py \
+            --combine \
+            --input-dir release-assets \
+            --output release-assets/firmware-manifest.json
+
+      - name: Upload complete installer bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-release-bundle
+          path: release-assets
+          if-no-files-found: error
+          retention-days: 5
+
+  publish:
+    name: Attach installer assets to published stable release
+    needs: combine
+    if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download complete installer bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: installer-release-bundle
+          path: release-assets
+
+      - name: Attach additive installer assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          fail_on_unmatched_files: true
+          files: |
+            release-assets/*.bin
+            release-assets/firmware-manifest.json

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -9,27 +9,10 @@ on:
       - "*"
   pull_request:
 
-permissions:
-  contents: read
-
 jobs:
-  installer_manifest_tests:
-    name: Validate installer manifest tooling
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Validate target registry
-        run: python3 tools/installer_manifest.py --validate-registry
-
-      - name: Test manifest generation
-        run: python3 -m unittest tools/test_installer_manifest.py -v
-
   compile_sketch:
     name: build ${{ matrix.board.name }}
     runs-on: ubuntu-latest
-    needs: installer_manifest_tests
     strategy:
       fail-fast: false
       matrix:
@@ -257,66 +240,51 @@ jobs:
         with:
           sketch-names: esp32_marauder.ino
           arduino-board-fqbn: ${{ matrix.board.fbqn }}
-          set-build-path: true
           extra-arduino-cli-args: "--warnings none --build-property compiler.cpp.extra_flags='-D${{ matrix.board.flag }}'"
           arduino-platform: esp32:esp32@${{ matrix.board.idf_ver }}
           platform-url: https://github.com/espressif/arduino-esp32/releases/download/${{ matrix.board.idf_ver }}/package_esp32_dev_index.json
 
-      - name: Generate authoritative installer assets for ${{ matrix.board.name }}
+      #- name: Rename Marauder ${{ matrix.board.name }} bin
+      #  run: |
+      #    mv ./esp32_marauder/build/esp32.esp32.${{ matrix.board.build_dir }}/esp32_marauder.ino.bin ./esp32_marauder/build/esp32.esp32.${{ matrix.board.build_dir }}/esp32_marauder.${{ matrix.board.file_name }}.bin
+      
+      - name: Rename and Upload ${{ matrix.board.name }} Artifact
         run: |
-          VERSION_DOT=$(grep '#define MARAUDER_VERSION' ./esp32_marauder/configs.h | sed -E 's/.*"v([^"]+)"/v\1/')
+          VERSION=$(grep '#define MARAUDER_VERSION' ./esp32_marauder/configs.h | sed -E 's/.*"v([^"]+)"/v\1/' | tr '.' '_')
           DATE=$(date +%Y%m%d)
-          BUILD_DIR=./esp32_marauder/build
 
-          arduino-cli compile \
-            --fqbn "${{ matrix.board.fbqn }}" \
-            --build-path "$BUILD_DIR" \
-            --show-properties=expanded \
-            ./esp32_marauder > "$BUILD_DIR/arduino-build-properties.txt"
+          BUILD_DIR=./esp32_marauder/build/esp32.esp32.${{ matrix.board.build_dir }}
+          INPUT_BIN=$BUILD_DIR/esp32_marauder.ino.bin
+          OUTPUT_BIN=esp32_marauder_${VERSION}_${DATE}_${{ matrix.board.file_name }}.bin
+          VERSION_DOT=${VERSION_DOT}
 
-          python3 tools/installer_manifest.py \
-            --generate-target \
-            --build-flag "${{ matrix.board.flag }}" \
-            --build-dir "$BUILD_DIR" \
-            --version "$VERSION_DOT" \
-            --release-date "$DATE" \
-            --source-commit "$GITHUB_SHA" \
-            --output-dir release-assets
+          mv "$INPUT_BIN" "$BUILD_DIR/$OUTPUT_BIN"
 
+          echo "artifact_name=$OUTPUT_BIN" >> $GITHUB_ENV
+          echo "artifact_path=$BUILD_DIR/$OUTPUT_BIN" >> $GITHUB_ENV
       - name: Upload ${{ matrix.board.name }} Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: installer-${{ matrix.board.file_name }}
-          path: release-assets
-          if-no-files-found: error
+          name: ${{ env.artifact_name }}
+          path: ${{ env.artifact_path }}
           retention-days: 5
 
   post_compile_steps:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [compile_sketch, installer_manifest_tests]
+    needs: [compile_sketch]
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    permissions:
-      contents: write
     steps: 
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          path: release-assets
           merge-multiple: true
           
       - name: Get Tag Version
         run: |
           VERSION_DOT=$(grep '#define MARAUDER_VERSION' ./esp32_marauder/configs.h | sed -E 's/.*"v([^"]+)"/v\1/')
           echo "version_dot=$VERSION_DOT" >> $GITHUB_ENV
-
-      - name: Combine and validate authoritative release manifest
-        run: |
-          python3 tools/installer_manifest.py \
-            --combine \
-            --input-dir release-assets \
-            --output release-assets/firmware-manifest.json
-
+          
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -325,8 +293,7 @@ jobs:
           generate_release_notes: false
           draft: true
           files: |
-            release-assets/*.bin
-            release-assets/firmware-manifest.json
+            esp32_marauder_v*.bin
           body: |
             [justcallmekokollc.com](https://justcallmekokollc.com)
 

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -9,10 +9,27 @@ on:
       - "*"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
+  installer_manifest_tests:
+    name: Validate installer manifest tooling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Validate target registry
+        run: python3 tools/installer_manifest.py --validate-registry
+
+      - name: Test manifest generation
+        run: python3 -m unittest tools/test_installer_manifest.py -v
+
   compile_sketch:
     name: build ${{ matrix.board.name }}
     runs-on: ubuntu-latest
+    needs: installer_manifest_tests
     strategy:
       fail-fast: false
       matrix:
@@ -244,47 +261,55 @@ jobs:
           arduino-platform: esp32:esp32@${{ matrix.board.idf_ver }}
           platform-url: https://github.com/espressif/arduino-esp32/releases/download/${{ matrix.board.idf_ver }}/package_esp32_dev_index.json
 
-      #- name: Rename Marauder ${{ matrix.board.name }} bin
-      #  run: |
-      #    mv ./esp32_marauder/build/esp32.esp32.${{ matrix.board.build_dir }}/esp32_marauder.ino.bin ./esp32_marauder/build/esp32.esp32.${{ matrix.board.build_dir }}/esp32_marauder.${{ matrix.board.file_name }}.bin
-      
-      - name: Rename and Upload ${{ matrix.board.name }} Artifact
+      - name: Generate authoritative installer assets for ${{ matrix.board.name }}
         run: |
-          VERSION=$(grep '#define MARAUDER_VERSION' ./esp32_marauder/configs.h | sed -E 's/.*"v([^"]+)"/v\1/' | tr '.' '_')
+          VERSION_DOT=$(grep '#define MARAUDER_VERSION' ./esp32_marauder/configs.h | sed -E 's/.*"v([^"]+)"/v\1/')
           DATE=$(date +%Y%m%d)
-
           BUILD_DIR=./esp32_marauder/build/esp32.esp32.${{ matrix.board.build_dir }}
-          INPUT_BIN=$BUILD_DIR/esp32_marauder.ino.bin
-          OUTPUT_BIN=esp32_marauder_${VERSION}_${DATE}_${{ matrix.board.file_name }}.bin
-          VERSION_DOT=${VERSION_DOT}
 
-          mv "$INPUT_BIN" "$BUILD_DIR/$OUTPUT_BIN"
+          python3 tools/installer_manifest.py \
+            --generate-target \
+            --build-flag "${{ matrix.board.flag }}" \
+            --build-dir "$BUILD_DIR" \
+            --version "$VERSION_DOT" \
+            --release-date "$DATE" \
+            --source-commit "$GITHUB_SHA" \
+            --output-dir release-assets
 
-          echo "artifact_name=$OUTPUT_BIN" >> $GITHUB_ENV
-          echo "artifact_path=$BUILD_DIR/$OUTPUT_BIN" >> $GITHUB_ENV
       - name: Upload ${{ matrix.board.name }} Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.artifact_name }}
-          path: ${{ env.artifact_path }}
+          name: installer-${{ matrix.board.file_name }}
+          path: release-assets
+          if-no-files-found: error
           retention-days: 5
 
   post_compile_steps:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [compile_sketch]
+    needs: [compile_sketch, installer_manifest_tests]
     if: ${{ github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: write
     steps: 
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
+          path: release-assets
           merge-multiple: true
           
       - name: Get Tag Version
         run: |
           VERSION_DOT=$(grep '#define MARAUDER_VERSION' ./esp32_marauder/configs.h | sed -E 's/.*"v([^"]+)"/v\1/')
           echo "version_dot=$VERSION_DOT" >> $GITHUB_ENV
-          
+
+      - name: Combine and validate authoritative release manifest
+        run: |
+          python3 tools/installer_manifest.py \
+            --combine \
+            --input-dir release-assets \
+            --output release-assets/firmware-manifest.json
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -293,7 +318,8 @@ jobs:
           generate_release_notes: false
           draft: true
           files: |
-            esp32_marauder_v*.bin
+            release-assets/*.bin
+            release-assets/firmware-manifest.json
           body: |
             [justcallmekokollc.com](https://justcallmekokollc.com)
 

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -257,6 +257,7 @@ jobs:
         with:
           sketch-names: esp32_marauder.ino
           arduino-board-fqbn: ${{ matrix.board.fbqn }}
+          set-build-path: true
           extra-arduino-cli-args: "--warnings none --build-property compiler.cpp.extra_flags='-D${{ matrix.board.flag }}'"
           arduino-platform: esp32:esp32@${{ matrix.board.idf_ver }}
           platform-url: https://github.com/espressif/arduino-esp32/releases/download/${{ matrix.board.idf_ver }}/package_esp32_dev_index.json
@@ -265,7 +266,7 @@ jobs:
         run: |
           VERSION_DOT=$(grep '#define MARAUDER_VERSION' ./esp32_marauder/configs.h | sed -E 's/.*"v([^"]+)"/v\1/')
           DATE=$(date +%Y%m%d)
-          BUILD_DIR=./esp32_marauder/build/esp32.esp32.${{ matrix.board.build_dir }}
+          BUILD_DIR=./esp32_marauder/build
 
           python3 tools/installer_manifest.py \
             --generate-target \

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -268,6 +268,12 @@ jobs:
           DATE=$(date +%Y%m%d)
           BUILD_DIR=./esp32_marauder/build
 
+          arduino-cli compile \
+            --fqbn "${{ matrix.board.fbqn }}" \
+            --build-path "$BUILD_DIR" \
+            --show-properties=expanded \
+            ./esp32_marauder > "$BUILD_DIR/arduino-build-properties.txt"
+
           python3 tools/installer_manifest.py \
             --generate-target \
             --build-flag "${{ matrix.board.flag }}" \

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .vscode/c_cpp_properties.json
 .vscode/settings.json
 esp32_marauder/.vscode/settings.json
+__pycache__/
+*.pyc

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,20 @@
+# Installer manifest
+
+`targets.json` is the canonical identity registry for the 22 stable firmware build targets. It maps each build flag to a stable target ID, aliases, release asset suffix, browser-facing chip family, and esptool chip name.
+
+The stable release workflow runs `tools/installer_manifest.py` after every matrix build. The generator reads Arduino's emitted `flash_args` or `flash_args.txt`; it does not guess offsets, flash size, mode, frequency, or segment paths. It copies each actual flash segment into a target-specific release asset, calculates its size and SHA-256 digest, and emits:
+
+- an update plan containing only the application image and preserving user data;
+- a factory plan containing every emitted flash segment and requiring erase;
+- a per-target manifest used only as an intermediate CI artifact.
+
+The release job refuses to create `firmware-manifest.json` unless every registry target is present exactly once and every target agrees on stable channel, version, and full source commit. The final manifest and all referenced binaries are attached to the draft stable release.
+
+Nightly releases intentionally do not publish installer manifests at launch.
+
+## Local validation
+
+```sh
+python3 tools/installer_manifest.py --validate-registry
+python3 -m unittest tools/test_installer_manifest.py -v
+```

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,20 +1,35 @@
 # Installer manifest
 
-`targets.json` is the canonical identity registry for the 22 stable firmware build targets. It maps each build flag to a stable target ID, aliases, release asset suffix, browser-facing chip family, and esptool chip name.
+`targets.json` is the canonical installer identity registry for the 22 stable firmware build targets. It maps each build flag to a stable target ID, aliases, release asset suffix, browser-facing chip family, and esptool chip name.
 
-The stable release workflow runs `tools/installer_manifest.py` after every matrix build. The generator reads Arduino's emitted `flash_args` or `flash_args.txt`; it does not guess offsets, flash size, mode, frequency, or segment paths. It copies each actual flash segment into a target-specific release asset, calculates its size and SHA-256 digest, and emits:
+The normal release workflow, `.github/workflows/build_parallel.yml`, remains unchanged and continues producing its existing downloadable application binaries. Installer automation lives only in the additive `.github/workflows/build_installer_manifests.yml` workflow.
+
+The installer workflow exports its build matrix directly from the normal workflow and validates every build flag against `targets.json`. Matrix parsing fails closed on unsupported syntax, missing fields, duplicates, or target drift. This keeps the existing normal-release matrix authoritative without requiring it to consume installer-specific configuration.
+
+Each installer build reads Arduino CLI's expanded upload recipe and concrete build properties; it does not guess offsets, flash size, mode, frequency, or segment paths. It copies each actual flash segment into a target-specific asset, calculates its size and SHA-256 digest, and emits:
 
 - an update plan containing only the application image and preserving user data;
 - a factory plan containing every emitted flash segment and requiring erase;
 - a per-target manifest used only as an intermediate CI artifact.
 
-The release job refuses to create `firmware-manifest.json` unless every registry target is present exactly once and every target agrees on stable channel, version, and full source commit. The final manifest and all referenced binaries are attached to the draft stable release.
+The combine job refuses to create `firmware-manifest.json` unless every registry target is present exactly once and every target agrees on stable channel, version, and full source commit.
+
+## Triggers and release relationship
+
+- Pull requests and relevant pushes to `develop` rebuild and validate the complete installer bundle as short-lived Actions artifacts.
+- Manual dispatch is artifact-only; it does not create, publish, or modify a release.
+- Publishing a non-prerelease GitHub release triggers an independent rebuild from that release tag. Only after all 22 targets and the combined manifest pass does the workflow attach the additive installer assets to the already-published release.
+- The installer workflow never invokes or replaces the normal release workflow, and it never renames or removes the normal downloadable binaries.
+- Every additive installer binary uses the `esp32_marauder_installer_` namespace so release attachment cannot collide with or overwrite a normal binary filename.
 
 Nightly releases intentionally do not publish installer manifests at launch.
+
+The isolation has one deliberate cost: stable release publication performs a second 22-target build so installer assets can include authoritative bootloader, partition, OTA-data, and application segments without changing the normal release jobs.
 
 ## Local validation
 
 ```sh
 python3 tools/installer_manifest.py --validate-registry
+python3 tools/installer_manifest.py --export-build-matrix
 python3 -m unittest tools/test_installer_manifest.py -v
 ```

--- a/installer/firmware-manifest.schema.json
+++ b/installer/firmware-manifest.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/justcallmekoko/ESP32Marauder/master/installer/firmware-manifest.schema.json",
+  "title": "ESP32 Marauder stable installer release manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "kind",
+    "metadataStatus",
+    "sourceRepository",
+    "sourceCommit",
+    "channel",
+    "version",
+    "targets"
+  ],
+  "properties": {
+    "$schema": { "type": "string", "format": "uri" },
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "esp32-marauder-installer-release" },
+    "metadataStatus": { "const": "authoritative" },
+    "sourceRepository": { "const": "justcallmekoko/ESP32Marauder" },
+    "sourceCommit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "channel": { "const": "stable" },
+    "version": { "type": "string", "pattern": "^v[0-9A-Za-z._-]+$" },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/target" }
+    }
+  },
+  "$defs": {
+    "segment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "offset", "size", "sha256", "fileName"],
+      "properties": {
+        "role": {
+          "enum": [
+            "bootloader",
+            "partition-table",
+            "ota-data",
+            "application",
+            "auxiliary"
+          ]
+        },
+        "offset": { "type": "integer", "minimum": 0 },
+        "size": { "type": "integer", "minimum": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "fileName": { "type": "string", "minLength": 1 }
+      }
+    },
+    "plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["erase", "preservesUserData", "segments"],
+      "properties": {
+        "erase": { "type": "boolean" },
+        "preservesUserData": { "type": "boolean" },
+        "segments": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/segment" }
+        }
+      }
+    },
+    "flash": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sizeBytes", "mode", "frequency", "update", "factory"],
+      "properties": {
+        "sizeBytes": { "type": "integer", "minimum": 1 },
+        "mode": { "enum": ["dio", "dout", "qio", "qout"] },
+        "frequency": { "type": "string", "pattern": "^[0-9]+m$" },
+        "update": { "$ref": "#/$defs/plan" },
+        "factory": { "$ref": "#/$defs/plan" }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "displayName",
+        "aliases",
+        "buildFlag",
+        "assetSuffix",
+        "chipFamily",
+        "esptoolChip",
+        "flash"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "displayName": { "type": "string", "minLength": 1 },
+        "aliases": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "buildFlag": { "type": "string", "pattern": "^[A-Z0-9_]+$" },
+        "assetSuffix": { "type": "string", "pattern": "^[A-Za-z0-9_]+$" },
+        "chipFamily": {
+          "enum": ["ESP32", "ESP32-S2", "ESP32-S3", "ESP32-C5", "ESP32-C6"]
+        },
+        "esptoolChip": {
+          "enum": ["esp32", "esp32s2", "esp32s3", "esp32c5", "esp32c6"]
+        },
+        "flash": { "$ref": "#/$defs/flash" }
+      }
+    }
+  }
+}

--- a/installer/targets.json
+++ b/installer/targets.json
@@ -1,0 +1,204 @@
+{
+  "schemaVersion": 1,
+  "sourceWorkflow": ".github/workflows/build_parallel.yml",
+  "targets": [
+    {
+      "id": "flipper-zero-wifi-dev-board",
+      "displayName": "Flipper Zero WiFi Dev Board",
+      "aliases": ["Flipper Zero", "WiFi Dev Board"],
+      "buildFlag": "MARAUDER_FLIPPER",
+      "assetSuffix": "flipper",
+      "chipFamily": "ESP32-S2",
+      "esptoolChip": "esp32s2"
+    },
+    {
+      "id": "flipper-zero-multiboard-s3",
+      "displayName": "Flipper Zero Multi Board S3",
+      "aliases": ["MultiBoard S3", "Multiboard S3"],
+      "buildFlag": "MARAUDER_MULTIBOARD_S3",
+      "assetSuffix": "multiboardS3",
+      "chipFamily": "ESP32-S3",
+      "esptoolChip": "esp32s3"
+    },
+    {
+      "id": "og-marauder",
+      "displayName": "OG Marauder",
+      "aliases": ["Marauder v4", "Old hardware"],
+      "buildFlag": "MARAUDER_V4",
+      "assetSuffix": "old_hardware",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "marauder-v6",
+      "displayName": "Marauder v6",
+      "aliases": ["New hardware"],
+      "buildFlag": "MARAUDER_V6",
+      "assetSuffix": "v6",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "marauder-v6-1",
+      "displayName": "Marauder v6.1",
+      "aliases": ["Marauder v6.2", "AWOK V2 screen", "AWOK V3 screen"],
+      "buildFlag": "MARAUDER_V6_1",
+      "assetSuffix": "v6_1",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "marauder-kit",
+      "displayName": "Marauder Kit",
+      "aliases": [],
+      "buildFlag": "MARAUDER_KIT",
+      "assetSuffix": "kit",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "marauder-mini",
+      "displayName": "Marauder Mini",
+      "aliases": [],
+      "buildFlag": "MARAUDER_MINI",
+      "assetSuffix": "mini",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "esp32-lddb",
+      "displayName": "ESP32 LDDB",
+      "aliases": ["NodeMCU", "Wemos"],
+      "buildFlag": "ESP32_LDDB",
+      "assetSuffix": "esp32_lddb",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "marauder-dev-board-pro",
+      "displayName": "Marauder Dev Board Pro",
+      "aliases": ["BFFB", "AWOK V3 flipper"],
+      "buildFlag": "MARAUDER_DEV_BOARD_PRO",
+      "assetSuffix": "marauder_dev_board_pro",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "m5stickc-plus",
+      "displayName": "M5StickC Plus",
+      "aliases": [],
+      "buildFlag": "MARAUDER_M5STICKC",
+      "assetSuffix": "m5stickc_plus",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "m5stickc-plus-2",
+      "displayName": "M5StickC Plus 2",
+      "aliases": [],
+      "buildFlag": "MARAUDER_M5STICKCP2",
+      "assetSuffix": "m5stickc_plus2",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "reverse-feather",
+      "displayName": "ESP32-S2 Reverse Feather",
+      "aliases": ["Rev Feather"],
+      "buildFlag": "MARAUDER_REV_FEATHER",
+      "assetSuffix": "rev_feather",
+      "chipFamily": "ESP32-S2",
+      "esptoolChip": "esp32s2"
+    },
+    {
+      "id": "marauder-v7",
+      "displayName": "Marauder v7",
+      "aliases": [],
+      "buildFlag": "MARAUDER_V7",
+      "assetSuffix": "marauder_v7",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "cyd-2432s028",
+      "displayName": "Marauder CYD 2432S028",
+      "aliases": ["CYD 2432S028R"],
+      "buildFlag": "MARAUDER_CYD_MICRO",
+      "assetSuffix": "cyd_2432S028",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "cyd-2432s024-guition",
+      "displayName": "Marauder CYD 2432S024 GUITION",
+      "aliases": ["RL Phantom"],
+      "buildFlag": "MARAUDER_CYD_GUITION",
+      "assetSuffix": "cyd_2432S024_guition",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "cyd-2432s028-2usb",
+      "displayName": "Marauder CYD 2432S028 2 USB",
+      "aliases": [],
+      "buildFlag": "MARAUDER_CYD_2USB",
+      "assetSuffix": "cyd_2432S028_2usb",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "cyd-3-5-inch",
+      "displayName": "Marauder CYD 3.5 inch",
+      "aliases": [],
+      "buildFlag": "MARAUDER_CYD_3_5_INCH",
+      "assetSuffix": "cyd_3_5_inch",
+      "chipFamily": "ESP32",
+      "esptoolChip": "esp32"
+    },
+    {
+      "id": "m5cardputer",
+      "displayName": "M5 Cardputer",
+      "aliases": [],
+      "buildFlag": "MARAUDER_CARDPUTER",
+      "assetSuffix": "m5cardputer",
+      "chipFamily": "ESP32-S3",
+      "esptoolChip": "esp32s3"
+    },
+    {
+      "id": "m5cardputer-adv",
+      "displayName": "M5 Cardputer ADV",
+      "aliases": [],
+      "buildFlag": "MARAUDER_CARDPUTER_ADV",
+      "assetSuffix": "m5cardputer_adv",
+      "chipFamily": "ESP32-S3",
+      "esptoolChip": "esp32s3"
+    },
+    {
+      "id": "esp32-c5-devkitc-1",
+      "displayName": "ESP32-C5-DevKitC-1",
+      "aliases": ["ESP32-C5 DevKit"],
+      "buildFlag": "MARAUDER_C5",
+      "assetSuffix": "esp32c5devkitc1",
+      "chipFamily": "ESP32-C5",
+      "esptoolChip": "esp32c5"
+    },
+    {
+      "id": "m5-nano-c6",
+      "displayName": "M5 Nano C6",
+      "aliases": ["M5NanoC6"],
+      "buildFlag": "MARAUDER_M5_NANO_C6",
+      "assetSuffix": "m5nanoc6",
+      "chipFamily": "ESP32-C6",
+      "esptoolChip": "esp32c6"
+    },
+    {
+      "id": "marauder-pancake",
+      "displayName": "Marauder Pancake",
+      "aliases": ["Pancake Marauder V8"],
+      "buildFlag": "MARAUDER_PANCAKE",
+      "assetSuffix": "pancake",
+      "chipFamily": "ESP32-C5",
+      "esptoolChip": "esp32c5"
+    }
+  ]
+}

--- a/tools/installer_manifest.py
+++ b/tools/installer_manifest.py
@@ -23,10 +23,31 @@ REQUIRED_TARGET_KEYS = {
     "chipFamily",
     "esptoolChip",
 }
+REQUIRED_BUILD_MATRIX_KEYS = {
+    "name",
+    "flag",
+    "fbqn",
+    "file_name",
+    "tft",
+    "tft_file",
+    "build_dir",
+    "addr",
+    "idf_ver",
+    "nimble_ver",
+    "esp_async",
+    "esp_async_ver",
+}
+OPTIONAL_BUILD_MATRIX_KEYS = {"tft_repo", "tft_ref"}
 CHIP_FAMILIES = {"ESP32", "ESP32-S2", "ESP32-S3", "ESP32-C5", "ESP32-C6"}
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 OFFSET_PATTERN = re.compile(r"^0x[0-9a-fA-F]+$")
 SIZE_PATTERN = re.compile(r"^(?P<size>\d+)(?P<unit>MB|M|KB|K|B)?$", re.IGNORECASE)
+FLOW_ENTRY_PATTERN = re.compile(r"^\s*-\s*\{(?P<body>.*)\}\s*$")
+FLOW_FIELD_PATTERN = re.compile(
+    r'\s*(?P<key>[a-z_][a-z0-9_]*)\s*:\s*'
+    r'(?:(?:"(?P<string>[^"]*)")|(?P<boolean>true|false))\s*'
+    r"(?P<separator>,|$)"
+)
 
 
 class ManifestError(RuntimeError):
@@ -80,6 +101,72 @@ def target_for_flag(registry: dict[str, Any], build_flag: str) -> dict[str, Any]
     if len(matches) != 1:
         raise ManifestError(f"Expected exactly one registry target for {build_flag}.")
     return matches[0]
+
+
+def parse_workflow_flow_mapping(body: str, line_number: int) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    position = 0
+    while position < len(body):
+        match = FLOW_FIELD_PATTERN.match(body, position)
+        if match is None:
+            raise ManifestError(
+                f"Unsupported build matrix syntax on workflow line {line_number}."
+            )
+        key = match.group("key")
+        if key in values:
+            raise ManifestError(f"Duplicate build matrix field {key} on line {line_number}.")
+        values[key] = (
+            match.group("string")
+            if match.group("string") is not None
+            else match.group("boolean") == "true"
+        )
+        position = match.end()
+    return values
+
+
+def load_normal_build_matrix(
+    workflow_path: Path, registry_path: Path
+) -> list[dict[str, Any]]:
+    try:
+        workflow_lines = workflow_path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise ManifestError(f"Cannot read normal build workflow {workflow_path}: {error}") from error
+
+    boards: list[dict[str, Any]] = []
+    allowed_keys = REQUIRED_BUILD_MATRIX_KEYS | OPTIONAL_BUILD_MATRIX_KEYS
+    for line_number, line in enumerate(workflow_lines, start=1):
+        if "flag:" not in line or not line.lstrip().startswith("- {"):
+            continue
+        match = FLOW_ENTRY_PATTERN.fullmatch(line)
+        if match is None:
+            raise ManifestError(f"Malformed build matrix entry on workflow line {line_number}.")
+        board = parse_workflow_flow_mapping(match.group("body"), line_number)
+        missing = REQUIRED_BUILD_MATRIX_KEYS - set(board)
+        extra = set(board) - allowed_keys
+        if missing or extra:
+            raise ManifestError(
+                f"Build matrix entry on line {line_number} has missing={sorted(missing)}, "
+                f"extra={sorted(extra)}."
+            )
+        boards.append(board)
+
+    if not boards:
+        raise ManifestError(f"No hardware matrix entries found in {workflow_path}.")
+    for key in ("name", "flag", "file_name"):
+        values = [board[key] for board in boards]
+        if len(values) != len(set(values)):
+            raise ManifestError(f"Normal build matrix contains duplicate {key} values.")
+
+    registry = load_registry(registry_path)
+    registry_flags = {target["buildFlag"] for target in registry["targets"]}
+    matrix_flags = {board["flag"] for board in boards}
+    if matrix_flags != registry_flags:
+        raise ManifestError(
+            "Installer target registry does not match the normal build workflow; "
+            f"missing={sorted(matrix_flags - registry_flags)}, "
+            f"extra={sorted(registry_flags - matrix_flags)}."
+        )
+    return boards
 
 
 def parse_size(value: str) -> int:
@@ -204,7 +291,7 @@ def generate_target_manifest(
 
     version_slug = version.replace(".", "_")
     application_stem = (
-        f"esp32_marauder_{version_slug}_{release_date}_{target['assetSuffix']}"
+        f"esp32_marauder_installer_{version_slug}_{release_date}_{target['assetSuffix']}"
     )
     copied_segments: list[dict[str, Any]] = []
     used_names: set[str] = set()
@@ -336,6 +423,12 @@ def build_parser() -> argparse.ArgumentParser:
     action.add_argument("--validate-registry", action="store_true")
     action.add_argument("--generate-target", action="store_true")
     action.add_argument("--combine", action="store_true")
+    action.add_argument("--export-build-matrix", action="store_true")
+    parser.add_argument(
+        "--workflow",
+        type=Path,
+        default=Path(".github/workflows/build_parallel.yml"),
+    )
     parser.add_argument("--build-flag")
     parser.add_argument("--build-dir", type=Path)
     parser.add_argument("--version")
@@ -358,6 +451,10 @@ def main() -> None:
     if args.validate_registry:
         registry = load_registry(args.registry)
         print(f"Validated {len(registry['targets'])} installer targets.")
+        return
+    if args.export_build_matrix:
+        boards = load_normal_build_matrix(args.workflow, args.registry)
+        print(json.dumps({"include": boards}, separators=(",", ":")))
         return
     if args.generate_target:
         output = generate_target_manifest(

--- a/tools/installer_manifest.py
+++ b/tools/installer_manifest.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Generate fail-closed installer metadata from Arduino's actual flash arguments."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shlex
+import shutil
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+SOURCE_REPOSITORY = "justcallmekoko/ESP32Marauder"
+REQUIRED_TARGET_KEYS = {
+    "id",
+    "displayName",
+    "aliases",
+    "buildFlag",
+    "assetSuffix",
+    "chipFamily",
+    "esptoolChip",
+}
+CHIP_FAMILIES = {"ESP32", "ESP32-S2", "ESP32-S3", "ESP32-C5", "ESP32-C6"}
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+OFFSET_PATTERN = re.compile(r"^0x[0-9a-fA-F]+$")
+SIZE_PATTERN = re.compile(r"^(?P<size>\d+)(?P<unit>MB|M|KB|K|B)?$", re.IGNORECASE)
+
+
+class ManifestError(RuntimeError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ManifestError(f"Cannot read valid JSON from {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ManifestError(f"{path} must contain a JSON object.")
+    return value
+
+
+def load_registry(path: Path) -> dict[str, Any]:
+    registry = read_json(path)
+    if registry.get("schemaVersion") != SCHEMA_VERSION:
+        raise ManifestError("Unsupported target registry schemaVersion.")
+    targets = registry.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise ManifestError("Target registry must contain at least one target.")
+
+    ids: set[str] = set()
+    flags: set[str] = set()
+    suffixes: set[str] = set()
+    for target in targets:
+        if not isinstance(target, dict) or set(target) != REQUIRED_TARGET_KEYS:
+            raise ManifestError("Every target must contain exactly the required registry fields.")
+        if target["chipFamily"] not in CHIP_FAMILIES:
+            raise ManifestError(f"Unsupported chip family for {target['id']}.")
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", target["id"]):
+            raise ManifestError(f"Invalid target id: {target['id']}.")
+        if not isinstance(target["aliases"], list):
+            raise ManifestError(f"Aliases must be an array for {target['id']}.")
+        for value, seen, label in (
+            (target["id"], ids, "target id"),
+            (target["buildFlag"], flags, "build flag"),
+            (target["assetSuffix"], suffixes, "asset suffix"),
+        ):
+            if value in seen:
+                raise ManifestError(f"Duplicate {label}: {value}.")
+            seen.add(value)
+
+    return registry
+
+
+def target_for_flag(registry: dict[str, Any], build_flag: str) -> dict[str, Any]:
+    matches = [target for target in registry["targets"] if target["buildFlag"] == build_flag]
+    if len(matches) != 1:
+        raise ManifestError(f"Expected exactly one registry target for {build_flag}.")
+    return matches[0]
+
+
+def parse_size(value: str) -> int:
+    match = SIZE_PATTERN.fullmatch(value)
+    if not match:
+        raise ManifestError(f"Unsupported flash size: {value}.")
+    multiplier = {
+        None: 1,
+        "B": 1,
+        "K": 1024,
+        "KB": 1024,
+        "M": 1024 * 1024,
+        "MB": 1024 * 1024,
+    }[match.group("unit").upper() if match.group("unit") else None]
+    return int(match.group("size")) * multiplier
+
+
+def role_for_file(path: Path) -> str:
+    name = path.name.lower()
+    if "bootloader" in name:
+        return "bootloader"
+    if "partition" in name:
+        return "partition-table"
+    if "boot_app0" in name or "ota_data" in name:
+        return "ota-data"
+    if name.endswith(".ino.bin"):
+        return "application"
+    return "auxiliary"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_flash_args(build_dir: Path) -> tuple[dict[str, str], list[tuple[int, Path]]]:
+    candidates = [build_dir / "flash_args", build_dir / "flash_args.txt"]
+    flash_args = next((candidate for candidate in candidates if candidate.is_file()), None)
+    if flash_args is None:
+        raise ManifestError(f"No flash_args or flash_args.txt found in {build_dir}.")
+
+    tokens = shlex.split(flash_args.read_text(encoding="utf-8"))
+    options: dict[str, str] = {}
+    for option in ("--flash_mode", "--flash_freq", "--flash_size"):
+        try:
+            index = tokens.index(option)
+            options[option] = tokens[index + 1]
+        except (ValueError, IndexError) as error:
+            raise ManifestError(f"{flash_args} does not declare {option}.") from error
+
+    segments: list[tuple[int, Path]] = []
+    for index, token in enumerate(tokens[:-1]):
+        if not OFFSET_PATTERN.fullmatch(token):
+            continue
+        raw_path = Path(tokens[index + 1])
+        source = raw_path if raw_path.is_absolute() else build_dir / raw_path
+        source = source.resolve()
+        if not source.is_file():
+            raise ManifestError(f"Flash segment does not exist: {source}.")
+        segments.append((int(token, 16), source))
+
+    if not segments:
+        raise ManifestError(f"{flash_args} does not contain any flash segments.")
+    if len({offset for offset, _ in segments}) != len(segments):
+        raise ManifestError("Flash arguments contain duplicate offsets.")
+    if len([path for _, path in segments if role_for_file(path) == "application"]) != 1:
+        raise ManifestError("Flash arguments must contain exactly one application image.")
+    return options, sorted(segments)
+
+
+def generate_target_manifest(
+    registry_path: Path,
+    build_flag: str,
+    build_dir: Path,
+    version: str,
+    release_date: str,
+    source_commit: str,
+    output_dir: Path,
+) -> Path:
+    if not SHA_PATTERN.fullmatch(source_commit):
+        raise ManifestError("sourceCommit must be a full lowercase Git SHA.")
+    if not re.fullmatch(r"v[0-9A-Za-z._-]+", version):
+        raise ManifestError("Version must begin with v and contain filename-safe characters.")
+    if not re.fullmatch(r"\d{8}", release_date):
+        raise ManifestError("Release date must use YYYYMMDD.")
+
+    registry = load_registry(registry_path)
+    target = target_for_flag(registry, build_flag)
+    options, source_segments = parse_flash_args(build_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    version_slug = version.replace(".", "_")
+    application_stem = (
+        f"esp32_marauder_{version_slug}_{release_date}_{target['assetSuffix']}"
+    )
+    copied_segments: list[dict[str, Any]] = []
+    used_names: set[str] = set()
+
+    for offset, source in source_segments:
+        role = role_for_file(source)
+        destination_name = (
+            f"{application_stem}.bin"
+            if role == "application"
+            else f"{application_stem}.{role}.bin"
+        )
+        if destination_name in used_names:
+            raise ManifestError(f"Multiple segments resolve to {destination_name}.")
+        used_names.add(destination_name)
+        destination = output_dir / destination_name
+        shutil.copyfile(source, destination)
+        if destination.stat().st_size == 0:
+            raise ManifestError(f"Flash segment is empty: {source}.")
+        copied_segments.append(
+            {
+                "role": role,
+                "offset": offset,
+                "size": destination.stat().st_size,
+                "sha256": sha256(destination),
+                "fileName": destination.name,
+            }
+        )
+
+    flash_size_bytes = parse_size(options["--flash_size"])
+    for index, segment in enumerate(copied_segments):
+        end = segment["offset"] + segment["size"]
+        if end > flash_size_bytes:
+            raise ManifestError(f"{segment['role']} exceeds the declared flash size.")
+        next_segment = (
+            copied_segments[index + 1] if index + 1 < len(copied_segments) else None
+        )
+        if next_segment and end > next_segment["offset"]:
+            raise ManifestError(
+                f"{segment['role']} overlaps {next_segment['role']} in flash arguments."
+            )
+
+    application = [segment for segment in copied_segments if segment["role"] == "application"]
+    target_manifest = {
+        "schemaVersion": SCHEMA_VERSION,
+        "kind": "esp32-marauder-installer-target",
+        "metadataStatus": "authoritative",
+        "sourceRepository": SOURCE_REPOSITORY,
+        "sourceCommit": source_commit,
+        "channel": "stable",
+        "version": version,
+        "target": target,
+        "flash": {
+            "sizeBytes": flash_size_bytes,
+            "mode": options["--flash_mode"],
+            "frequency": options["--flash_freq"],
+            "update": {
+                "erase": False,
+                "preservesUserData": True,
+                "segments": application,
+            },
+            "factory": {
+                "erase": True,
+                "preservesUserData": False,
+                "segments": copied_segments,
+            },
+        },
+    }
+    output_path = output_dir / f"{target['id']}.installer.json"
+    output_path.write_text(json.dumps(target_manifest, indent=2) + "\n", encoding="utf-8")
+    return output_path
+
+
+def combine_manifests(registry_path: Path, input_dir: Path, output_path: Path) -> Path:
+    registry = load_registry(registry_path)
+    paths = sorted(input_dir.glob("*.installer.json"))
+    manifests = [read_json(path) for path in paths]
+    expected_ids = {target["id"] for target in registry["targets"]}
+    actual_ids = {
+        manifest.get("target", {}).get("id")
+        for manifest in manifests
+        if isinstance(manifest.get("target"), dict)
+    }
+    if actual_ids != expected_ids:
+        missing = sorted(expected_ids - actual_ids)
+        extra = sorted(actual_ids - expected_ids)
+        raise ManifestError(
+            f"Release target coverage mismatch; missing={missing}, extra={extra}."
+        )
+
+    versions = {manifest.get("version") for manifest in manifests}
+    commits = {manifest.get("sourceCommit") for manifest in manifests}
+    channels = {manifest.get("channel") for manifest in manifests}
+    kinds = {manifest.get("kind") for manifest in manifests}
+    statuses = {manifest.get("metadataStatus") for manifest in manifests}
+    if len(versions) != 1 or len(commits) != 1 or channels != {"stable"}:
+        raise ManifestError("Target manifests disagree on version, commit, or stable channel.")
+    if kinds != {"esp32-marauder-installer-target"}:
+        raise ManifestError("Unexpected target manifest kind.")
+    if statuses != {"authoritative"}:
+        raise ManifestError("Target metadata is not authoritative.")
+
+    release_manifest = {
+        "$schema": (
+            "https://raw.githubusercontent.com/"
+            f"{SOURCE_REPOSITORY}/{next(iter(commits))}/"
+            "installer/firmware-manifest.schema.json"
+        ),
+        "schemaVersion": SCHEMA_VERSION,
+        "kind": "esp32-marauder-installer-release",
+        "metadataStatus": "authoritative",
+        "sourceRepository": SOURCE_REPOSITORY,
+        "sourceCommit": commits.pop(),
+        "channel": "stable",
+        "version": versions.pop(),
+        "targets": sorted(
+            (manifest["target"] | {"flash": manifest["flash"]} for manifest in manifests),
+            key=lambda target: target["id"],
+        ),
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(release_manifest, indent=2) + "\n", encoding="utf-8")
+    return output_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", type=Path, default=Path("installer/targets.json"))
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--validate-registry", action="store_true")
+    action.add_argument("--generate-target", action="store_true")
+    action.add_argument("--combine", action="store_true")
+    parser.add_argument("--build-flag")
+    parser.add_argument("--build-dir", type=Path)
+    parser.add_argument("--version")
+    parser.add_argument("--release-date")
+    parser.add_argument("--source-commit")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--input-dir", type=Path)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def require(value: Any, name: str) -> Any:
+    if value is None:
+        raise ManifestError(f"{name} is required for this operation.")
+    return value
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if args.validate_registry:
+        registry = load_registry(args.registry)
+        print(f"Validated {len(registry['targets'])} installer targets.")
+        return
+    if args.generate_target:
+        output = generate_target_manifest(
+            args.registry,
+            require(args.build_flag, "--build-flag"),
+            require(args.build_dir, "--build-dir"),
+            require(args.version, "--version"),
+            require(args.release_date, "--release-date"),
+            require(args.source_commit, "--source-commit"),
+            require(args.output_dir, "--output-dir"),
+        )
+        print(output)
+        return
+    output = combine_manifests(
+        args.registry,
+        require(args.input_dir, "--input-dir"),
+        require(args.output, "--output"),
+    )
+    print(output)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ManifestError as error:
+        raise SystemExit(f"installer manifest error: {error}") from error

--- a/tools/installer_manifest.py
+++ b/tools/installer_manifest.py
@@ -119,19 +119,47 @@ def sha256(path: Path) -> str:
 
 
 def parse_flash_args(build_dir: Path) -> tuple[dict[str, str], list[tuple[int, Path]]]:
-    candidates = [build_dir / "flash_args", build_dir / "flash_args.txt"]
-    flash_args = next((candidate for candidate in candidates if candidate.is_file()), None)
-    if flash_args is None:
-        raise ManifestError(f"No flash_args or flash_args.txt found in {build_dir}.")
-
-    tokens = shlex.split(flash_args.read_text(encoding="utf-8"))
-    options: dict[str, str] = {}
-    for option in ("--flash_mode", "--flash_freq", "--flash_size"):
+    properties_path = build_dir / "arduino-build-properties.txt"
+    if properties_path.is_file():
+        properties: dict[str, str] = {}
+        for line in properties_path.read_text(encoding="utf-8").splitlines():
+            key, separator, value = line.partition("=")
+            if separator:
+                properties[key] = value
         try:
-            index = tokens.index(option)
-            options[option] = tokens[index + 1]
-        except (ValueError, IndexError) as error:
-            raise ManifestError(f"{flash_args} does not declare {option}.") from error
+            tokens = shlex.split(properties["tools.esptool_py.upload.pattern_args"])
+            options = {
+                "--flash_mode": properties["build.flash_mode"],
+                "--flash_freq": properties["build.flash_freq"],
+                "--flash_size": properties["build.flash_size"],
+            }
+        except KeyError as error:
+            raise ManifestError(
+                f"{properties_path} is missing required ESP32 upload properties: {error.args[0]}."
+            ) from error
+        source_description = properties_path
+    else:
+        candidates = [build_dir / "flash_args", build_dir / "flash_args.txt"]
+        flash_args = next((candidate for candidate in candidates if candidate.is_file()), None)
+        if flash_args is None:
+            raise ManifestError(
+                f"No Arduino build properties or flash_args found in {build_dir}."
+            )
+        tokens = shlex.split(flash_args.read_text(encoding="utf-8"))
+        options = {}
+        for normalized, spellings in (
+            ("--flash_mode", ("--flash_mode", "--flash-mode")),
+            ("--flash_freq", ("--flash_freq", "--flash-freq")),
+            ("--flash_size", ("--flash_size", "--flash-size")),
+        ):
+            option = next((spelling for spelling in spellings if spelling in tokens), None)
+            try:
+                if option is None:
+                    raise ValueError
+                options[normalized] = tokens[tokens.index(option) + 1]
+            except (ValueError, IndexError) as error:
+                raise ManifestError(f"{flash_args} does not declare {normalized}.") from error
+        source_description = flash_args
 
     segments: list[tuple[int, Path]] = []
     for index, token in enumerate(tokens[:-1]):
@@ -145,7 +173,7 @@ def parse_flash_args(build_dir: Path) -> tuple[dict[str, str], list[tuple[int, P
         segments.append((int(token, 16), source))
 
     if not segments:
-        raise ManifestError(f"{flash_args} does not contain any flash segments.")
+        raise ManifestError(f"{source_description} does not contain any flash segments.")
     if len({offset for offset, _ in segments}) != len(segments):
         raise ManifestError("Flash arguments contain duplicate offsets.")
     if len([path for _, path in segments if role_for_file(path) == "application"]) != 1:

--- a/tools/test_installer_manifest.py
+++ b/tools/test_installer_manifest.py
@@ -41,6 +41,8 @@ class InstallerManifestTests(unittest.TestCase):
         )
         workflow_flags = set(re.findall(r'flag: "([A-Z0-9_]+)"', workflow))
         registry_flags = {target["buildFlag"] for target in registry["targets"]}
+        self.assertIn("set-build-path: true", workflow)
+        self.assertIn("BUILD_DIR=./esp32_marauder/build", workflow)
         self.assertEqual(len(registry["targets"]), 22)
         self.assertEqual(registry_flags, workflow_flags)
         self.assertEqual(

--- a/tools/test_installer_manifest.py
+++ b/tools/test_installer_manifest.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.installer_manifest import (
+    ManifestError,
+    combine_manifests,
+    generate_target_manifest,
+    load_registry,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = REPOSITORY_ROOT / "installer" / "targets.json"
+
+
+class InstallerManifestTests(unittest.TestCase):
+    @staticmethod
+    def make_fake_build(root: Path) -> Path:
+        build = root / "build"
+        build.mkdir()
+        (build / "bootloader.bin").write_bytes(b"boot")
+        (build / "partitions.bin").write_bytes(b"partitions")
+        (build / "boot_app0.bin").write_bytes(b"ota")
+        (build / "esp32_marauder.ino.bin").write_bytes(b"application")
+        (build / "flash_args").write_text(
+            "--flash_mode dio --flash_freq 40m --flash_size 4MB "
+            "0x1000 bootloader.bin 0x8000 partitions.bin "
+            "0xe000 boot_app0.bin 0x10000 esp32_marauder.ino.bin\n",
+            encoding="utf-8",
+        )
+        return build
+
+    def test_registry_contains_unique_complete_build_targets(self) -> None:
+        registry = load_registry(REGISTRY)
+        workflow = (REPOSITORY_ROOT / ".github/workflows/build_parallel.yml").read_text(
+            encoding="utf-8"
+        )
+        workflow_flags = set(re.findall(r'flag: "([A-Z0-9_]+)"', workflow))
+        registry_flags = {target["buildFlag"] for target in registry["targets"]}
+        self.assertEqual(len(registry["targets"]), 22)
+        self.assertEqual(registry_flags, workflow_flags)
+        self.assertEqual(
+            len(registry_flags),
+            len(registry["targets"]),
+        )
+
+    def test_generates_hashed_update_and_factory_segments_from_flash_args(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            build = self.make_fake_build(root)
+            output = root / "output"
+
+            path = generate_target_manifest(
+                REGISTRY,
+                "MARAUDER_V6",
+                build,
+                "v1.2.3",
+                "20260731",
+                "a" * 40,
+                output,
+            )
+            manifest = json.loads(path.read_text(encoding="utf-8"))
+
+            self.assertEqual(manifest["channel"], "stable")
+            self.assertEqual(manifest["metadataStatus"], "authoritative")
+            self.assertEqual(manifest["target"]["id"], "marauder-v6")
+            self.assertEqual(manifest["flash"]["sizeBytes"], 4 * 1024 * 1024)
+            self.assertEqual(len(manifest["flash"]["update"]["segments"]), 1)
+            self.assertEqual(len(manifest["flash"]["factory"]["segments"]), 4)
+            for segment in manifest["flash"]["factory"]["segments"]:
+                self.assertRegex(segment["sha256"], r"^[0-9a-f]{64}$")
+                self.assertTrue((output / segment["fileName"]).is_file())
+
+    def test_fails_closed_without_actual_flash_arguments(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaisesRegex(ManifestError, "No flash_args"):
+                generate_target_manifest(
+                    REGISTRY,
+                    "MARAUDER_V6",
+                    Path(temporary),
+                    "v1.2.3",
+                    "20260731",
+                    "a" * 40,
+                    Path(temporary) / "output",
+                )
+
+    def test_combiner_requires_complete_registry_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with self.assertRaisesRegex(ManifestError, "coverage mismatch"):
+                combine_manifests(REGISTRY, root, root / "firmware-manifest.json")
+
+    def test_combines_complete_stable_release(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            build = self.make_fake_build(root)
+            output = root / "output"
+            registry = load_registry(REGISTRY)
+            for target in registry["targets"]:
+                generate_target_manifest(
+                    REGISTRY,
+                    target["buildFlag"],
+                    build,
+                    "v1.2.3",
+                    "20260731",
+                    "a" * 40,
+                    output,
+                )
+
+            release_path = combine_manifests(
+                REGISTRY, output, output / "firmware-manifest.json"
+            )
+            release = json.loads(release_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(release["metadataStatus"], "authoritative")
+            self.assertEqual(release["channel"], "stable")
+            self.assertEqual(release["sourceCommit"], "a" * 40)
+            self.assertEqual(len(release["targets"]), 22)
+            self.assertIn("/" + "a" * 40 + "/", release["$schema"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_installer_manifest.py
+++ b/tools/test_installer_manifest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -10,11 +9,14 @@ from tools.installer_manifest import (
     ManifestError,
     combine_manifests,
     generate_target_manifest,
+    load_normal_build_matrix,
     load_registry,
 )
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 REGISTRY = REPOSITORY_ROOT / "installer" / "targets.json"
+NORMAL_WORKFLOW = REPOSITORY_ROOT / ".github/workflows/build_parallel.yml"
+INSTALLER_WORKFLOW = REPOSITORY_ROOT / ".github/workflows/build_installer_manifests.yml"
 
 
 class InstallerManifestTests(unittest.TestCase):
@@ -52,20 +54,32 @@ class InstallerManifestTests(unittest.TestCase):
 
     def test_registry_contains_unique_complete_build_targets(self) -> None:
         registry = load_registry(REGISTRY)
-        workflow = (REPOSITORY_ROOT / ".github/workflows/build_parallel.yml").read_text(
-            encoding="utf-8"
-        )
-        workflow_flags = set(re.findall(r'flag: "([A-Z0-9_]+)"', workflow))
+        boards = load_normal_build_matrix(NORMAL_WORKFLOW, REGISTRY)
+        workflow_flags = {board["flag"] for board in boards}
         registry_flags = {target["buildFlag"] for target in registry["targets"]}
-        self.assertIn("set-build-path: true", workflow)
-        self.assertIn("BUILD_DIR=./esp32_marauder/build", workflow)
-        self.assertIn("--show-properties=expanded", workflow)
+        normal_workflow = NORMAL_WORKFLOW.read_text(encoding="utf-8")
+        installer_workflow = INSTALLER_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertNotIn("installer_manifest.py", normal_workflow)
+        self.assertIn("--export-build-matrix", installer_workflow)
+        self.assertIn("set-build-path: true", installer_workflow)
+        self.assertIn("--show-properties=expanded", installer_workflow)
+        self.assertIn("github.event_name == 'release'", installer_workflow)
         self.assertEqual(len(registry["targets"]), 22)
+        self.assertEqual(len(boards), 22)
         self.assertEqual(registry_flags, workflow_flags)
         self.assertEqual(
             len(registry_flags),
             len(registry["targets"]),
         )
+
+    def test_build_matrix_parser_fails_closed_on_unsupported_syntax(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workflow = Path(temporary) / "build_parallel.yml"
+            contents = NORMAL_WORKFLOW.read_text(encoding="utf-8")
+            workflow.write_text(contents.replace("fbqn:", "fbqn=", 1), encoding="utf-8")
+            with self.assertRaisesRegex(ManifestError, "Unsupported build matrix syntax"):
+                load_normal_build_matrix(workflow, REGISTRY)
 
     def test_generates_hashed_update_and_factory_segments_from_flash_args(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -91,6 +105,9 @@ class InstallerManifestTests(unittest.TestCase):
             self.assertEqual(len(manifest["flash"]["update"]["segments"]), 1)
             self.assertEqual(len(manifest["flash"]["factory"]["segments"]), 4)
             for segment in manifest["flash"]["factory"]["segments"]:
+                self.assertTrue(
+                    segment["fileName"].startswith("esp32_marauder_installer_")
+                )
                 self.assertRegex(segment["sha256"], r"^[0-9a-f]{64}$")
                 self.assertTrue((output / segment["fileName"]).is_file())
 

--- a/tools/test_installer_manifest.py
+++ b/tools/test_installer_manifest.py
@@ -34,6 +34,22 @@ class InstallerManifestTests(unittest.TestCase):
         )
         return build
 
+    @staticmethod
+    def make_fake_properties_build(root: Path) -> Path:
+        build = InstallerManifestTests.make_fake_build(root)
+        (build / "flash_args").unlink()
+        (build / "arduino-build-properties.txt").write_text(
+            "build.flash_mode=dio\n"
+            "build.flash_freq=80m\n"
+            "build.flash_size=4MB\n"
+            "tools.esptool_py.upload.pattern_args=--chip esp32 --flash-mode keep "
+            "--flash-freq keep --flash-size keep 0x1000 bootloader.bin "
+            "0x8000 partitions.bin 0xe000 boot_app0.bin "
+            "0x10000 esp32_marauder.ino.bin\n",
+            encoding="utf-8",
+        )
+        return build
+
     def test_registry_contains_unique_complete_build_targets(self) -> None:
         registry = load_registry(REGISTRY)
         workflow = (REPOSITORY_ROOT / ".github/workflows/build_parallel.yml").read_text(
@@ -43,6 +59,7 @@ class InstallerManifestTests(unittest.TestCase):
         registry_flags = {target["buildFlag"] for target in registry["targets"]}
         self.assertIn("set-build-path: true", workflow)
         self.assertIn("BUILD_DIR=./esp32_marauder/build", workflow)
+        self.assertIn("--show-properties=expanded", workflow)
         self.assertEqual(len(registry["targets"]), 22)
         self.assertEqual(registry_flags, workflow_flags)
         self.assertEqual(
@@ -79,7 +96,7 @@ class InstallerManifestTests(unittest.TestCase):
 
     def test_fails_closed_without_actual_flash_arguments(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
-            with self.assertRaisesRegex(ManifestError, "No flash_args"):
+            with self.assertRaisesRegex(ManifestError, "No Arduino build properties"):
                 generate_target_manifest(
                     REGISTRY,
                     "MARAUDER_V6",
@@ -89,6 +106,31 @@ class InstallerManifestTests(unittest.TestCase):
                     "a" * 40,
                     Path(temporary) / "output",
                 )
+
+    def test_generates_from_expanded_arduino_upload_properties(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            build = self.make_fake_properties_build(root)
+            output = root / "output"
+
+            path = generate_target_manifest(
+                REGISTRY,
+                "MARAUDER_FLIPPER",
+                build,
+                "v1.2.3",
+                "20260731",
+                "a" * 40,
+                output,
+            )
+            manifest = json.loads(path.read_text(encoding="utf-8"))
+
+            self.assertEqual(manifest["flash"]["mode"], "dio")
+            self.assertEqual(manifest["flash"]["frequency"], "80m")
+            self.assertEqual(manifest["flash"]["sizeBytes"], 4 * 1024 * 1024)
+            self.assertEqual(
+                [segment["offset"] for segment in manifest["flash"]["factory"]["segments"]],
+                [0x1000, 0x8000, 0xE000, 0x10000],
+            )
 
     def test_combiner_requires_complete_registry_coverage(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Outcome

Adds a fail-closed, machine-readable stable installer manifest path without changing the existing normal release workflow or its downloadable binaries.

## Isolation and source of truth

- `.github/workflows/build_parallel.yml` is byte-for-byte identical to `develop` (Git blob `55e032a31b8f7633515614a962fdcbb97645839a`).
- All installer automation lives in the additive `.github/workflows/build_installer_manifests.yml` workflow.
- The installer workflow exports its 22-target matrix directly from the unchanged normal workflow and fails closed if that matrix and `installer/targets.json` drift.
- Installer assets use an `esp32_marauder_installer_` namespace and cannot overwrite normal release binary filenames.

## Triggers and release behavior

- Pull request and relevant `develop` pushes: full validation and artifact-only installer builds.
- Manual dispatch: artifact-only; no release creation or mutation.
- Published non-prerelease release: independently rebuild all 22 targets from the release tag, combine the authoritative manifest, then attach only additive installer assets to the existing release.
- Nightly/prerelease publication remains excluded.

## Verification

- target registry validation: 22 targets
- matrix export from normal workflow: 22 targets
- Python unit tests: 7 pass
- Python bytecode, registry/schema JSON, and all workflow YAML parsing: pass
- `build_parallel.yml` feature/develop diff: zero

## Tradeoff

The isolated design deliberately performs a second 22-target build for stable installer assets so it can capture authoritative bootloader, partition, OTA-data, and application segments without modifying the established release jobs.