### PR TITLE
Correct the Flipper BLE advertisement data length

### DIFF
--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -242,7 +242,7 @@ extern "C" {
         AdvData_Raw[i++] = 0x00;  // TX Power level value
 
         // Manufacturer specific data based on your hex dump
-        AdvData_Raw[i++] = 0x05;  // Length of Manufacturer Specific Data section
+        AdvData_Raw[i++] = 0x09;  // Type + company ID + six manufacturer bytes
         AdvData_Raw[i++] = 0xFF;  // Manufacturer Specific Data type
         AdvData_Raw[i++] = 0xBA;  // LSB of Manufacturer ID (Flipper Zero: 0x0FBA)
         AdvData_Raw[i++] = 0x0F;  // MSB of Manufacturer ID

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -158,7 +158,7 @@ extern "C" {
 
         AdvData_Raw = new uint8_t[15];
 
-        uint8_t model = watch_models[rand() % 25].value;
+        uint8_t model = watch_models[rand() % WATCH_MODEL_COUNT].value;
         
         AdvData_Raw[i++] = 14; // Size
         AdvData_Raw[i++] = 0xFF; // AD Type (Manufacturer Specific)
@@ -1894,7 +1894,7 @@ void WiFiScan::RunSetup() {
     mac_entry_state[i] = 0;
 
   #ifdef HAS_BT
-    watch_models = new WatchModel[17] {
+    watch_models = new WatchModel[WATCH_MODEL_COUNT] {
       {0x1A, "Fallback Watch"},
       {0x02, "Black Watch4 Classic 40m"},
       {0x03, "White Watch4 Classic 40m"},

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -670,6 +670,7 @@ class WiFiScan
           const char *name;
       };
 
+      static constexpr size_t WATCH_MODEL_COUNT = 17;
       WatchModel* watch_models = nullptr;
 
       static void scanCompleteCB(BLEScanResults scanResults);


### PR DESCRIPTION
## Stack

- Draft follow-up to #1426.
- Until #1426 merges, this comparison includes the Samsung bounds commit; the intended review delta is the final one-line Flipper length correction.

## Summary

- change the Flipper Manufacturer Specific Data AD length from `0x05` to `0x09`

## Protocol basis

The Bluetooth GAP format defines the length octet as the number of following data octets, with the first data octet being the AD type. This structure contains one type byte (`0xFF`), two company-ID bytes, and six manufacturer payload bytes: `1 + 2 + 6 = 9`. See the [Bluetooth Core Generic Access Profile](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-62/out/en/host/generic-access-profile.html#UUID-81a9bad1-0e76-c7d9-2e3e-1c557ba54310).

## Testing boundary

- The corrected source was build-covered in the cumulative validation firmware.
- The post-fix Android btsnoop contained no Flipper signature, likely due to filtering, so the corrected Flipper frame was not independently observed over the air.
- This PR is intentionally a draft and does not claim a complete post-fix OTA pass.