### PR TITLE
ci: publish firmware unit-test coverage badge

### DIFF
--- a/.github/workflows/firmware-unit-tests.yml
+++ b/.github/workflows/firmware-unit-tests.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: firmware-unit-tests-${{ github.event.pull_request.number || github.ref }}
@@ -26,7 +27,18 @@ jobs:
       - name: Install PlatformIO
         run: |
           python3 -m venv .venv
-          .venv/bin/python -m pip install --disable-pip-version-check platformio==6.1.19
+          .venv/bin/python -m pip install --disable-pip-version-check platformio==6.1.19 gcovr==7.2
 
       - name: Run firmware unit tests
         run: .venv/bin/platformio test -e native
+
+      - name: Generate coverage report
+        run: .venv/bin/gcovr --root . --filter esp32_marauder --exclude test --cobertura coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
+        with:
+          files: coverage.xml
+          flags: firmware-unit-tests
+          fail_ci_if_error: false
+          use_oidc: true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 </p>
     
 [![Build and Push](https://github.com/justcallmekoko/ESP32Marauder/actions/workflows/build_push.yml/badge.svg)](https://github.com/justcallmekoko/ESP32Marauder/actions/workflows/build_push.yml)
+[![Firmware coverage](https://codecov.io/gh/justcallmekoko/ESP32Marauder/branch/develop/graph/badge.svg?flag=firmware-unit-tests)](https://app.codecov.io/gh/justcallmekoko/ESP32Marauder/tree/develop)
 
 ## Getting Started
 Download the [latest release](https://github.com/justcallmekoko/ESP32Marauder/releases/latest) of the firmware.  

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,8 @@ test_dir = test
 platform = native@1.2.1
 test_framework = unity
 test_build_src = true
+extra_scripts =
+  pre:tools/native_coverage.py
 build_src_filter =
   -<*>
   +<MarauderMacAddress.cpp>
@@ -14,3 +16,4 @@ build_flags =
   -Wall
   -Wextra
   -Wpedantic
+  --coverage

--- a/tools/native_coverage.py
+++ b/tools/native_coverage.py
@@ -1,0 +1,3 @@
+Import("env")
+
+env.Append(LINKFLAGS=["--coverage"])


### PR DESCRIPTION
## Summary
- instrument the PlatformIO Native test target for gcov coverage
- generate and upload a Cobertura report to Codecov using OIDC
- add a firmware coverage badge to the repository README

## Verification
- `platformio test -e native` — 7/7 tests passed
- `gcovr --root . --filter esp32_marauder --exclude test` — 100% line coverage for the currently tested `MarauderMacAddress.cpp` module

The workflow keeps its existing pull-request triggers and remains non-blocking if the external coverage upload is unavailable.