### PR TITLE
Fix Ping/ARP/Port subnet scans returning no hosts when gateway is high in the subnet

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -2097,6 +2097,24 @@ void WiFiScan::showNetworkInfo() {
   #endif
 }
 
+// Scan header: push network context through the scroll buffer (not a direct TFT
+// banner) so it scrolls with results instead of overlaying them, and no delay.
+void WiFiScan::showScanNetworkInfo() {
+  Serial.print(F("IP address: ")); Serial.println(this->ip_addr);
+  Serial.print(F("Gateway: ")); Serial.println(this->gateway);
+  Serial.print(F("Netmask: ")); Serial.println(this->subnet);
+  Serial.print(F("MAC: ")); Serial.println(WiFi.macAddress());
+  #ifdef HAS_SCREEN
+    // Header lines pushed through the scroll buffer (so they scroll with the
+    // results, no overlay), colored red via the RED_KEY line prefix.
+    display_obj.display_buffer->add(String(RED_KEY) + "Connected!");
+    display_obj.display_buffer->add(String(RED_KEY) + "IP address: " + this->ip_addr.toString());
+    display_obj.display_buffer->add(String(RED_KEY) + "Gateway: " + this->gateway.toString());
+    display_obj.display_buffer->add(String(RED_KEY) + "Netmask: " + this->subnet.toString());
+    display_obj.display_buffer->add(String(RED_KEY) + "MAC: " + WiFi.macAddress());
+  #endif
+}
+
 bool WiFiScan::joinWiFi(String ssid, String password, bool gui) {
   static const char * btns[] ={text16, ""};
   int count = 0;
@@ -3349,7 +3367,7 @@ void WiFiScan::RunPingScan(uint8_t scan_mode, uint16_t color) {
     Serial.println(F("Starting Ping Scan with..."));
   else if (scan_mode == WIFI_ARP_SCAN)
     Serial.println(F("Starting ARP Scan with..."));
-  this->showNetworkInfo();
+  this->showScanNetworkInfo();
 
   if (scan_mode == WIFI_PING_SCAN)
     buffer_obj.append(F("Starting Ping Scan with..."));
@@ -3425,7 +3443,7 @@ void WiFiScan::RunPortScanAll(uint8_t scan_mode, uint16_t color) {
     this->current_scan_ip = getNetworkBase(this->ip_addr, this->subnet);
 
   Serial.println(F("Starting Port Scan with..."));
-  this->showNetworkInfo();
+  this->showScanNetworkInfo();
 
   buffer_obj.append(F("Starting Port Scan with..."));
   this->writeNetworkInfo();

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -3342,7 +3342,7 @@ void WiFiScan::RunPingScan(uint8_t scan_mode, uint16_t color) {
     #endif
     this->prepareScanStage(TFT_RED, TFT_BLACK);
   #endif
-  this->current_scan_ip = this->gateway;
+  this->current_scan_ip = getNetworkBase(this->ip_addr, this->subnet);
   //Serial.print(F("Cleared IPs: "));
   this->clearList(CLEAR_IPS);
   if (scan_mode == WIFI_PING_SCAN)
@@ -3422,7 +3422,7 @@ void WiFiScan::RunPortScanAll(uint8_t scan_mode, uint16_t color) {
       (scan_mode == WIFI_SCAN_HTTP) ||
       (scan_mode == WIFI_SCAN_HTTPS) ||
       (scan_mode == WIFI_SCAN_RDP))
-    this->current_scan_ip = this->gateway;
+    this->current_scan_ip = getNetworkBase(this->ip_addr, this->subnet);
 
   Serial.println(F("Starting Port Scan with..."));
   this->showNetworkInfo();

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -703,6 +703,7 @@ class WiFiScan
     void setupScanDisplayArea(uint16_t background, uint16_t color);
     void updateTrackerUI();
     void showNetworkInfo();
+    void showScanNetworkInfo();
     void setNetworkInfo();
     void fullARP();
     bool readARP(IPAddress targ_ip);

--- a/esp32_marauder/utils.h
+++ b/esp32_marauder/utils.h
@@ -205,6 +205,13 @@ inline void convertMacStringToUint8(const String& macStr, uint8_t macAddr[6]) {
 }
 
 
+// Network base address (ip & mask), so subnet scans cover the whole range
+// regardless of where the gateway sits (e.g. .254 routers). getNextIP walks up from here.
+inline IPAddress getNetworkBase(IPAddress ip, IPAddress subnetMask) {
+  return IPAddress(ip[0] & subnetMask[0], ip[1] & subnetMask[1],
+                   ip[2] & subnetMask[2], ip[3] & subnetMask[3]);
+}
+
 inline IPAddress getNextIP(IPAddress currentIP, IPAddress subnetMask) {
   // Convert IPAddress to uint32_t
   uint32_t ipInt = (currentIP[0] << 24) | (currentIP[1] << 16) | (currentIP[2] << 8) | currentIP[3];


### PR DESCRIPTION
## Problem

`Ping Scan`, `ARP Scan`, and `Port Scan` (including the SSH/Telnet/DNS/HTTP/HTTPS/RDP service scans) return **no hosts** and jump straight to "Scan complete" on any network whose gateway sits high in the subnet — e.g. `192.168.1.254`, common on ISP-issued routers.

Fixes #802 (CYD 2.8", gateway `192.168.1.254`, netmask `255.255.255.0` — reporter gets an instant empty "Scan complete", exactly this bug).

## Root cause

The subnet scan seeds `current_scan_ip` at the **gateway** and walks upward with `getNextIP()`:

```cpp
this->current_scan_ip = this->gateway;
...
this->current_scan_ip = getNextIP(this->current_scan_ip, this->subnet);
```

`getNextIP()` returns `0.0.0.0` (end-of-scan) as soon as the next address reaches the broadcast. When the gateway is near the top of the range that happens on the first step:

- Gateway `192.168.1.254`, `/24` → `getNextIP(.254)` → `.255` ≥ broadcast → returns `0.0.0.0` on the **first call** → scan ends having checked **zero** hosts.
- Gateway `192.168.1.1` (what the code implicitly assumes) → walks `.2 … .254` → works.

## Fix

Seed the scan at the **network base** (`ip & netmask`) instead of the gateway, so the whole subnet is covered regardless of gateway position:

```cpp
this->current_scan_ip = getNetworkBase(this->ip_addr, this->subnet);
```

Verified with a standalone copy of `getNextIP` (`/24`):

| seed | hosts scanned |
|---|---|
| gateway `.254` (bug) | 0 |
| gateway `.1` | 253 |
| network base `.0` (fix) | 254 |

On real hardware (CYD 2432S028, gateway `.254`) the ping scan now returns the full set of live hosts. When disconnected (`ip`/`subnet` are `0.0.0.0`) the seed is `0.0.0.0` and the existing guard short-circuits to "Scan complete" as before — no regression.

## Scope

Board-agnostic: `getNextIP` and the gateway seed live in shared code (`utils.h`, `WiFiScan.cpp`), and `pingscan`/`portscan` are in shared `CommandLine.cpp` — so every board, screened or headless, is affected on high-gateway networks.

## Second commit — display cleanup

Once the scan produced actual results, they collided with the network-info banner that `RunPingScan`/`RunPortScanAll` drew via `showNetworkInfo()` (a join-style banner painted directly to the TFT with a 2s delay, never cleared). The second commit routes that header (`Connected!/IP/Gateway/Netmask/MAC`) through the scroll buffer like the results, colored red via the existing `RED_KEY` prefix, so it scrolls cleanly instead of overlaying output. The join-flow `showNetworkInfo()` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rYGeAyf9oUzresEwurgu5
