### PR TITLE
Improve probe request diagnostics

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -1379,7 +1379,8 @@ void CommandLine::runCommand(String input) {
     // List Probes
     else if (pr_sw != -1) {
       for (int i = 0; i < probe_req_ssids->size(); i++) {
-        Serial.println("[" + (String)i + "] " + probe_req_ssids->get(i).essid);
+        const ProbeReqSsid probe = probe_req_ssids->get(i);
+        Serial.println("[" + (String)i + "][REQ:" + (String)probe.requests + "] " + probe.essid);
       }
     }
     // List SSIDs

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -8157,8 +8157,10 @@ void WiFiScan::beaconSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type
               for (int i = 0; i < probe_req_ssids->size(); i++) {
                   ProbeReqSsid cur_probe_ssid = probe_req_ssids->get(i);
                   if (cur_probe_ssid.essid == probe_req_essid) {
-                      cur_probe_ssid.requests++;
-                probe_req_ssids->set(i, cur_probe_ssid);
+                      if (cur_probe_ssid.requests < UINT16_MAX) {
+                          cur_probe_ssid.requests++;
+                      }
+                      probe_req_ssids->set(i, cur_probe_ssid);
                       essidExist = true;
                       break;
                   }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -8144,12 +8144,12 @@ void WiFiScan::beaconSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type
           display_string.concat(" -> ");
           for (int i = 0; i < snifferPacket->payload[25]; i++)
           {
-            Serial.print((char)snifferPacket->payload[26 + i]);
             probe_req_essid.concat((char)snifferPacket->payload[26 + i]);
           }
 
           probe_req_essid = wifi_scan_obj.checkEmptyProbe(probe_req_essid);
 
+          Serial.print(probe_req_essid);
           display_string.concat(probe_req_essid);
 
           if (probe_req_essid.length() > 0) {

--- a/esp32_marauder/utils.h
+++ b/esp32_marauder/utils.h
@@ -26,7 +26,7 @@ struct Station {
 struct ProbeReqSsid {
     String essid;
     bool selected;
-    uint8_t requests;
+    uint16_t requests;
 };
 
 inline uint8_t getDRAMUsagePercent() {


### PR DESCRIPTION
## Summary

- expose the existing per-probe request count in `list -p`
- render wildcard probe requests as `<hidden>` without changing named probes

## Testing

- Focused ESP32-C5 hardware test: `list -p` exposed plausible `[REQ:n]` counts; wildcard probes rendered as `<hidden>` while named probes remained unchanged.