### PR TITLE
Add Chasing Your Tail time-window detection to MAC Monitor

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -263,7 +263,10 @@ void CommandLine::runCommand(String input) {
       Serial.println(HELP_WARDRIVEPOI_CMD);
     #endif
     Serial.println(HELP_MAC_TRACK_CMD);
-    
+    Serial.println(HELP_TAIL_IGNORE_CMD);
+    Serial.println(HELP_TAIL_ZONE_CMD);
+    Serial.println(HELP_TAIL_REPORT_CMD);
+
     // WiFi attack
     Serial.println(HELP_ATTACK_CMD);
     
@@ -791,6 +794,78 @@ void CommandLine::runCommand(String input) {
         menu_function_obj.drawStatusBar();
       #endif
       wifi_scan_obj.StartScan(WIFI_SCAN_DETECT_FOLLOW, TFT_MAGENTA);*/
+    }
+    // Tail ignore list
+    else if (cmd_args.get(0) == TAIL_IGNORE_CMD) {
+      int add_sw = this->argSearch(&cmd_args, "-a");
+      int rem_sw = this->argSearch(&cmd_args, "-r");
+      int list_sw = this->argSearch(&cmd_args, "-l");
+      int clear_sw = this->argSearch(&cmd_args, "-c");
+      int baseline_sw = this->argSearch(&cmd_args, "-b");
+      int mac_sw = this->argSearch(&cmd_args, "-m");
+
+      if (add_sw != -1) {
+        if (mac_sw == -1 || !this->checkValueExists(&cmd_args, mac_sw)) {
+          Serial.println(F("MAC required: tailignore -a -m <mac>"));
+        } else {
+          wifi_scan_obj.addIgnoreMac(cmd_args.get(mac_sw + 1));
+        }
+      }
+      else if (rem_sw != -1) {
+        if (mac_sw == -1 || !this->checkValueExists(&cmd_args, mac_sw)) {
+          Serial.println(F("MAC required: tailignore -r -m <mac>"));
+        } else {
+          wifi_scan_obj.removeIgnoreMac(cmd_args.get(mac_sw + 1));
+        }
+      }
+      else if (list_sw != -1) {
+        wifi_scan_obj.loadTailIgnoreData();
+        Serial.println("Tail ignore list (" + (String)wifi_scan_obj.tail_ignore_macs->size() + "):");
+        for (int i = 0; i < wifi_scan_obj.tail_ignore_macs->size(); i++) {
+          Serial.println(wifi_scan_obj.tail_ignore_macs->get(i));
+        }
+      }
+      else if (clear_sw != -1) {
+        wifi_scan_obj.clearIgnoreMacs();
+      }
+      else if (baseline_sw != -1) {
+        wifi_scan_obj.startTailBaselineScan();
+      }
+      else {
+        Serial.println(HELP_TAIL_IGNORE_CMD);
+      }
+    }
+    // Tail safe zones
+    else if (cmd_args.get(0) == TAIL_ZONE_CMD) {
+      #ifdef HAS_GPS
+        int add_sw = this->argSearch(&cmd_args, "-a");
+        int clear_sw = this->argSearch(&cmd_args, "-c");
+        int radius_sw = this->argSearch(&cmd_args, "-r");
+
+        if (add_sw != -1) {
+          if (!gps_obj.getFixStatus()) {
+            Serial.println(F("Cannot add safe zone: no GPS fix"));
+          } else {
+            uint16_t radius_m = TAIL_DEFAULT_ZONE_RADIUS_M;
+            if (radius_sw != -1 && this->checkValueExists(&cmd_args, radius_sw)) {
+              radius_m = (uint16_t)cmd_args.get(radius_sw + 1).toInt();
+            }
+            wifi_scan_obj.addSafeZone(gps_obj.getLatInt(), gps_obj.getLonInt(), radius_m);
+          }
+        }
+        else if (clear_sw != -1) {
+          wifi_scan_obj.clearSafeZones();
+        }
+        else {
+          Serial.println(HELP_TAIL_ZONE_CMD);
+        }
+      #else
+        Serial.println(F("This board has no GPS"));
+      #endif
+    }
+    // Tail report
+    else if (cmd_args.get(0) == TAIL_REPORT_CMD) {
+      wifi_scan_obj.renderTailReport(false);
     }
 
 

--- a/esp32_marauder/CommandLine.h
+++ b/esp32_marauder/CommandLine.h
@@ -84,6 +84,11 @@ const char PROGMEM ARP_SCAN_CMD[] = "arpscan";
 const char PROGMEM MAC_TRACK_CMD[] = "mactrack";
 const char PROGMEM SNIFF_SAE_CMD[] = "sniffsae";
 
+// MAC Monitor ignore list / safe zones
+const char PROGMEM TAIL_IGNORE_CMD[] = "tailignore";
+const char PROGMEM TAIL_ZONE_CMD[] = "tailzone";
+const char PROGMEM TAIL_REPORT_CMD[] = "tailreport";
+
 // WiFi attack
 const char PROGMEM ATTACK_CMD[] = "attack";
 const char PROGMEM ATTACK_TYPE_DEAUTH[] = "deauth";
@@ -161,6 +166,11 @@ const char PROGMEM HELP_PORT_SCAN_CMD[] = "portscan [-a -t <ip index>]/[-s <ssh/
 const char PROGMEM HELP_ARP_SCAN_CMD[] = "arpscan [-f]";
 const char PROGMEM HELP_MAC_TRACK_CMD[] = "mactrack";
 const char PROGMEM HELP_SNIFF_SAE_CMD[] = "sniffsae";
+
+// MAC Monitor ignore list / safe zones
+const char PROGMEM HELP_TAIL_IGNORE_CMD[] = "tailignore [-a -m <mac>]/[-r -m <mac>]/[-l]/[-c]/[-b]";
+const char PROGMEM HELP_TAIL_ZONE_CMD[] = "tailzone [-a [-r <radius_m>]]/[-c]";
+const char PROGMEM HELP_TAIL_REPORT_CMD[] = "tailreport";
 
 // WiFi attack
 const char PROGMEM HELP_ATTACK_CMD[] = "attack -t <quiet/csa/sae/beacon [-l/-r/-a]/deauth [-c]/[-s <src mac>] [-d <dst mac>]/probe/rickroll/badmsg [-c]/sleep [-c]>";

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1637,6 +1637,9 @@ void MenuFunctions::RunSetup()
 
   foxHuntMenu.list = new LinkedList<MenuNode>();
 
+  tailOptionsMenu.list = new LinkedList<MenuNode>();
+  tailIgnoreMacMenu.list = new LinkedList<MenuNode>();
+
   // Work menu names
   mainMenu.name = text_table1[6];
   wifiMenu.name = text_table1[7];
@@ -1699,6 +1702,8 @@ void MenuFunctions::RunSetup()
   #endif
 
   foxHuntMenu.name = "Fox Hunt";
+  tailOptionsMenu.name = "Tail Options";
+  tailIgnoreMacMenu.name = "Ignore MAC";
 
   // Build Main Menu
   mainMenu.parentMenu = NULL;
@@ -1943,6 +1948,82 @@ void MenuFunctions::RunSetup()
     display_obj.clearScreen();
     this->drawStatusBar();
     wifi_scan_obj.StartScan(WIFI_SCAN_DETECT_FOLLOW, TFT_MAGENTA);
+  });
+  this->addNodes(&wifiSnifferMenu, "Tail Options", TFTMAGENTA, SCANNERS, [this]() {
+    tailOptionsMenu.list->clear();
+    tailOptionsMenu.parentMenu = &wifiSnifferMenu;
+
+    this->addNodes(&tailOptionsMenu, text09, TFTLIGHTGREY, 0, [this]() {
+      this->changeMenu(tailOptionsMenu.parentMenu, true);
+    });
+
+    this->addNodes(&tailOptionsMenu, "Start Tracking", TFTMAGENTA, SCANNERS, [this]() {
+      display_obj.clearScreen();
+      this->drawStatusBar();
+      wifi_scan_obj.StartScan(WIFI_SCAN_DETECT_FOLLOW, TFT_MAGENTA);
+    });
+
+    this->addNodes(&tailOptionsMenu, "Baseline Scan (30s)", TFTYELLOW, SCANNERS, [this]() {
+      display_obj.clearScreen();
+      this->drawStatusBar();
+      wifi_scan_obj.StartScan(WIFI_SCAN_DETECT_FOLLOW, TFT_MAGENTA);
+      wifi_scan_obj.startTailBaselineScan();
+    });
+
+    #ifdef HAS_GPS
+      this->addNodes(&tailOptionsMenu, "Add Safe Zone Here", TFTGREEN, SCANNERS, [this]() {
+        if (gps_obj.getFixStatus()) {
+          wifi_scan_obj.addSafeZone(gps_obj.getLatInt(), gps_obj.getLonInt(), TAIL_DEFAULT_ZONE_RADIUS_M);
+        } else {
+          Serial.println("Cannot add safe zone: no GPS fix");
+        }
+      });
+    #endif
+
+    this->addNodes(&tailOptionsMenu, "Ignore Tracked MAC...", TFTORANGE, SCANNERS, [this]() {
+      tailIgnoreMacMenu.list->clear();
+      tailIgnoreMacMenu.parentMenu = &tailOptionsMenu;
+
+      this->addNodes(&tailIgnoreMacMenu, text09, TFTLIGHTGREY, 0, [this]() {
+        this->changeMenu(tailIgnoreMacMenu.parentMenu, true);
+      });
+
+      for (uint32_t i = 0; i < mac_history_len_half; i++) {
+        if (WiFiScan::mac_entry_state[i] != VALID_ENTRY) continue;
+
+        MacEntry entry = WiFiScan::mac_entries[i];
+        if (entry.ignored) continue;
+
+        String tag = entry.following ? " FOLLOW" : (entry.tail_flag ? " TAIL" : "");
+        String node_name = (String)entry.rssi + " " + macToString(entry.mac) + tag;
+        uint8_t node_color = entry.following || entry.tail_flag ? TFTRED : TFTWHITE;
+
+        this->addNodes(&tailIgnoreMacMenu, node_name.c_str(), node_color, 255, [this, i]() {
+          wifi_scan_obj.addIgnoreMac(WiFiScan::mac_entries[i].mac);
+          this->changeMenu(&tailOptionsMenu, true);
+        });
+      }
+
+      this->changeMenu(&tailIgnoreMacMenu, true);
+    });
+
+    this->addNodes(&tailOptionsMenu, "Clear Ignore List", TFTRED, SCANNERS, [this]() {
+      wifi_scan_obj.clearIgnoreMacs();
+    });
+
+    #ifdef HAS_GPS
+      this->addNodes(&tailOptionsMenu, "Clear Safe Zones", TFTRED, SCANNERS, [this]() {
+        wifi_scan_obj.clearSafeZones();
+      });
+    #endif
+
+    this->addNodes(&tailOptionsMenu, "View Tail Report", TFTCYAN, SCANNERS, [this]() {
+      display_obj.clearScreen();
+      this->drawStatusBar();
+      wifi_scan_obj.renderTailReport();
+    });
+
+    this->changeMenu(&tailOptionsMenu, true);
   });
   this->addNodes(&wifiSnifferMenu, "SAE Commit", TFTLIME, EAPOL, [this]() {
     display_obj.clearScreen();

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -198,6 +198,10 @@ class MenuFunctions
 
     Menu foxHuntMenu;
 
+    // MAC Monitor options
+    Menu tailOptionsMenu;
+    Menu tailIgnoreMacMenu;
+
     #ifdef HAS_DIRECT_UPLOAD
       Menu deleteAllMenu;
       Menu uploadAllMenu;

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -914,6 +914,7 @@ extern "C" {
           }
           else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_DETECT_FOLLOW) {
             int frame_check = wifi_scan_obj.update_mac_entry(mac_char, advertisedDevice->getRSSI(), true);
+            wifi_scan_obj.evaluateTailCandidate(frame_check);
           }
           else if (wifi_scan_obj.currentScanMode == BT_SCAN_RAYBAN) { // Filters from https://github.com/NullPxl
             bool match = false;
@@ -1542,6 +1543,7 @@ extern "C" {
           else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_DETECT_FOLLOW) {
 
             int frame_check = wifi_scan_obj.update_mac_entry(mac_char, rssi, true);
+            wifi_scan_obj.evaluateTailCandidate(frame_check);
           }
           else if (wifi_scan_obj.currentScanMode == BT_SCAN_RAYBAN) { // Filters from https://github.com/NullPxl
             bool match = false;
@@ -1794,6 +1796,7 @@ void WiFiScan::RunSetup() {
   ble_devices = new LinkedList<BleDevice>();
   ipList = new LinkedList<IPAddress>();
   probe_req_ssids = new LinkedList<ProbeReqSsid>;
+  tail_ignore_macs = new LinkedList<String>();
   // for Pinescan
   pinescan_trackers = new LinkedList<PineScanTracker>();
   confirmed_pinescan = new LinkedList<ConfirmedPineScan>();
@@ -2629,6 +2632,10 @@ bool WiFiScan::shutdownBLE() {
 
 // Function to stop all wifi scans
 void WiFiScan::StopScan(uint8_t scan_mode) {
+  if (currentScanMode == WIFI_SCAN_DETECT_FOLLOW) {
+    this->closeTailLog();
+  }
+
   if ((currentScanMode == WIFI_SCAN_PROBE) ||
   (currentScanMode == WIFI_SCAN_SAE_COMMIT) ||
   (currentScanMode == WIFI_SCAN_AP) ||
@@ -2921,6 +2928,7 @@ int WiFiScan::update_mac_entry(const uint8_t mac[6], int8_t rssi, bool bt) {
           }
 
           mac_entries[idx].rssi = rssi;
+          this->update_seen_window(mac_entries[idx], now_ms);
 
           return idx + mac_history_len_half;
         }
@@ -2953,6 +2961,12 @@ inline void WiFiScan::insert_mac_entry(uint32_t idx, const uint8_t mac[6], uint3
   mac_entries[idx].dloc = 0;
   mac_entries[idx].rssi = rssi;
   mac_entries[idx].bt = bt;
+  mac_entries[idx].seen_bitmap = 0;
+  mac_entries[idx].bitmap_epoch_ms = 0;
+  mac_entries[idx].bitmap_initialized = false;
+  mac_entries[idx].tail_flag = false;
+  mac_entries[idx].ignored = this->isIgnoredMac(mac);
+  this->update_seen_window(mac_entries[idx], now_ms);
   mac_entry_state[idx] = VALID_ENTRY;
 }
 
@@ -3031,6 +3045,23 @@ static inline int32_t iabs32(int32_t v) {
   return (v < 0) ? -v : v;
 }
 
+// Cheap lat/lon delta proxy in e6-degree units (~9 e6-units per meter at mid-latitudes).
+// Shared by the GPS-displacement "following" heuristic and the safe-zone radius check.
+static inline int32_t dist_e6_proxy(int32_t lat1_e6, int32_t lon1_e6, int32_t lat2_e6, int32_t lon2_e6) {
+  int32_t dlat = iabs32(lat1_e6 - lat2_e6);
+  int32_t dlon = iabs32(lon1_e6 - lon2_e6);
+
+  // Rough longitude scaling for mid-latitudes (~0.75)
+  dlon = (dlon * 3) / 4;
+
+  return (dlat > dlon) ? dlat : dlon;
+}
+
+// Converts a radius in meters to the e6-degree proxy threshold used above.
+static inline int32_t meters_to_e6_proxy(uint16_t meters) {
+  return (int32_t)meters * 9;
+}
+
 // Uses e6 degrees. No meters conversion at runtime.
 // Writes computed location delta (e6 degrees) into out_dloc if provided.
 static inline bool is_following_candidate_light(
@@ -3041,7 +3072,7 @@ static inline bool is_following_candidate_light(
   const bool has_first = !(e.first_lat_e6 == 0 && e.first_lon_e6 == 0);
   const bool has_last  = !(e.last_lat_e6  == 0 && e.last_lon_e6  == 0);
   if (!has_first || !has_last) {
-    if (out_dloc) 
+    if (out_dloc)
       *out_dloc = 0;
 
     return false;
@@ -3056,22 +3087,518 @@ static inline bool is_following_candidate_light(
     return false;
   }
 
-  // Movement threshold:
-  // meters are e6 degrees = meters * 9
-  const int32_t THRESH_E6 = (int32_t)(2000 * 9); // ~75 m to-do: needs tuning
+  // Movement threshold, preserved exactly as before the refactor into dist_e6_proxy()
+  // (the "~75 m" comment on the original constant doesn't match meters_to_e6_proxy's
+  // conversion - not touching that pre-existing behavior here, out of scope for this change).
+  const int32_t THRESH_E6 = (int32_t)(2000 * 9); // to-do: needs tuning
 
-  int32_t dlat = iabs32(e.last_lat_e6 - e.first_lat_e6);
-  int32_t dlon = iabs32(e.last_lon_e6 - e.first_lon_e6);
-
-  // Rough longitude scaling for mid-latitudes (~0.75)
-  dlon = (dlon * 3) / 4;
-
-  // Cheap distance proxy
-  int32_t d = (dlat > dlon) ? dlat : dlon;
+  int32_t d = dist_e6_proxy(e.first_lat_e6, e.first_lon_e6, e.last_lat_e6, e.last_lon_e6);
 
   if (out_dloc) *out_dloc = d;
 
   return d >= THRESH_E6;
+}
+
+// Tail detection concept from Chasing Your Tail (CYT-NG) https://github.com/ArgeliusLabs/Chasing-Your-Tail-NG
+// Buckets sightings of a MAC into TAIL_WINDOW_SEC-wide time windows, kept as a rolling bitmap
+// (bit 0 = current window, bit i = seen i windows ago). A device that's just continuously
+// nearby only ever shows a contiguous run of bits from bit 0 - one that vanished for a whole
+// window and came back leaves a gap. is_tail_candidate() below tests for that gap.
+void WiFiScan::update_seen_window(MacEntry& entry, uint32_t now_ms) {
+  if (!entry.bitmap_initialized) {
+    // Don't test bitmap_epoch_ms==0 as the "unset" check instead of this flag - 0 is a
+    // legitimate millis() value too (at boot, and again on wraparound ~every 49.7 days).
+    entry.seen_bitmap = 0x1;
+    entry.bitmap_epoch_ms = now_ms;
+    entry.bitmap_initialized = true;
+    return;
+  }
+
+  const uint32_t window_ms = (uint32_t)TAIL_WINDOW_SEC * 1000UL;
+  uint32_t elapsed = age_ms(now_ms, entry.bitmap_epoch_ms);
+  uint32_t windows_passed = elapsed / window_ms;
+
+  if (windows_passed > 0) {
+    // Saturate the shift instead of relying on UB for shifts >= bit width
+    if (windows_passed >= TAIL_WINDOW_COUNT) {
+      entry.seen_bitmap = 0;
+    } else {
+      entry.seen_bitmap = (uint16_t)(entry.seen_bitmap << windows_passed);
+    }
+    entry.bitmap_epoch_ms += windows_passed * window_ms;
+  }
+
+  entry.seen_bitmap |= 0x1; // mark current window as seen
+}
+
+static inline uint8_t popcount16(uint16_t v) {
+  uint8_t c = 0;
+  while (v) {
+    c += (v & 1);
+    v >>= 1;
+  }
+  return c;
+}
+
+// True if entry was seen in the current window and in some earlier window, with at least
+// one empty window in between (a real gap, not just continuous presence)
+static inline bool is_tail_candidate(const MacEntry& entry) {
+  const uint16_t bitmap = entry.seen_bitmap;
+
+  if (!(bitmap & 0x1)) return false; // not seen in the current window
+  if (popcount16(bitmap) < TAIL_MIN_HITS) return false;
+
+  // Strip the contiguous run starting at bit 0 - whatever's left is from before a gap
+  uint16_t tmp = bitmap;
+  while (tmp & 0x1) tmp >>= 1;
+
+  return tmp != 0;
+}
+
+// MAC whitelist + GPS safe zones for MAC Monitor, so known-fixed devices (your own AP, etc.)
+// and known-safe locations (home, office) don't trigger tail/follow alerts. Persisted as
+// plain text on SD (one MAC per line, "lat_e6,lon_e6,radius_m" per zone); without HAS_SD
+// these still work for the current session, they just won't survive a reboot.
+void WiFiScan::loadTailIgnoreData() {
+  if (this->tail_ignore_loaded) return;
+  this->tail_ignore_loaded = true;
+
+  #ifdef HAS_SD
+    if (!sd_obj.supported) return;
+
+    File f = SD.open("/tail_ignore.txt", FILE_READ);
+    if (f) {
+      while (f.available()) {
+        String line = f.readStringUntil('\n');
+        line.trim();
+        if (line.length() == 17) {
+          this->tail_ignore_macs->add(line);
+        }
+      }
+      f.close();
+    }
+
+    File zf = SD.open("/tail_zones.txt", FILE_READ);
+    if (zf) {
+      this->tail_safe_zone_count = 0;
+      while (zf.available() && this->tail_safe_zone_count < TAIL_MAX_SAFE_ZONES) {
+        String line = zf.readStringUntil('\n');
+        line.trim();
+        if (line.length() == 0) continue;
+
+        int c1 = line.indexOf(',');
+        int c2 = (c1 < 0) ? -1 : line.indexOf(',', c1 + 1);
+        if (c1 < 0 || c2 < 0) continue;
+
+        SafeZone z;
+        z.lat_e6 = (int32_t)line.substring(0, c1).toInt();
+        z.lon_e6 = (int32_t)line.substring(c1 + 1, c2).toInt();
+        z.radius_m = (uint16_t)line.substring(c2 + 1).toInt();
+        this->tail_safe_zones[this->tail_safe_zone_count++] = z;
+      }
+      zf.close();
+    }
+
+    Serial.println("Tail ignore list: loaded " + (String)this->tail_ignore_macs->size() + " MAC(s), " + (String)this->tail_safe_zone_count + " safe zone(s)");
+  #endif
+}
+
+void WiFiScan::saveIgnoreMacs() {
+  #ifdef HAS_SD
+    if (!sd_obj.supported) return;
+    SD.remove("/tail_ignore.txt");
+    File f = SD.open("/tail_ignore.txt", FILE_WRITE);
+    if (!f) return;
+    for (int i = 0; i < this->tail_ignore_macs->size(); i++) {
+      f.println(this->tail_ignore_macs->get(i));
+    }
+    f.close();
+  #endif
+}
+
+void WiFiScan::saveSafeZones() {
+  #ifdef HAS_SD
+    if (!sd_obj.supported) return;
+    SD.remove("/tail_zones.txt");
+    File f = SD.open("/tail_zones.txt", FILE_WRITE);
+    if (!f) return;
+    for (uint8_t i = 0; i < this->tail_safe_zone_count; i++) {
+      f.println((String)this->tail_safe_zones[i].lat_e6 + "," +
+                (String)this->tail_safe_zones[i].lon_e6 + "," +
+                (String)this->tail_safe_zones[i].radius_m);
+    }
+    f.close();
+  #endif
+}
+
+bool WiFiScan::isIgnoredMac(const uint8_t mac[6]) {
+  this->loadTailIgnoreData();
+
+  String mac_str = macToString(mac);
+  for (int i = 0; i < this->tail_ignore_macs->size(); i++) {
+    if (this->tail_ignore_macs->get(i).equalsIgnoreCase(mac_str))
+      return true;
+  }
+  return false;
+}
+
+void WiFiScan::addIgnoreMac(const uint8_t mac[6]) {
+  this->addIgnoreMac(macToString(mac));
+}
+
+void WiFiScan::addIgnoreMac(String mac_str) {
+  this->loadTailIgnoreData();
+
+  mac_str.trim();
+  mac_str.toUpperCase();
+  if (mac_str.length() != 17) {
+    Serial.println("Invalid MAC (expected XX:XX:XX:XX:XX:XX): " + mac_str);
+    return;
+  }
+
+  for (int i = 0; i < this->tail_ignore_macs->size(); i++) {
+    if (this->tail_ignore_macs->get(i).equalsIgnoreCase(mac_str))
+      return; // already present
+  }
+
+  this->tail_ignore_macs->add(mac_str);
+  this->saveIgnoreMacs();
+
+  // Immediately suppress any live entry for this MAC so it stops alerting right away.
+  uint8_t mac_bytes[6] = {0, 0, 0, 0, 0, 0};
+  convertMacStringToUint8(mac_str, mac_bytes);
+  for (uint32_t i = 0; i < mac_history_len_half; i++) {
+    if (mac_entry_state[i] == VALID_ENTRY && memcmp(mac_entries[i].mac, mac_bytes, 6) == 0) {
+      mac_entries[i].ignored = true;
+      mac_entries[i].following = false;
+      mac_entries[i].tail_flag = false;
+    }
+  }
+
+  Serial.println("Added " + mac_str + " to tail ignore list");
+}
+
+void WiFiScan::removeIgnoreMac(String mac_str) {
+  this->loadTailIgnoreData();
+
+  mac_str.trim();
+  for (int i = 0; i < this->tail_ignore_macs->size(); i++) {
+    if (this->tail_ignore_macs->get(i).equalsIgnoreCase(mac_str)) {
+      this->tail_ignore_macs->remove(i);
+      this->saveIgnoreMacs();
+      Serial.println("Removed " + mac_str + " from tail ignore list");
+      return;
+    }
+  }
+  Serial.println("MAC not found in tail ignore list: " + mac_str);
+}
+
+void WiFiScan::clearIgnoreMacs() {
+  this->loadTailIgnoreData();
+  this->tail_ignore_macs->clear();
+  #ifdef HAS_SD
+    if (sd_obj.supported)
+      SD.remove("/tail_ignore.txt");
+  #endif
+  Serial.println("Cleared tail ignore list");
+}
+
+bool WiFiScan::insideSafeZone(int32_t lat_e6, int32_t lon_e6) {
+  this->loadTailIgnoreData();
+
+  if (lat_e6 == 0 && lon_e6 == 0) return false; // no fix / no data
+
+  for (uint8_t i = 0; i < this->tail_safe_zone_count; i++) {
+    const SafeZone& z = this->tail_safe_zones[i];
+    if (dist_e6_proxy(lat_e6, lon_e6, z.lat_e6, z.lon_e6) <= meters_to_e6_proxy(z.radius_m))
+      return true;
+  }
+  return false;
+}
+
+bool WiFiScan::addSafeZone(int32_t lat_e6, int32_t lon_e6, uint16_t radius_m) {
+  this->loadTailIgnoreData();
+
+  if (this->tail_safe_zone_count >= TAIL_MAX_SAFE_ZONES) {
+    Serial.println("Safe zone list full (" + (String)TAIL_MAX_SAFE_ZONES + " max)");
+    return false;
+  }
+
+  SafeZone z;
+  z.lat_e6 = lat_e6;
+  z.lon_e6 = lon_e6;
+  z.radius_m = radius_m;
+  this->tail_safe_zones[this->tail_safe_zone_count++] = z;
+  this->saveSafeZones();
+
+  Serial.println("Added safe zone: " + (String)lat_e6 + "," + (String)lon_e6 + " r=" + (String)radius_m + "m");
+  return true;
+}
+
+void WiFiScan::clearSafeZones() {
+  this->loadTailIgnoreData();
+  this->tail_safe_zone_count = 0;
+  #ifdef HAS_SD
+    if (sd_obj.supported)
+      SD.remove("/tail_zones.txt");
+  #endif
+  Serial.println("Cleared tail safe zones");
+}
+
+// Runs the tracker for TAIL_BASELINE_SCAN_SEC seconds and bulk-adds everything seen to the
+// ignore list - quickly whitelists whatever's already nearby before real tracking starts.
+void WiFiScan::startTailBaselineScan() {
+  this->loadTailIgnoreData();
+  this->tail_baseline_active = true;
+  this->tail_baseline_start_ms = millis();
+  Serial.println("Tail baseline scan started (" + (String)TAIL_BASELINE_SCAN_SEC + "s)...");
+}
+
+void WiFiScan::finishTailBaselineScanIfDue() {
+  if (!this->tail_baseline_active) return;
+  if (age_ms(millis(), this->tail_baseline_start_ms) < (uint32_t)TAIL_BASELINE_SCAN_SEC * 1000UL) return;
+
+  this->tail_baseline_active = false;
+
+  uint16_t added = 0;
+  for (uint32_t i = 0; i < mac_history_len_half; i++) {
+    if (mac_entry_state[i] != VALID_ENTRY) continue;
+
+    String mac_str = macToString(mac_entries[i].mac);
+    bool already = false;
+    for (int j = 0; j < this->tail_ignore_macs->size(); j++) {
+      if (this->tail_ignore_macs->get(j).equalsIgnoreCase(mac_str)) {
+        already = true;
+        break;
+      }
+    }
+    if (!already) {
+      this->tail_ignore_macs->add(mac_str);
+      mac_entries[i].ignored = true;
+      mac_entries[i].following = false;
+      mac_entries[i].tail_flag = false;
+      added++;
+    }
+  }
+  this->saveIgnoreMacs();
+
+  Serial.println("Tail baseline scan complete: added " + (String)added + " MAC(s) to ignore list");
+  #ifdef HAS_SCREEN
+    display_obj.display_buffer->add("Baseline: ignored " + (String)added + " MACs");
+  #endif
+}
+
+// Own SD File handle for the alert CSV, since buffer_obj is already busy with the mac_track
+// pcap capture (one Buffer instance can only own one file at a time)
+void WiFiScan::openTailLog() {
+  #ifdef HAS_SD
+    if (!sd_obj.supported) return;
+
+    int i = 0;
+    String fname;
+    do {
+      fname = "/tail_log_" + (String)i + ".log";
+      i++;
+    } while (SD.exists(fname));
+
+    this->tail_log_filename = fname;
+    this->tail_log_file = SD.open(fname, FILE_WRITE);
+    if (this->tail_log_file) {
+      this->tail_log_file.print("datetime,mac,rssi,lat,lon,follow,tail\n");
+      this->tail_log_file.flush();
+    }
+  #endif
+}
+
+void WiFiScan::closeTailLog() {
+  #ifdef HAS_SD
+    if (this->tail_log_file)
+      this->tail_log_file.close();
+  #endif
+}
+
+// One CSV row per edge-triggered alert (not per frame) - datetime,mac,rssi,lat,lon,follow,tail
+void WiFiScan::logTailAlert(const MacEntry& entry, bool follow_edge, bool tail_edge) {
+  String datetime = "";
+  String lat = "0";
+  String lon = "0";
+  #ifdef HAS_GPS
+    datetime = gps_obj.getDatetime();
+    lat = gps_obj.getLat();
+    lon = gps_obj.getLon();
+  #endif
+
+  String row = datetime + "," +
+               macToString(entry.mac) + "," +
+               (String)entry.rssi + "," +
+               lat + "," +
+               lon + "," +
+               (String)(follow_edge ? 1 : 0) + "," +
+               (String)(tail_edge ? 1 : 0) + "\n";
+
+  Serial.print("TAIL ALERT " + row);
+
+  #ifdef HAS_SD
+    if (this->tail_log_file) {
+      this->tail_log_file.print(row);
+      this->tail_log_file.flush();
+    }
+  #endif
+}
+
+// Shared by the WiFi sniffer callback and both BLE advertisement callbacks. frame_check is
+// whatever update_mac_entry() returned - only >= mac_history_len_half (a matched, existing
+// entry) has anything to evaluate; a fresh insert/evict has nothing recorded yet.
+bool WiFiScan::evaluateTailCandidate(int frame_check) {
+  if (frame_check < (int)mac_history_len_half) return false;
+
+  MacEntry& entry = this->mac_entries[frame_check - mac_history_len_half];
+
+  if (this->tail_baseline_active) return false; // just accumulating sightings for now
+
+  if (entry.ignored || this->insideSafeZone(entry.last_lat_e6, entry.last_lon_e6)) {
+    entry.ignored = true;
+    entry.following = false;
+    entry.tail_flag = false;
+    return false;
+  }
+
+  int32_t dloc = 0;
+  bool is_following = is_following_candidate_light(entry, millis(), &dloc);
+  bool is_tail = is_tail_candidate(entry);
+
+  bool follow_edge = is_following && !entry.following;
+  bool tail_edge = is_tail && !entry.tail_flag;
+
+  entry.dloc = dloc;
+  // following stays sticky once true, matching the old behavior. tail_flag tracks the live
+  // windowed state instead, so a device can re-alert once its old gap closes up again.
+  entry.following = entry.following || is_following;
+  entry.tail_flag = is_tail;
+
+  if (follow_edge || tail_edge) {
+    this->fireTailAlert(entry, follow_edge, tail_edge);
+  }
+
+  return is_following;
+}
+
+// Fired once per false->true transition, not once per frame
+void WiFiScan::fireTailAlert(const MacEntry& entry, bool follow_edge, bool tail_edge) {
+  String reason = follow_edge && tail_edge ? "FOLLOW+TAIL" : (follow_edge ? "FOLLOW" : "TAIL");
+  String line = reason + " " + macToString(entry.mac) + " RSSI:" + (String)entry.rssi;
+
+  Serial.println("*** " + line + " ***");
+
+  #ifdef HAS_SCREEN
+    display_obj.display_buffer->add(line);
+  #endif
+
+  this->logTailAlert(entry, follow_edge, tail_edge);
+
+  #ifdef HAS_NEOPIXEL_LED
+    this->tail_alert_led_until_ms = millis() + 400;
+    if (this->tail_alert_led_until_ms == 0) this->tail_alert_led_until_ms = 1; // avoid the off sentinel on wrap
+  #endif
+}
+
+// Drives a short red LED flash for fireTailAlert(), then hands back to the normal sniff color
+void WiFiScan::serviceTailAlertLed() {
+  #ifdef HAS_NEOPIXEL_LED
+    if (this->tail_alert_led_until_ms == 0) return;
+
+    if ((int32_t)(millis() - this->tail_alert_led_until_ms) < 0) {
+      led_obj.setMode(MODE_CUSTOM);
+      led_obj.setColor(255, 0, 0);
+    } else {
+      this->tail_alert_led_until_ms = 0;
+      led_obj.setMode(MODE_SNIFF);
+    }
+  #endif
+}
+
+// Reads back the tail alert CSV log and prints a per-MAC summary (hit count, first/last seen)
+void WiFiScan::renderTailReport(bool to_display) {
+  #ifdef HAS_SD
+    if (!sd_obj.supported) {
+      Serial.println("No SD card - no tail log to report on");
+      return;
+    }
+
+    if (this->tail_log_filename.length() == 0) {
+      Serial.println("No tail log recorded yet");
+      return;
+    }
+
+    File f = SD.open(this->tail_log_filename, FILE_READ);
+    if (!f) {
+      Serial.println("Could not open " + this->tail_log_filename + " for report");
+      return;
+    }
+
+    struct TailReportRow {
+      String mac;
+      uint16_t hits;
+      String first_seen;
+      String last_seen;
+    };
+
+    const uint8_t MAX_REPORT_ROWS = 30;
+    TailReportRow rows[MAX_REPORT_ROWS];
+    uint8_t row_count = 0;
+
+    while (f.available()) {
+      String line = f.readStringUntil('\n');
+      line.trim();
+      if (line.length() == 0) continue;
+
+      int c1 = line.indexOf(',');
+      int c2 = (c1 < 0) ? -1 : line.indexOf(',', c1 + 1);
+      if (c1 < 0 || c2 < 0) continue;
+
+      String datetime = line.substring(0, c1);
+      String mac_str = line.substring(c1 + 1, c2);
+
+      int found = -1;
+      for (uint8_t i = 0; i < row_count; i++) {
+        if (rows[i].mac == mac_str) {
+          found = i;
+          break;
+        }
+      }
+
+      if (found < 0 && row_count < MAX_REPORT_ROWS) {
+        found = row_count++;
+        rows[found].mac = mac_str;
+        rows[found].hits = 0;
+        rows[found].first_seen = datetime;
+      }
+
+      if (found >= 0) {
+        rows[found].hits++;
+        rows[found].last_seen = datetime;
+      }
+    }
+    f.close();
+
+    Serial.println("--- Tail Report (" + (String)row_count + " device(s)) ---");
+    for (uint8_t i = 0; i < row_count; i++) {
+      String line = rows[i].mac + "  hits=" + (String)rows[i].hits +
+                    "  first=" + rows[i].first_seen +
+                    "  last=" + rows[i].last_seen;
+      Serial.println(line);
+      #ifdef HAS_SCREEN
+        if (to_display)
+          display_obj.display_buffer->add(line);
+      #endif
+    }
+
+    if (row_count == MAX_REPORT_ROWS) {
+      Serial.println("(report truncated at " + (String)MAX_REPORT_ROWS + " devices)");
+    }
+  #else
+    Serial.println("No SD card - no tail log to report on");
+  #endif
 }
 
 // Returns how many entries were written to out_top10 (0..10)
@@ -3090,12 +3617,12 @@ uint8_t WiFiScan::build_top10_for_ui(MacEntry* out_top10, MacSortMode mode) {
     const MacEntry& A = mac_entries[a_idx];
     const MacEntry& B = mac_entries[b_idx];
 
-    const bool A_follow = is_following_candidate_light(A, now_ms);
-    const bool B_follow = is_following_candidate_light(B, now_ms);
+    const bool A_flagged = is_following_candidate_light(A, now_ms) || is_tail_candidate(A);
+    const bool B_flagged = is_following_candidate_light(B, now_ms) || is_tail_candidate(B);
 
-    // Following entries always rank ahead of non-following
-    if (A_follow != B_follow)
-      return A_follow && !B_follow;
+    // Following/tail-flagged entries always rank ahead of unflagged ones
+    if (A_flagged != B_flagged)
+      return A_flagged && !B_flagged;
 
     // Original sort rules
     if (mode == MacSortMode::MOST_FRAMES) {
@@ -3150,6 +3677,7 @@ uint8_t WiFiScan::build_top10_for_ui(MacEntry* out_top10, MacSortMode mode) {
       int32_t dloc = 0;
       out_top10[k] = mac_entries[(uint32_t)src];
       out_top10[k].following = is_following_candidate_light(out_top10[k], now_ms, &dloc);
+      out_top10[k].tail_flag = is_tail_candidate(out_top10[k]);
       out_top10[k].dloc = dloc;
     }
   }
@@ -6209,8 +6737,11 @@ void WiFiScan::RunProbeScan(uint8_t scan_mode, uint16_t color) {
     startPcap("probe");
   else if (scan_mode == BT_SCAN_FLOCK)
     startPcap("flock");
-  else if (scan_mode == WIFI_SCAN_DETECT_FOLLOW)
+  else if (scan_mode == WIFI_SCAN_DETECT_FOLLOW) {
     startPcap("mac_track");
+    this->loadTailIgnoreData();
+    this->openTailLog();
+  }
 
   this->setLEDMode(MODE_SNIFF);
   
@@ -8411,15 +8942,10 @@ void WiFiScan::beaconSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type
   }
   else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_DETECT_FOLLOW) {
     int frame_check = wifi_scan_obj.update_mac_entry(src_addr, snifferPacket->rx_ctrl.rssi);
+    bool is_following_now = wifi_scan_obj.evaluateTailCandidate(frame_check);
 
-    if (frame_check >= mac_history_len_half) {
-      int32_t dloc = 0;
-      bool is_following = is_following_candidate_light(wifi_scan_obj.mac_entries[frame_check - mac_history_len_half], millis(), &dloc);
-      if (is_following) {
-        wifi_scan_obj.mac_entries[frame_check - mac_history_len_half].dloc = dloc;
-        wifi_scan_obj.mac_entries[frame_check - mac_history_len_half].following = is_following;
-        buffer_obj.append(snifferPacket, len);
-      }
+    if (is_following_now) {
+      buffer_obj.append(snifferPacket, len);
     }
   }
   else if ((wifi_scan_obj.currentScanMode == WIFI_SCAN_SAE_COMMIT) ||
@@ -10798,6 +11324,8 @@ void WiFiScan::updateTrackerUI() {
 
     display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
     display_obj.tft.print("FOLLOW");
+    display_obj.tft.setTextColor(TFT_ORANGE, TFT_BLACK);
+    display_obj.tft.print("/TAIL");
     display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
     display_obj.tft.print(" | WIFI | ");
     display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
@@ -10816,11 +11344,23 @@ void WiFiScan::updateTrackerUI() {
   Serial.println(F("---------------"));
 
   for (int i = 0; i < n; i++) {
-    if (ui_list[i].following) {
+    if (ui_list[i].following && ui_list[i].tail_flag) {
       #ifdef HAS_SCREEN
         display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
       #endif
-      Serial.print(F("FOLLOWING "));
+      Serial.print(F("FOLLOW+TAIL "));
+    }
+    else if (ui_list[i].following) {
+      #ifdef HAS_SCREEN
+        display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
+      #endif
+      Serial.print(F("FOLLOW "));
+    }
+    else if (ui_list[i].tail_flag) {
+      #ifdef HAS_SCREEN
+        display_obj.tft.setTextColor(TFT_ORANGE, TFT_BLACK);
+      #endif
+      Serial.print(F("TAIL "));
     }
     else if (ui_list[i].bt) {
       #ifdef HAS_SCREEN
@@ -11459,6 +11999,9 @@ void WiFiScan::main(uint32_t currentTime)
       this->last_ui_update = millis();
       this->updateTrackerUI();
     }
+
+    this->finishTailBaselineScanIfDue();
+    this->serviceTailAlertLed();
   }
   else if ((currentScanMode == BT_SCAN_FLOCK) ||
           (currentScanMode == BT_SCAN_FLIPPER) ||

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -324,8 +324,21 @@ struct MacEntry {
   int32_t dloc;
   int8_t rssi;
   bool bt;
+  // Time-window reappearance tracking
+  uint16_t seen_bitmap;     // bit i = seen in window (now - i*TAIL_WINDOW_SEC), bit 0 = current window
+  uint32_t bitmap_epoch_ms; // anchor time for bit 0
+  bool tail_flag;
+  bool ignored;
+  bool bitmap_initialized;  // don't use bitmap_epoch_ms==0 as the "unset" check, millis() can be 0 too
 };
 #pragma pack(pop)
+
+// Devices seen only within radius_m of this point are ignored for tail/follow alerts
+struct SafeZone {
+  int32_t lat_e6;
+  int32_t lon_e6;
+  uint16_t radius_m;
+};
 
 struct AirTag {
     String mac;                  // MAC address of the AirTag
@@ -782,12 +795,32 @@ class WiFiScan
 
     bool send_deauth = false;
 
+    // Set by the sniffer callback on a tail/follow alert, serviced by main() (keeps
+    // NeoPixel access out of the RX callback)
+    volatile uint32_t tail_alert_led_until_ms = 0;
+
     bool channel_hop = false;
     uint8_t connected_devices = 0;
 
 
     static MacEntry mac_entries[mac_history_len_half];
     static uint8_t mac_entry_state[mac_history_len_half];
+
+    // MAC Monitor ignore list / safe zones (allocated in RunSetup(), same as access_points etc)
+    LinkedList<String>* tail_ignore_macs = nullptr;
+    SafeZone tail_safe_zones[TAIL_MAX_SAFE_ZONES];
+    uint8_t tail_safe_zone_count = 0;
+    bool tail_ignore_loaded = false;
+
+    // Baseline scan - capture-only window that bulk-adds everything seen to the ignore list
+    bool tail_baseline_active = false;
+    uint32_t tail_baseline_start_ms = 0;
+
+    // Tail alert CSV log - own File handle since buffer_obj is already the mac_track pcap
+    String tail_log_filename = "";
+    #ifdef HAS_SD
+      File tail_log_file;
+    #endif
 
     String header_line = "WigleWifi-1.4,appRelease=" + (String)MARAUDER_VERSION + ",model=ESP32 Marauder,release=" + (String)MARAUDER_VERSION + ",device=ESP32 Marauder,display=SPI TFT,board=ESP32 Marauder,brand=JustCallMeKoko\nMAC,SSID,AuthMode,FirstSeen,Channel,RSSI,CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,Type\n";
 
@@ -987,6 +1020,32 @@ class WiFiScan
     void evict_and_insert(const uint8_t mac[6], uint32_t now_ms);
     uint8_t build_top10_for_ui(MacEntry* out_top10, MacSortMode mode);
     void save_mac(unsigned char* mac);
+
+    // MAC Monitor tail detection / ignore list
+    void update_seen_window(MacEntry& entry, uint32_t now_ms);
+    bool isIgnoredMac(const uint8_t mac[6]);
+    void addIgnoreMac(const uint8_t mac[6]);
+    void addIgnoreMac(String mac_str);
+    void removeIgnoreMac(String mac_str);
+    void clearIgnoreMacs();
+    void loadTailIgnoreData();
+    void saveIgnoreMacs();
+    bool insideSafeZone(int32_t lat_e6, int32_t lon_e6);
+    bool addSafeZone(int32_t lat_e6, int32_t lon_e6, uint16_t radius_m);
+    void clearSafeZones();
+    void saveSafeZones();
+    void startTailBaselineScan();
+    void finishTailBaselineScanIfDue();
+    void logTailAlert(const MacEntry& entry, bool follow_edge, bool tail_edge);
+    void renderTailReport(bool to_display = true);
+    void openTailLog();
+    void closeTailLog();
+    void fireTailAlert(const MacEntry& entry, bool follow_edge, bool tail_edge);
+    void serviceTailAlertLed();
+    // Shared by the WiFi/BLE sniffer callbacks - evaluates follow/tail state for the entry
+    // update_mac_entry() just touched and fires an alert on a false->true transition. Returns
+    // the live (non-sticky) GPS-following state for callers gating per-frame side effects.
+    bool evaluateTailCandidate(int frame_check);
     #ifdef HAS_BT
       void copyNimbleMac(const BLEAddress &addr, unsigned char out[6]);
     #endif

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -45,7 +45,15 @@
 
   #define GRAPH_REFRESH   100
 
-  #define TRACK_EVICT_SEC 90 // Seconds before marking tracked MAC as tombstone
+  #define TRACK_EVICT_SEC 2700 // Seconds before marking tracked MAC as tombstone
+
+  // MAC Monitor tail detection
+  #define TAIL_WINDOW_SEC 300             // Width of one detection time-bucket (5 min)
+  #define TAIL_WINDOW_COUNT 16            // Buckets kept per MAC (16 * 5 min = 80 min horizon)
+  #define TAIL_MIN_HITS 2                 // Min distinct windows seen before a gap counts as "tail"
+  #define TAIL_DEFAULT_ZONE_RADIUS_M 100  // Default safe-zone radius in meters
+  #define TAIL_MAX_SAFE_ZONES 8           // Max number of persisted GPS safe zones
+  #define TAIL_BASELINE_SCAN_SEC 30       // Duration of the baseline auto-ignore capture
 
   #define DUAL_BAND_CHANNELS 51
 


### PR DESCRIPTION
Extends the existing MAC Monitor mode (WIFI_SCAN_DETECT_FOLLOW) with a second, GPS-independent detection axis inspired by [Chasing Your Tail](https://github.com/ArgeliusLabs/Chasing-Your-Tail-NG) (CYT-NG): bucket MAC sightings into rolling time windows and flag a device that reappears after a real gap, rather than relying solely on the existing GPS-displacement "following" heuristic (which needs a GPS fix and doesn't distinguish "always there" from "keeps coming back").

Core detection (WiFiScan.h/.cpp):
- MacEntry gains a 16-bit rolling window bitmap + tail_flag/ignored
- update_seen_window()/is_tail_candidate() implement the bucket-and-gap logic; evaluateTailCandidate() is shared by the WiFi sniffer callback and both BLE advertisement callbacks (previously BLE sightings were tracked but never evaluated at all)
- TRACK_EVICT_SEC raised 90s -> 45min so entries survive long enough to show a reappearance gap (configs.h)
- Fixed a latent bug found while writing a standalone test harness for this logic: the "fresh entry" check used bitmap_epoch_ms==0 as a sentinel, but 0 is also a legitimate millis() value (at boot, and again on wraparound) - replaced with an explicit bitmap_initialized flag

Ignore system: MAC whitelist + GPS safe zones, persisted as plain text on SD, populated via a 30s baseline scan, geofencing at the current GPS position, or manual add - CLI (tailignore/tailzone) and a new "Tail Options" menu under MAC Monitor.

Alerting: edge-triggered (once per detection, not per frame) TFT alert line + Serial + a non-blocking LED flash + a CSV row in a dedicated tail_log, with an on-screen/CLI report reading that log back.

Verification: full-firmware arduino-cli builds for Marauder Mini (HAS_GPS+HAS_SD+HAS_SCREEN) and ESP32 LDDB (no GPS/screen, HAS_SD+LED) both compile clean. The core algorithm (window bucketing, gap detection, safe-zone containment) is additionally covered by a standalone 25-case host-side test harness built from the verbatim production logic.