### PR TITLE
test: expand native firmware coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 .pio/
 .venv/
+coverage.xml
 .vscode/arduino.json
 .vscode/c_cpp_properties.json
 .vscode/settings.json

--- a/esp32_marauder/Buffer.cpp
+++ b/esp32_marauder/Buffer.cpp
@@ -1,4 +1,5 @@
 #include "Buffer.h"
+#include "PcapHeader.h"
 #include "lang_var.h"
 
 Buffer::Buffer(){
@@ -42,13 +43,9 @@ void Buffer::open(bool is_pcap){
   writing = true;
 
   if (is_pcap) {
-    write(uint32_t(0xa1b2c3d4)); // magic number
-    write(uint16_t(2)); // major version number
-    write(uint16_t(4)); // minor version number
-    write(int32_t(0)); // GMT to local correction
-    write(uint32_t(0)); // accuracy of timestamps
-    write(uint32_t(SNAP_LEN)); // max length of captured packets, in octets
-    write(uint32_t(105)); // data link type
+    uint8_t header[marauder::kPcapGlobalHeaderSize];
+    marauder::makePcapGlobalHeader(SNAP_LEN, header);
+    write(header, sizeof(header));
   }
 }
 

--- a/esp32_marauder/PcapHeader.cpp
+++ b/esp32_marauder/PcapHeader.cpp
@@ -1,0 +1,31 @@
+#include "PcapHeader.h"
+
+namespace marauder {
+namespace {
+
+void writeLittleEndian16(uint16_t value, uint8_t* output) {
+  output[0] = static_cast<uint8_t>(value);
+  output[1] = static_cast<uint8_t>(value >> 8);
+}
+
+void writeLittleEndian32(uint32_t value, uint8_t* output) {
+  output[0] = static_cast<uint8_t>(value);
+  output[1] = static_cast<uint8_t>(value >> 8);
+  output[2] = static_cast<uint8_t>(value >> 16);
+  output[3] = static_cast<uint8_t>(value >> 24);
+}
+
+}  // namespace
+
+void makePcapGlobalHeader(uint32_t snapshot_length,
+                          uint8_t output[kPcapGlobalHeaderSize]) {
+  writeLittleEndian32(0xa1b2c3d4, output);
+  writeLittleEndian16(2, output + 4);
+  writeLittleEndian16(4, output + 6);
+  writeLittleEndian32(0, output + 8);
+  writeLittleEndian32(0, output + 12);
+  writeLittleEndian32(snapshot_length, output + 16);
+  writeLittleEndian32(105, output + 20);
+}
+
+}  // namespace marauder

--- a/esp32_marauder/PcapHeader.h
+++ b/esp32_marauder/PcapHeader.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace marauder {
+
+constexpr size_t kPcapGlobalHeaderSize = 24;
+
+void makePcapGlobalHeader(uint32_t snapshot_length,
+                          uint8_t output[kPcapGlobalHeaderSize]);
+
+}  // namespace marauder

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,9 +11,12 @@ extra_scripts =
 build_src_filter =
   -<*>
   +<MarauderMacAddress.cpp>
+  +<PcapHeader.cpp>
+  +<Switches.cpp>
 build_flags =
   -std=gnu++17
   -Wall
   -Wextra
   -Wpedantic
   --coverage
+  -Itest/support

--- a/test/support/Arduino.h
+++ b/test/support/Arduino.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <stdint.h>
+
+constexpr int LOW = 0;
+constexpr int HIGH = 1;
+constexpr int INPUT = 0;
+constexpr int INPUT_PULLUP = 1;
+constexpr int INPUT_PULLDOWN = 2;
+
+namespace arduino_test {
+inline int read_value = LOW;
+inline uint32_t current_millis = 0;
+inline int pin_mode_pin = -1;
+inline int pin_mode_value = -1;
+}
+
+inline void pinMode(int pin, int mode) {
+  arduino_test::pin_mode_pin = pin;
+  arduino_test::pin_mode_value = mode;
+}
+inline int digitalRead(int) { return arduino_test::read_value; }
+inline uint32_t millis() { return arduino_test::current_millis; }
+
+namespace arduino_test {
+inline void reset() {
+  read_value = LOW;
+  current_millis = 0;
+  pin_mode_pin = -1;
+  pin_mode_value = -1;
+}
+inline void setDigitalRead(int value) { read_value = value; }
+inline void setMillis(uint32_t value) { current_millis = value; }
+inline int lastPinModePin() { return pin_mode_pin; }
+inline int lastPinModeValue() { return pin_mode_value; }
+}

--- a/test/test_mac_address/test_main.cpp
+++ b/test/test_mac_address/test_main.cpp
@@ -46,6 +46,36 @@ void test_parse_mac_address_rejects_invalid_separator_and_hex() {
       marauder::parseMacAddress("00:11:22:33:44:GG", output));
 }
 
+void test_parse_mac_address_rejects_invalid_hex_in_each_octet() {
+  const size_t hex_offsets[] = {0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16};
+  for (size_t index = 0; index < sizeof(hex_offsets) / sizeof(hex_offsets[0]); ++index) {
+    char text[] = "00:11:22:33:44:55";
+    uint8_t output[marauder::kMacAddressSize] = {};
+    text[hex_offsets[index]] = 'Z';
+    TEST_ASSERT_FALSE(marauder::parseMacAddress(text, output));
+  }
+}
+
+void test_parse_mac_address_rejects_invalid_separator_in_each_position() {
+  const size_t separator_offsets[] = {2, 5, 8, 11, 14};
+  for (size_t index = 0; index < sizeof(separator_offsets) / sizeof(separator_offsets[0]); ++index) {
+    char text[] = "00:11:22:33:44:55";
+    uint8_t output[marauder::kMacAddressSize] = {};
+    text[separator_offsets[index]] = '-';
+    TEST_ASSERT_FALSE(marauder::parseMacAddress(text, output));
+  }
+}
+
+void test_mac_address_boundary_values_round_trip() {
+  const uint8_t expected[marauder::kMacAddressSize] = {0x00, 0x0F, 0x10, 0x7F, 0x80, 0xFF};
+  uint8_t parsed[marauder::kMacAddressSize] = {};
+  char formatted[marauder::kMacAddressTextLength + 1] = {};
+  TEST_ASSERT_TRUE(marauder::formatMacAddress(expected, formatted));
+  TEST_ASSERT_EQUAL_STRING("00:0F:10:7F:80:FF", formatted);
+  TEST_ASSERT_TRUE(marauder::parseMacAddress(formatted, parsed));
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, parsed, marauder::kMacAddressSize);
+}
+
 void test_parse_failure_does_not_modify_output() {
   uint8_t output[marauder::kMacAddressSize] = {1, 2, 3, 4, 5, 6};
   const uint8_t expected[marauder::kMacAddressSize] = {1, 2, 3, 4, 5, 6};
@@ -82,6 +112,9 @@ int main() {
   RUN_TEST(test_parse_mac_address_accepts_uppercase_and_lowercase);
   RUN_TEST(test_parse_mac_address_rejects_invalid_length);
   RUN_TEST(test_parse_mac_address_rejects_invalid_separator_and_hex);
+  RUN_TEST(test_parse_mac_address_rejects_invalid_hex_in_each_octet);
+  RUN_TEST(test_parse_mac_address_rejects_invalid_separator_in_each_position);
+  RUN_TEST(test_mac_address_boundary_values_round_trip);
   RUN_TEST(test_parse_failure_does_not_modify_output);
   RUN_TEST(test_mac_address_round_trip);
   RUN_TEST(test_mac_address_helpers_reject_null_buffers);

--- a/test/test_pcap_header/test_main.cpp
+++ b/test/test_pcap_header/test_main.cpp
@@ -1,0 +1,35 @@
+#include <unity.h>
+
+#include "PcapHeader.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_pcap_header_uses_expected_wire_format() {
+  uint8_t output[marauder::kPcapGlobalHeaderSize] = {};
+  const uint8_t expected[marauder::kPcapGlobalHeaderSize] = {
+      0xd4, 0xc3, 0xb2, 0xa1, 0x02, 0x00, 0x04, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x10, 0x00, 0x00, 0x69, 0x00, 0x00, 0x00};
+
+  marauder::makePcapGlobalHeader(4096, output);
+
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, output,
+                                marauder::kPcapGlobalHeaderSize);
+}
+
+void test_pcap_header_serializes_full_snapshot_length() {
+  uint8_t output[marauder::kPcapGlobalHeaderSize] = {};
+
+  marauder::makePcapGlobalHeader(0x89abcdef, output);
+
+  const uint8_t expected[] = {0xef, 0xcd, 0xab, 0x89};
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, output + 16, sizeof(expected));
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_pcap_header_uses_expected_wire_format);
+  RUN_TEST(test_pcap_header_serializes_full_snapshot_length);
+  return UNITY_END();
+}

--- a/test/test_switches/test_main.cpp
+++ b/test/test_switches/test_main.cpp
@@ -1,0 +1,68 @@
+#include <unity.h>
+
+#include "Arduino.h"
+#include "Switches.h"
+
+void setUp() { arduino_test::reset(); }
+void tearDown() {}
+
+void test_constructor_configures_pullup_and_accessors() {
+  Switches button(7, 1000, true);
+  TEST_ASSERT_EQUAL_INT(7, button.getPin());
+  TEST_ASSERT_TRUE(button.getPullup());
+  TEST_ASSERT_EQUAL_INT(7, arduino_test::lastPinModePin());
+  TEST_ASSERT_EQUAL_INT(INPUT_PULLUP, arduino_test::lastPinModeValue());
+  TEST_ASSERT_FALSE(button.isHeld());
+}
+
+void test_constructor_configures_pulldown() {
+  Switches button(9, 500, false);
+  TEST_ASSERT_FALSE(button.getPullup());
+  TEST_ASSERT_EQUAL_INT(INPUT_PULLDOWN, arduino_test::lastPinModeValue());
+}
+
+void test_default_constructor_starts_released() {
+  Switches button;
+  TEST_ASSERT_EQUAL_INT(0, button.getPin());
+  TEST_ASSERT_EQUAL_INT(0, arduino_test::lastPinModePin());
+  TEST_ASSERT_EQUAL_INT(INPUT, arduino_test::lastPinModeValue());
+  TEST_ASSERT_FALSE(button.isHeld());
+}
+
+void test_pullup_press_hold_and_release_sequence() {
+  Switches button(7, 1000, true);
+  arduino_test::setDigitalRead(LOW);
+  arduino_test::setMillis(100);
+  TEST_ASSERT_TRUE(button.justPressed());
+
+  arduino_test::setMillis(1099);
+  TEST_ASSERT_FALSE(button.justPressed());
+  TEST_ASSERT_FALSE(button.isHeld());
+
+  arduino_test::setMillis(1100);
+  TEST_ASSERT_FALSE(button.justPressed());
+  TEST_ASSERT_TRUE(button.isHeld());
+
+  arduino_test::setDigitalRead(HIGH);
+  TEST_ASSERT_TRUE(button.justReleased());
+  TEST_ASSERT_FALSE(button.isHeld());
+  TEST_ASSERT_FALSE(button.justReleased());
+}
+
+void test_pulldown_uses_high_as_pressed() {
+  Switches button(9, 500, false);
+  arduino_test::setDigitalRead(HIGH);
+  TEST_ASSERT_TRUE(button.justPressed());
+  arduino_test::setDigitalRead(LOW);
+  TEST_ASSERT_TRUE(button.justReleased());
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_constructor_configures_pullup_and_accessors);
+  RUN_TEST(test_constructor_configures_pulldown);
+  RUN_TEST(test_default_constructor_starts_released);
+  RUN_TEST(test_pullup_press_hold_and_release_sequence);
+  RUN_TEST(test_pulldown_uses_high_as_pressed);
+  return UNITY_END();
+}


### PR DESCRIPTION
Adds host tests for switch handling, PCAP header serialization, and MAC address edge cases. This gets the whole-source coverage baseline over 1% without changing the PCAP wire format.

Verified locally: 17/17 tests passed and whole-source line coverage reached 1.08%.