### PR TITLE
Fix Samsung BLE model selection bounds

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -158,7 +158,7 @@ extern "C" {
 
         AdvData_Raw = new uint8_t[15];
 
-        uint8_t model = watch_models[rand() % 25].value;
+        uint8_t model = watch_models[rand() % WATCH_MODEL_COUNT].value;
         
         AdvData_Raw[i++] = 14; // Size
         AdvData_Raw[i++] = 0xFF; // AD Type (Manufacturer Specific)
@@ -1894,7 +1894,7 @@ void WiFiScan::RunSetup() {
     mac_entry_state[i] = 0;
 
   #ifdef HAS_BT
-    watch_models = new WatchModel[17] {
+    watch_models = new WatchModel[WATCH_MODEL_COUNT] {
       {0x1A, "Fallback Watch"},
       {0x02, "Black Watch4 Classic 40m"},
       {0x03, "White Watch4 Classic 40m"},

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -670,6 +670,7 @@ class WiFiScan
           const char *name;
       };
 
+      static constexpr size_t WATCH_MODEL_COUNT = 17;
       WatchModel* watch_models = nullptr;
 
       static void scanCompleteCB(BLEScanResults scanResults);


### PR DESCRIPTION
## Summary

- bound random Samsung model selection to initialized entries
- preserve the existing advertisement format while preventing reads beyond the populated model table

## Testing

- Post-fix Android btsnoop contained two exact, well-formed Samsung manufacturer advertisements (AD length `0E`, 15-byte structure, company `0x0075`).
- No malformed AD structures were present.