### PR TITLE
Redact credentials from serial output

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -1,5 +1,30 @@
 #include "CommandLine.h"
 
+namespace {
+String redactCommandForLog(const String& input, LinkedList<String>& arguments) {
+  if ((arguments.size() == 0) || (arguments.get(0) != JOIN_CMD))
+    return input;
+
+  String logged_input;
+  bool redact_next = false;
+  for (int i = 0; i < arguments.size(); i++) {
+    if (i > 0)
+      logged_input += ' ';
+
+    const String argument = arguments.get(i);
+    if (redact_next) {
+      logged_input += F("<redacted>");
+      redact_next = false;
+    } else {
+      logged_input += argument;
+      redact_next = (argument == "-p");
+    }
+  }
+
+  return logged_input;
+}
+}
+
 // Brightness functions defined in esp32_marauder.ino
 #ifndef HAS_MINI_SCREEN
   extern void brightnessCycle();
@@ -212,15 +237,14 @@ void CommandLine::startScanFromCLI(int scan_mode, uint16_t color, const char* sc
 
 void CommandLine::runCommand(String input) {
   if (input == "") return;
+  LinkedList<String> cmd_args = this->parseCommand(input, " ");
 
   if(wifi_scan_obj.scanning() && wifi_scan_obj.currentScanMode == WIFI_SCAN_GPS_NMEA){
     if(input != STOPSCAN_CMD) return;    
   }
   else
-    Serial.println("#" + input);
+    Serial.println("#" + redactCommandForLog(input, cmd_args));
 
-  LinkedList<String> cmd_args = this->parseCommand(input, " ");
-  
   //// Admin commands
   // Help
   if (cmd_args.get(0) == HELP_CMD) {
@@ -1448,7 +1472,7 @@ void CommandLine::runCommand(String input) {
       int index = cmd_args.get(ap_sw + 1).toInt();
       String password = cmd_args.get(pw_sw + 1);
       AccessPoint access_point = access_points->get(index);
-      Serial.println("Using SSID: " + (String)access_point.essid + " Password: " + (String)password);
+      Serial.println("Using SSID: " + (String)access_point.essid + " Password: <redacted>");
       //wifi_scan_obj.currentScanMode = LV_JOIN_WIFI;
       //wifi_scan_obj.StartScan(LV_JOIN_WIFI, TFT_YELLOW); 
       wifi_scan_obj.joinWiFi(access_point.essid, password, false);

--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -237,12 +237,15 @@ void CommandLine::startScanFromCLI(int scan_mode, uint16_t color, const char* sc
 
 void CommandLine::runCommand(String input) {
   if (input == "") return;
+
+  const bool gps_nmea_active =
+    wifi_scan_obj.scanning() &&
+    (wifi_scan_obj.currentScanMode == WIFI_SCAN_GPS_NMEA);
+  if (gps_nmea_active && (input != STOPSCAN_CMD)) return;
+
   LinkedList<String> cmd_args = this->parseCommand(input, " ");
 
-  if(wifi_scan_obj.scanning() && wifi_scan_obj.currentScanMode == WIFI_SCAN_GPS_NMEA){
-    if(input != STOPSCAN_CMD) return;    
-  }
-  else
+  if (!gps_nmea_active)
     Serial.println("#" + redactCommandForLog(input, cmd_args));
 
   //// Admin commands

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -2457,7 +2457,7 @@ void MenuFunctions::RunSetup()
             this->changeMenu(&miniKbMenu, true);
             String password = this->miniKeyboard(&miniKbMenu, true);
             if (password != "") {
-              Serial.println("Using SSID: " + (String)access_points->get(i).essid + " Password: " + (String)password);
+              Serial.println("Using SSID: " + (String)access_points->get(i).essid + " Password: <redacted>");
               wifi_scan_obj.currentScanMode = LV_JOIN_WIFI;
               wifi_scan_obj.StartScan(LV_JOIN_WIFI, TFT_YELLOW); 
               wifi_scan_obj.joinWiFi(access_points->get(i).essid, password);
@@ -2505,7 +2505,7 @@ void MenuFunctions::RunSetup()
               this->changeMenu(&miniKbMenu, true);
               String password = this->miniKeyboard(&miniKbMenu, true);
               if (password != "") {
-                Serial.println("Using SSID: " + (String)access_points->get(i).essid + " Password: " + (String)password);
+                Serial.println("Using SSID: " + (String)access_points->get(i).essid + " Password: <redacted>");
                 wifi_scan_obj.currentScanMode = LV_JOIN_WIFI;
                 wifi_scan_obj.StartScan(LV_JOIN_WIFI, TFT_YELLOW); 
                 wifi_scan_obj.joinWiFi(access_points->get(i).essid, password);
@@ -2546,7 +2546,7 @@ void MenuFunctions::RunSetup()
             this->changeMenu(&miniKbMenu, true);
             String password = this->miniKeyboard(&miniKbMenu, true);
             if (password != "") {
-              Serial.println("Using SSID: " + (String)ssids->get(i).essid + " Password: " + (String)password);
+              Serial.println("Using SSID: " + (String)ssids->get(i).essid + " Password: <redacted>");
               wifi_scan_obj.currentScanMode = LV_JOIN_WIFI;
               wifi_scan_obj.StartScan(LV_JOIN_WIFI, TFT_YELLOW); 
               wifi_scan_obj.startWiFi(ssids->get(i).essid, password);
@@ -2558,7 +2558,7 @@ void MenuFunctions::RunSetup()
           #ifdef HAS_TOUCH
             char passwordBuf[64] = {0};  // or prefill with existing SSID
             if (keyboardInput(passwordBuf, sizeof(passwordBuf), "Enter Password")) {
-              Serial.println("Using SSID: " + (String)ssids->get(i).essid + " Password: " + String(passwordBuf));
+              Serial.println("Using SSID: " + (String)ssids->get(i).essid + " Password: <redacted>");
               wifi_scan_obj.startWiFi(ssids->get(i).essid, String(passwordBuf));
             }
 

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1850,7 +1850,7 @@ void WiFiScan::RunSetup() {
 
         if (settings_obj.saveSetting<bool>("wt", contents)) {
           sd_obj.removeFile("/wigle_api_token.txt");
-          Serial.println(F("Saved WiGLE API Token"));
+          Serial.println(F("Saved WiGLE API Token: <redacted>"));
         } else {
           Serial.println("Failed to save WiGLE API Token");
         }
@@ -1875,7 +1875,7 @@ void WiFiScan::RunSetup() {
 
         if (settings_obj.saveSetting<bool>(WDG_KEY_NAME, contents)) {
           sd_obj.removeFile("/wdg_key.txt");
-          Serial.println(F("Saved WDG API Token"));
+          Serial.println(F("Saved WDG API Token: <redacted>"));
         } else {
           Serial.println("Failed to save WDG API Token");
         }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1850,7 +1850,7 @@ void WiFiScan::RunSetup() {
 
         if (settings_obj.saveSetting<bool>("wt", contents)) {
           sd_obj.removeFile("/wigle_api_token.txt");
-          Serial.println("Saved WiGLE API Token: " + contents);
+          Serial.println(F("Saved WiGLE API Token"));
         } else {
           Serial.println("Failed to save WiGLE API Token");
         }
@@ -1875,7 +1875,7 @@ void WiFiScan::RunSetup() {
 
         if (settings_obj.saveSetting<bool>(WDG_KEY_NAME, contents)) {
           sd_obj.removeFile("/wdg_key.txt");
-          Serial.println("Saved WDG API Token: " + contents);
+          Serial.println(F("Saved WDG API Token"));
         } else {
           Serial.println("Failed to save WDG API Token");
         }

--- a/esp32_marauder/settings.cpp
+++ b/esp32_marauder/settings.cpp
@@ -1,5 +1,14 @@
 #include "settings.h"
 
+namespace {
+bool isSensitiveSetting(const char* name) {
+  return name != nullptr &&
+         (strcmp(name, "ClientPW") == 0 ||
+          strcmp(name, "wt") == 0 ||
+          strcmp(name, WDG_KEY_NAME) == 0);
+}
+}
+
 // ---------------------------------------------------------------------------
 // _buildCache — called once after json_settings_string is loaded/updated.
 // Parses the JSON exactly once and fills every field of _cache.
@@ -397,9 +406,13 @@ void Settings::printJsonSettings(String json_string) {
 
   Serial.println("Settings\n----------------------------------------------");
   for (int i = 0; i < (int)json["Settings"].size(); i++) {
-    Serial.println("Name: " + json["Settings"][i]["name"].as<String>());
+    const char* name = json["Settings"][i]["name"] | "";
+    Serial.println("Name: " + String(name));
     Serial.println("Type: " + json["Settings"][i]["type"].as<String>());
-    Serial.println("Value: " + json["Settings"][i]["value"].as<String>() + "\n");
+    if (isSensitiveSetting(name))
+      Serial.println(F("Value: <redacted>\n"));
+    else
+      Serial.println("Value: " + json["Settings"][i]["value"].as<String>() + "\n");
   }
 }
 


### PR DESCRIPTION
## Summary

- replace WiFi passwords, API tokens, and API keys in serial diagnostics with `<redacted>`
- preserve the underlying configuration and connection behavior

## Testing

- Focused serial test: settings and join output exposed no WiFi password, API token, or API key and rendered sensitive settings as `<redacted>`.

## Scope

- This changes diagnostic output only. It does not encrypt credentials at rest.