### PR TITLE
Synchronize the WiFi status after shutdown

### DIFF
--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -2587,6 +2587,8 @@ void MenuFunctions::RunSetup()
   this->addNodes(&wifiGeneralMenu, "Shutdown WiFi", TFTRED, 0, [this]() {
     WiFi.softAPdisconnect(true); // Also shut down the SoftAP if it is running
 	WiFi.disconnect(true);
+    // Synchronize teardown with the immediately redrawn status icon.
+    wifi_scan_obj.wifi_connected = false;
     delay(100);
     wifi_scan_obj.StartScan(WIFI_SCAN_OFF, TFT_RED);
     this->changeMenu(current_menu, true);


### PR DESCRIPTION
## Summary

- update the displayed WiFi state immediately after a successful shutdown
- remove the stale green connection icon that previously required a second menu action

## Testing

- Focused ESP32-C5 hardware test: five join/shutdown cycles changed the icon to gray after one tap, while the router independently confirmed immediate disconnection.