### PR TITLE
Filter active PMKID stimulation before transmission

### DIFF
--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1850,7 +1850,11 @@ void MenuFunctions::RunSetup()
     this->addNodes(&wifiSnifferMenu, text_table1[46], TFTVIOLET, EAPOL, [this]() {
       display_obj.clearScreen();
       this->drawStatusBar();
-      wifi_scan_obj.StartScan(WIFI_SCAN_EAPOL, TFT_VIOLET);
+      const uint8_t scan_mode =
+        settings_obj.loadSetting<bool>(text_table4[5])
+          ? WIFI_SCAN_ACTIVE_EAPOL
+          : WIFI_SCAN_EAPOL;
+      wifi_scan_obj.StartScan(scan_mode, TFT_VIOLET);
     });
     this->addNodes(&wifiSnifferMenu, text_table1[45], TFTBLUE, PACKET_MONITOR, [this]() {
       wifi_scan_obj.StartScan(WIFI_PACKET_MONITOR, TFT_BLUE);
@@ -1859,7 +1863,11 @@ void MenuFunctions::RunSetup()
     this->addNodes(&wifiSnifferMenu, text_table1[46], TFTVIOLET, EAPOL, [this]() {
       display_obj.clearScreen();
       this->drawStatusBar();
-      wifi_scan_obj.StartScan(WIFI_SCAN_EAPOL, TFT_VIOLET);
+      const uint8_t scan_mode =
+        settings_obj.loadSetting<bool>(text_table4[5])
+          ? WIFI_SCAN_ACTIVE_EAPOL
+          : WIFI_SCAN_EAPOL;
+      wifi_scan_obj.StartScan(scan_mode, TFT_VIOLET);
     });
     this->addNodes(&wifiSnifferMenu, text_table1[45], TFTBLUE, PACKET_MONITOR, [this]() {
       display_obj.clearScreen();

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -4495,7 +4495,9 @@ void WiFiScan::RunEapolScan(uint8_t scan_mode, uint16_t color) {
     led_obj.setMode(MODE_SNIFF);
   #endif*/
 
-  this->send_deauth = settings_obj.loadSetting<bool>(text_table4[5]);
+  this->send_deauth =
+    (scan_mode == WIFI_SCAN_ACTIVE_EAPOL) ||
+    (scan_mode == WIFI_SCAN_ACTIVE_LIST_EAPOL);
   
   num_eapol = 0;
 
@@ -9610,6 +9612,15 @@ void WiFiScan::eapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
   if (snifferPacket->rx_ctrl.rssi > wifi_scan_obj.max_rssi)
     wifi_scan_obj.max_rssi = snifferPacket->rx_ctrl.rssi;
 
+  bool filter = wifi_scan_obj.filterActive();
+
+  // Apply an active target filter before any frame is transmitted.
+  if (filter) {
+    if ((ap_index < 0) || (!access_points->get(ap_index).selected)) {
+      return;
+    }
+  }
+
   
   // Found beacon frame. Decide whether to deauth
   if (wifi_scan_obj.send_deauth) {
@@ -9638,16 +9649,6 @@ void WiFiScan::eapolSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type)
 
 
   }
-
-  bool filter = wifi_scan_obj.filterActive();
-
-  // Check for and apply filters
-  if (filter) {
-    if ((ap_index < 0) || (!access_points->get(ap_index).selected)) {
-      return;
-    }
-  }
-
   uint8_t handshake_msg = 0;
 
   int eapol_offset = -1;


### PR DESCRIPTION
## Summary

- separate passive EAPOL/PMKID capture from the active stimulation path
- apply the selected-AP filter before any active transmission

## Testing

- Controlled PCAP passed: 795 active frames in the valid channel-36 section used only the selected BSSID; canary and foreign BSSIDs had zero matches.
- The capture ended at the final frame, so a separate post-stop capture window was not proven. Broadcast DA behavior is intentionally unchanged.