### PR TITLE
Reject list saves when no SD card is available

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -36,6 +36,20 @@ LinkedList<IPAddress>* ipList;
 LinkedList<ProbeReqSsid>* probe_req_ssids;
 LinkedList<BleDevice>* ble_devices;
 
+#ifdef HAS_SD
+static void reportUnavailableSD() {
+  Serial.println(F("Save failed: SD card unavailable"));
+  #ifdef HAS_SCREEN
+    display_obj.tft.setTextWrap(false);
+    display_obj.tft.setFreeFont(NULL);
+    display_obj.tft.setCursor(0, 100);
+    display_obj.tft.setTextSize(1);
+    display_obj.tft.setTextColor(TFT_RED);
+    display_obj.tft.println(F("Save failed: SD unavailable"));
+  #endif
+}
+#endif
+
 extern "C" int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3){
     if (arg == 31337)
       return 1;
@@ -3502,6 +3516,11 @@ void WiFiScan::RunLoadATList() {
 void WiFiScan::RunSaveATList(bool save_as) {
   #ifdef HAS_SD
     if (save_as) {
+      if (!sd_obj.supported) {
+        reportUnavailableSD();
+        return;
+      }
+
       sd_obj.removeFile(F("/Airtags_0.log"));
 
       this->startLog("Airtags");
@@ -3635,6 +3654,11 @@ void WiFiScan::RunLoadAPList() {
 void WiFiScan::RunSaveAPList(bool save_as) {
   #ifdef HAS_SD
     if (save_as) {
+      if (!sd_obj.supported) {
+        reportUnavailableSD();
+        return;
+      }
+
       sd_obj.removeFile(F("/APs_0.log"));
 
       this->startLog("APs");
@@ -3728,6 +3752,11 @@ void WiFiScan::RunLoadSSIDList() {
 void WiFiScan::RunSaveSSIDList(bool save_as) {
   #ifdef HAS_SD
     if (save_as) {
+      if (!sd_obj.supported) {
+        reportUnavailableSD();
+        return;
+      }
+
       sd_obj.removeFile(F("/SSIDs_0.log"));
 
       this->startLog("SSIDs");


### PR DESCRIPTION
## Summary

- reject saved-list writes immediately when SD support is unavailable
- avoid reporting a successful save when no card is mounted

## Testing

- Focused ESP32-C5 hardware test: saves without detected SD media were rejected immediately without a false success message.

## Scope

- Later create, write, and flush failures are intentionally left to the transactional saved-list follow-up.