### PR TITLE
Replace the in-memory SSID list when loading a snapshot

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -3702,6 +3702,9 @@ void WiFiScan::RunLoadSSIDList() {
       #endif
       return;
     }
+
+    this->clearList(CLEAR_SSID);
+
     while (log_file.available()) {
       String line = log_file.readStringUntil('\n'); // Read until newline character
       this->addSSID(line);


### PR DESCRIPTION
## Summary

- clear the current SSID list only after the selected file opens successfully
- treat a loaded file as a snapshot instead of appending duplicates

## Testing

- Focused ESP32-C5 hardware test: loading replaced a 20-entry in-memory snapshot, removed an added sentinel, and a repeated load remained idempotent.

## Follow-up

- The larger transactional saved-list PR also covers this behavior and will be rebased if this focused fix merges first.