### PR TITLE
chore: bump firmware version to v1.14.1

### DIFF
--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -41,7 +41,7 @@
 
   #define JSON_SETTING_SIZE 2048
 
-  #define MARAUDER_VERSION "v1.14.0"
+  #define MARAUDER_VERSION "v1.14.1"
 
   #define GRAPH_REFRESH   100
 


### PR DESCRIPTION
## Scope
Updates only `esp32_marauder/configs.h`: `MARAUDER_VERSION` from `v1.14.0` to `v1.14.1`.

## Validation
- `python3 tools/installer_manifest.py --validate-registry`
- `python3 -m unittest tools/test_installer_manifest.py -v`

No release, master change, workflow change, or installer asset publication is included.