### PR TITLE
Render complete channel activity summary pages

### DIFF
--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -184,9 +184,10 @@ void MenuFunctions::main(uint32_t currentTime)
 
       if (wifi_scan_obj.currentScanMode == WIFI_SCAN_CHAN_ACT) {
         #ifdef HAS_SCREEN
-          this->setGraphScale(this->graphScaleCheckSmall(wifi_scan_obj.channel_activity));
+          const uint8_t *page_values = wifi_scan_obj.channel_activity + wifi_scan_obj.activityPageStart();
+          this->setGraphScale(this->graphScaleCheckSmall(page_values));
 
-          this->drawGraphSmall(wifi_scan_obj.channel_activity);
+          this->drawGraphSmall(page_values);
 
         #endif
       }
@@ -593,15 +594,8 @@ void MenuFunctions::main(uint32_t currentTime)
             #endif
           }
           else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_CHAN_ACT) {
-            #ifndef HAS_DUAL_BAND
-              if (wifi_scan_obj.activity_page < MAX_CHANNEL / CHAN_PER_PAGE) {
-                wifi_scan_obj.activity_page++;
-              }
-            #else
-              if (wifi_scan_obj.activity_page < DUAL_BAND_CHANNELS / CHAN_PER_PAGE) {
-                wifi_scan_obj.activity_page++;
-              }
-            #endif
+            if (wifi_scan_obj.activity_page < wifi_scan_obj.activityPageCount())
+              wifi_scan_obj.activity_page++;
             wifi_scan_obj.drawChannelLine();
           }
         }
@@ -662,15 +656,8 @@ void MenuFunctions::main(uint32_t currentTime)
             #endif
           }
           else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_CHAN_ACT) {
-            #ifndef HAS_DUAL_BAND
-              if (wifi_scan_obj.activity_page > 1) {
-                wifi_scan_obj.activity_page--;
-              }
-            #else
-              if (wifi_scan_obj.activity_page > 0) {
-                wifi_scan_obj.activity_page--;
-              }
-            #endif
+            if (wifi_scan_obj.activity_page > 1)
+              wifi_scan_obj.activity_page--;
             wifi_scan_obj.drawChannelLine();
           }
         }
@@ -750,15 +737,8 @@ void MenuFunctions::main(uint32_t currentTime)
                 #endif
               }
               else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_CHAN_ACT) {
-                #ifndef HAS_DUAL_BAND
-                  if (wifi_scan_obj.activity_page < MAX_CHANNEL / CHAN_PER_PAGE) {
-                    wifi_scan_obj.activity_page++;
-                  }
-                #else
-                  if (wifi_scan_obj.activity_page < DUAL_BAND_CHANNELS / CHAN_PER_PAGE) {
-                    wifi_scan_obj.activity_page++;
-                  }
-                #endif
+                if (wifi_scan_obj.activity_page < wifi_scan_obj.activityPageCount())
+                  wifi_scan_obj.activity_page++;
                 wifi_scan_obj.drawChannelLine();
               }
             }
@@ -827,15 +807,8 @@ void MenuFunctions::main(uint32_t currentTime)
           #endif
         }
         else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_CHAN_ACT) {
-          #ifndef HAS_DUAL_BAND
-            if (wifi_scan_obj.activity_page > 1) {
-              wifi_scan_obj.activity_page--;
-            }
-          #else
-            if (wifi_scan_obj.activity_page > 0) {
-              wifi_scan_obj.activity_page--;
-            }
-          #endif
+          if (wifi_scan_obj.activity_page > 1)
+            wifi_scan_obj.activity_page--;
           wifi_scan_obj.drawChannelLine();
         }
       }
@@ -4076,22 +4049,16 @@ void MenuFunctions::drawMaxLine(uint8_t value, uint16_t color) {
   display_obj.tft.println((String)value);
 }
 
-void MenuFunctions::drawGraphSmall(uint8_t *values) {
-  uint8_t maxValue = 0;
-  //(i + (CHAN_PER_PAGE * (this->activity_page - 1)))
-
+void MenuFunctions::drawGraphSmall(const uint8_t *values) {
   int bar_width = SCREEN_WIDTH / (CHAN_PER_PAGE * 2);
   //display_obj.tft.fillRect(0, TFT_HEIGHT / 2 + 1, SCREEN_WIDTH, (TFT_HEIGHT / 2) + 1, TFT_BLACK);
 
   #ifndef HAS_DUAL_BAND
     for (int i = 1; i < CHAN_PER_PAGE + 1; i++) {
-      int targ_val = i + (CHAN_PER_PAGE * (wifi_scan_obj.activity_page - 1)) - 1;
+      int targ_val = i - 1;
       int x_mult = (i * 2) - 1;
       int x_coord = (SCREEN_WIDTH / (CHAN_PER_PAGE * 2)) * (x_mult - 1);
 
-      if (values[targ_val] > maxValue) {
-        maxValue = values[targ_val];
-      }
 
       if (values[targ_val] * this->_graph_scale <= GRAPH_VERT_LIM) {
         display_obj.tft.fillRect(x_coord, SCREEN_HEIGHT / 2 + 1, bar_width, SCREEN_HEIGHT / 2 + 1, TFT_BLACK);
@@ -4102,13 +4069,10 @@ void MenuFunctions::drawGraphSmall(uint8_t *values) {
     }
   #else
     for (int i = 1; i < CHAN_PER_PAGE + 1; i++) {
-      int targ_val = i + (CHAN_PER_PAGE * (wifi_scan_obj.activity_page - 1)) - 1;
+      int targ_val = i - 1;
       int x_mult = (i * 2) - 1;
       int x_coord = (SCREEN_WIDTH / (CHAN_PER_PAGE * 2)) * (x_mult - 1);
 
-      if (values[targ_val] > maxValue) {
-        maxValue = values[targ_val];
-      }
 
       if (values[targ_val] * this->_graph_scale <= GRAPH_VERT_LIM) {
         display_obj.tft.fillRect(x_coord, SCREEN_HEIGHT / 2 + 1, bar_width + 3, SCREEN_HEIGHT / 2 + 1, TFT_BLACK);
@@ -4118,8 +4082,6 @@ void MenuFunctions::drawGraphSmall(uint8_t *values) {
       display_obj.tft.drawLine(x_coord - 2, SCREEN_HEIGHT - GRAPH_VERT_LIM - (CHAR_WIDTH * 2), x_coord - 2, SCREEN_HEIGHT, TFT_WHITE);
     }
   #endif
-
-  this->drawMaxLine(maxValue, TFT_GREEN); // Draw max
 }
 
 void MenuFunctions::drawGraph(int16_t *values) {

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -4050,6 +4050,13 @@ void MenuFunctions::drawMaxLine(uint8_t value, uint16_t color) {
 }
 
 void MenuFunctions::drawGraphSmall(const uint8_t *values) {
+  uint8_t maxValue = 0;
+  for (int i = 0; i < CHAN_PER_PAGE; i++) {
+    if (values[i] > maxValue) {
+      maxValue = values[i];
+    }
+  }
+
   int bar_width = SCREEN_WIDTH / (CHAN_PER_PAGE * 2);
   //display_obj.tft.fillRect(0, TFT_HEIGHT / 2 + 1, SCREEN_WIDTH, (TFT_HEIGHT / 2) + 1, TFT_BLACK);
 
@@ -4082,6 +4089,8 @@ void MenuFunctions::drawGraphSmall(const uint8_t *values) {
       display_obj.tft.drawLine(x_coord - 2, SCREEN_HEIGHT - GRAPH_VERT_LIM - (CHAR_WIDTH * 2), x_coord - 2, SCREEN_HEIGHT, TFT_WHITE);
     }
   #endif
+
+  this->drawMaxLine(maxValue, TFT_GREEN); // Draw max
 }
 
 void MenuFunctions::drawGraph(int16_t *values) {

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -218,13 +218,9 @@ class MenuFunctions
     float calculateGraphScale(int16_t value);
     float calculateGraphScale(uint8_t value);
     float graphScaleCheck(const int16_t array[TFT_WIDTH]);
-    #ifndef HAS_DUAL_BAND
-      float graphScaleCheckSmall(const uint8_t array[MAX_CHANNEL]);
-    #else
-      float graphScaleCheckSmall(const uint8_t array[DUAL_BAND_CHANNELS]);
-    #endif
+    float graphScaleCheckSmall(const uint8_t array[CHAN_PER_PAGE]);
     void drawGraph(int16_t *values);
-    void drawGraphSmall(uint8_t *values);
+    void drawGraphSmall(const uint8_t *values);
     void renderGraphUI(uint8_t scan_mode = 0);
     void addNodes(Menu* menu, const char* name, uint8_t color, int place, std::function<void()> callable, bool selected = false);
     void battery(bool initial = false);

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10048,7 +10048,7 @@ void WiFiScan::channelHop(bool filtered, bool ranged) {
         top_chan = this->activityPageEnd() - 1;
       }
       else {
-        top_chan = DUAL_BAND_CHANNELS;
+        top_chan = DUAL_BAND_CHANNELS - 1;
         bot_chan = 0;
       }
 

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -9961,6 +9961,53 @@ void WiFiScan::changeChannel(int chan) {
   #endif
 }
 
+uint8_t WiFiScan::activityPageCount() const {
+  #ifdef HAS_DUAL_BAND
+    const uint16_t channel_count = DUAL_BAND_CHANNELS;
+  #else
+    const uint16_t channel_count = MAX_CHANNEL;
+  #endif
+
+  return (channel_count + CHAN_PER_PAGE - 1) / CHAN_PER_PAGE;
+}
+
+uint8_t WiFiScan::activityPageStart() const {
+  #ifdef HAS_DUAL_BAND
+    const uint16_t channel_count = DUAL_BAND_CHANNELS;
+  #else
+    const uint16_t channel_count = MAX_CHANNEL;
+  #endif
+
+  uint8_t page = this->activity_page;
+  if (page < 1)
+    page = 1;
+  else if (page > this->activityPageCount())
+    page = this->activityPageCount();
+
+  uint16_t page_start = (page - 1) * CHAN_PER_PAGE;
+  // Keep the final page full so graph slots and scan dwell stay consistent.
+  if ((channel_count > CHAN_PER_PAGE) && (page_start + CHAN_PER_PAGE > channel_count))
+    page_start = channel_count - CHAN_PER_PAGE;
+  else if (channel_count <= CHAN_PER_PAGE)
+    page_start = 0;
+
+  return page_start;
+}
+
+uint8_t WiFiScan::activityPageEnd() const {
+  #ifdef HAS_DUAL_BAND
+    const uint16_t channel_count = DUAL_BAND_CHANNELS;
+  #else
+    const uint16_t channel_count = MAX_CHANNEL;
+  #endif
+
+  uint16_t page_end = this->activityPageStart() + CHAN_PER_PAGE;
+  if (page_end > channel_count)
+    page_end = channel_count;
+
+  return page_end;
+}
+
 // Function to cycle to the next channel
 void WiFiScan::channelHop(bool filtered, bool ranged) {
   bool channel_match = false;
@@ -9983,29 +10030,29 @@ void WiFiScan::channelHop(bool filtered, bool ranged) {
   if (!filtered) {
     #ifndef HAS_DUAL_BAND
       if (ranged) {
-        top_chan = activity_page * CHAN_PER_PAGE;
-        bot_chan = (activity_page * CHAN_PER_PAGE) - CHAN_PER_PAGE + 1;
+        bot_chan = this->activityPageStart() + 1;
+        top_chan = this->activityPageEnd();
       }
       else {
         top_chan = MAX_CHANNEL;
         bot_chan = 1;
       }
 
-      this->set_channel = this->set_channel + 1;
-      if (this->set_channel > top_chan) {
+      if ((this->set_channel < bot_chan) || (this->set_channel >= top_chan))
         this->set_channel = bot_chan;
-      }
+      else
+        this->set_channel++;
     #else
       if (ranged) {
-        top_chan = activity_page * CHAN_PER_PAGE - 1;
-        bot_chan = (activity_page * CHAN_PER_PAGE) - CHAN_PER_PAGE;
+        bot_chan = this->activityPageStart();
+        top_chan = this->activityPageEnd() - 1;
       }
       else {
         top_chan = DUAL_BAND_CHANNELS;
         bot_chan = 0;
       }
 
-      if (this->dual_band_channel_index >= top_chan)
+      if ((this->dual_band_channel_index < bot_chan) || (this->dual_band_channel_index >= top_chan))
         this->dual_band_channel_index = bot_chan;
       else
         this->dual_band_channel_index++;
@@ -10156,10 +10203,15 @@ void WiFiScan::signalAnalyzerLoop(uint32_t tick) {
 
 void WiFiScan::drawChannelLine() {
   #ifdef HAS_SCREEN
+    const int graph_area_top = SCREEN_HEIGHT / 2 + 1;
+    display_obj.tft.fillRect(0, graph_area_top, SCREEN_WIDTH, SCREEN_HEIGHT - graph_area_top, TFT_BLACK);
     display_obj.tft.fillRect(0, SCREEN_HEIGHT - GRAPH_VERT_LIM - (CHAR_WIDTH * 2), SCREEN_WIDTH, (CHAR_WIDTH * 2) - 1, TFT_BLACK);
+    const uint8_t page_start = this->activityPageStart();
+    const uint8_t page_end = this->activityPageEnd();
     #ifndef HAS_DUAL_BAND
-      for (int i = 1; i < CHAN_PER_PAGE + 1; i++) {
-        int x_mult = (i * 2) - 1;
+      for (int channel_index = page_start; channel_index < page_end; channel_index++) {
+        int page_slot = channel_index - page_start;
+        int x_mult = ((page_slot + 1) * 2) - 1;
         int x_coord = (SCREEN_WIDTH / (CHAN_PER_PAGE * 2)) * (x_mult - 1);
         #ifdef HAS_FULL_SCREEN
           display_obj.tft.setTextSize(2);
@@ -10168,11 +10220,12 @@ void WiFiScan::drawChannelLine() {
         #endif
         display_obj.tft.setCursor(x_coord, SCREEN_HEIGHT - GRAPH_VERT_LIM - (CHAR_WIDTH * 2));
         display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
-        display_obj.tft.print((String)(i + (CHAN_PER_PAGE * (this->activity_page - 1))));
+        display_obj.tft.print((String)(channel_index + 1));
       }
     #else
-      for (int i = 1; i < CHAN_PER_PAGE + 1; i++) {
-        int x_mult = (i * 2) - 1;
+      for (int channel_index = page_start; channel_index < page_end; channel_index++) {
+        int page_slot = channel_index - page_start;
+        int x_mult = ((page_slot + 1) * 2) - 1;
         int x_coord = (SCREEN_WIDTH / (CHAN_PER_PAGE * 2)) * (x_mult - 1);
         //#ifdef HAS_FULL_SCREEN
         //  display_obj.tft.setTextSize(2);
@@ -10181,7 +10234,7 @@ void WiFiScan::drawChannelLine() {
         //#endif
         display_obj.tft.setCursor(x_coord, SCREEN_HEIGHT - GRAPH_VERT_LIM - (CHAR_WIDTH * 2));
         display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
-        display_obj.tft.print((String)this->dual_band_channels[(i + (CHAN_PER_PAGE * (this->activity_page - 1)) - 1)]);
+        display_obj.tft.print((String)this->dual_band_channels[channel_index]);
       }
     #endif
   #endif
@@ -10192,7 +10245,9 @@ void WiFiScan::channelActivityLoop(uint32_t tick) {
     if (tick - this->initTime >= BANNER_TIME * 50) {
       initTime = millis();
       Serial.println(F("--------------"));
-      for (int i = (activity_page * CHAN_PER_PAGE) - CHAN_PER_PAGE; i < activity_page * CHAN_PER_PAGE; i++) {
+      const uint8_t page_start = this->activityPageStart();
+      const uint8_t page_end = this->activityPageEnd();
+      for (int i = page_start; i < page_end; i++) {
         #ifndef HAS_DUAL_BAND
           Serial.println((String)(i+1) + ": " + (String)channel_activity[i]);
         #else
@@ -10241,7 +10296,7 @@ void WiFiScan::channelActivityLoop(uint32_t tick) {
             return;
           }
         #else
-          if (this->activity_page < DUAL_BAND_CHANNELS / CHAN_PER_PAGE) {
+          if (this->activity_page < this->activityPageCount()) {
             this->activity_page++;
             display_obj.tftDrawChannelScaleButtons(this->set_channel, false);
             display_obj.tftDrawExitScaleButtons(false);

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -977,6 +977,9 @@ class WiFiScan
     bool isMetaIdentifier(uint16_t id);
     bool isBlockedIdentifier(uint16_t id);
     uint32_t getCompleteEapol(int check_index = -1);
+    uint8_t activityPageCount() const;
+    uint8_t activityPageStart() const;
+    uint8_t activityPageEnd() const;
     void drawChannelLine();
     #ifdef HAS_SCREEN
       int8_t checkAnalyzerButtons(uint32_t currentTime);


### PR DESCRIPTION
## Summary

- make every supported channel-summary entry reachable
- keep seven visible entries on every page, using an overlapping final page instead of an undersized tail

## Testing

- Focused ESP32-C5 hardware test: all supported pages showed seven entries, including the overlapping final page. Navigation and exit remained stable with no phantom bar, blinking value, out-of-bounds symptom, reset, or touch loss.