### PR TITLE
ci: dispatch private Marauder v8 firmware build

### DIFF
--- a/.github/workflows/build_installer_manifests.yml
+++ b/.github/workflows/build_installer_manifests.yml
@@ -291,26 +291,24 @@ jobs:
                 repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches \
                 --input -
 
-      - name: Wait for sanitized private target fragments
+      - name: Wait for sanitized Marauder v8 target fragment
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p private-targets
           for attempt in $(seq 1 90); do
             ASSETS=$(gh api "repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets" --jq '.[].name')
-            if grep -Fxq 'marauder-v8.installer.json' <<< "$ASSETS" \
-              && grep -Fxq 'marauder-mini-v3.installer.json' <<< "$ASSETS" \
-              && grep -Fxq 'dual-c5-mini.installer.json' <<< "$ASSETS"; then
+            if grep -Fxq 'marauder-v8.installer.json' <<< "$ASSETS"; then
               gh release download "${{ github.event.release.tag_name }}" \
                 --repo "${{ github.repository }}" \
                 --dir private-targets \
                 --pattern '*.installer.json'
-              test "$(find private-targets -maxdepth 1 -name '*.installer.json' | wc -l)" -eq 3
+              test "$(find private-targets -maxdepth 1 -name '*.installer.json' | wc -l)" -eq 1
               exit 0
             fi
             sleep 10
           done
-          echo "Timed out waiting for all private installer fragments" >&2
+          echo "Timed out waiting for the Marauder v8 installer fragment" >&2
           exit 1
 
       - name: Upload sanitized private fragments

--- a/.github/workflows/build_installer_manifests.yml
+++ b/.github/workflows/build_installer_manifests.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      source_sha: ${{ steps.source.outputs.sha }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -40,6 +41,10 @@ jobs:
 
       - name: Validate target registry
         run: python3 tools/installer_manifest.py --validate-registry
+
+      - name: Record exact source commit
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Test manifest generation
         run: python3 -m unittest tools/test_installer_manifest.py -v
@@ -266,9 +271,60 @@ jobs:
           if-no-files-found: error
           retention-days: 5
 
+  private-c5:
+    name: Obtain private C5 installer targets
+    needs: prepare
+    if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch exact-source private build
+        env:
+          GH_TOKEN: ${{ secrets.PRIVATE_TFT_BUILD_TOKEN }}
+        run: |
+          test -n "$GH_TOKEN"
+          jq -n \
+            --arg source_sha "${{ needs.prepare.outputs.source_sha }}" \
+            --arg release_tag "${{ github.event.release.tag_name }}" \
+            --arg release_id "${{ github.event.release.id }}" \
+            '{ref:"main",inputs:{mode:"installer",source_sha:$source_sha,release_tag:$release_tag,release_id:$release_id}}' \
+            | gh api --method POST \
+                repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches \
+                --input -
+
+      - name: Wait for sanitized private target fragments
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p private-targets
+          for attempt in $(seq 1 90); do
+            ASSETS=$(gh api "repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets" --jq '.[].name')
+            if grep -Fxq 'marauder-v8.installer.json' <<< "$ASSETS" \
+              && grep -Fxq 'marauder-mini-v3.installer.json' <<< "$ASSETS" \
+              && grep -Fxq 'dual-c5-mini.installer.json' <<< "$ASSETS"; then
+              gh release download "${{ github.event.release.tag_name }}" \
+                --repo "${{ github.repository }}" \
+                --dir private-targets \
+                --pattern '*.installer.json'
+              test "$(find private-targets -maxdepth 1 -name '*.installer.json' | wc -l)" -eq 3
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Timed out waiting for all private installer fragments" >&2
+          exit 1
+
+      - name: Upload sanitized private fragments
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-private-c5-fragments
+          path: private-targets/*.installer.json
+          if-no-files-found: error
+          retention-days: 5
+
   combine:
     name: Combine authoritative installer manifest
-    needs: build
+    needs: [build, private-c5]
+    if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -274,6 +274,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [compile_sketch]
     if: ${{ github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: write
     steps: 
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -340,3 +342,34 @@ jobs:
             | AWOK V2/V3 screen (white usb) | `_v6_1.bin` |
             | AWOK V2 flipper (orange usb) | `_flipper.bin` |
             | AWOK V3 flipper (orange usb) | `_marauder_dev_board_pro.bin` |
+
+      - name: Dispatch private C5 display builds
+        env:
+          GH_TOKEN: ${{ secrets.PRIVATE_TFT_BUILD_TOKEN }}
+        run: |
+          test -n "$GH_TOKEN"
+          RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases/tags/${{ env.version_dot }}" --jq .id)
+          jq -n \
+            --arg source_sha "${{ github.sha }}" \
+            --arg release_tag "${{ env.version_dot }}" \
+            --arg release_id "$RELEASE_ID" \
+            '{ref:"main",inputs:{mode:"release",source_sha:$source_sha,release_tag:$release_tag,release_id:$release_id}}' \
+            | gh api --method POST \
+                repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches \
+                --input -
+
+      - name: Wait for private C5 display binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for attempt in $(seq 1 60); do
+            ASSETS=$(gh api "repos/${{ github.repository }}/releases/tags/${{ env.version_dot }}" --jq '.assets[].name')
+            if grep -Eq '_v8\.bin$' <<< "$ASSETS" \
+              && grep -Eq '_mini_v3\.bin$' <<< "$ASSETS" \
+              && grep -Eq '_dual_c5_mini\.bin$' <<< "$ASSETS"; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Timed out waiting for all private C5 display binaries" >&2
+          exit 1

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -343,7 +343,7 @@ jobs:
             | AWOK V2 flipper (orange usb) | `_flipper.bin` |
             | AWOK V3 flipper (orange usb) | `_marauder_dev_board_pro.bin` |
 
-      - name: Dispatch private C5 display builds
+      - name: Dispatch private Marauder v8 build
         env:
           GH_TOKEN: ${{ secrets.PRIVATE_TFT_BUILD_TOKEN }}
         run: |
@@ -358,18 +358,16 @@ jobs:
                 repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches \
                 --input -
 
-      - name: Wait for private C5 display binaries
+      - name: Wait for private Marauder v8 binary
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           for attempt in $(seq 1 60); do
             ASSETS=$(gh api "repos/${{ github.repository }}/releases/tags/${{ env.version_dot }}" --jq '.assets[].name')
-            if grep -Eq '_v8\.bin$' <<< "$ASSETS" \
-              && grep -Eq '_mini_v3\.bin$' <<< "$ASSETS" \
-              && grep -Eq '_dual_c5_mini\.bin$' <<< "$ASSETS"; then
+            if grep -Eq '_v8\.bin$' <<< "$ASSETS"; then
               exit 0
             fi
             sleep 10
           done
-          echo "Timed out waiting for all private C5 display binaries" >&2
+          echo "Timed out waiting for the private Marauder v8 binary" >&2
           exit 1

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,10 +1,10 @@
 # Installer manifest
 
-`targets.json` is the canonical installer identity registry for the 22 stable firmware build targets. It maps each build flag to a stable target ID, aliases, release asset suffix, browser-facing chip family, and esptool chip name.
+`targets.json` is the canonical installer identity registry for all stable firmware build targets. It maps each build flag to a stable target ID, aliases, release asset suffix, browser-facing chip family, and esptool chip name. `privateBuildFlags` identifies the three C5 display targets built only in the private TFT repository.
 
 The normal release workflow, `.github/workflows/build_parallel.yml`, remains unchanged and continues producing its existing downloadable application binaries. Installer automation lives only in the additive `.github/workflows/build_installer_manifests.yml` workflow.
 
-The installer workflow exports its build matrix directly from the normal workflow and validates every build flag against `targets.json`. Matrix parsing fails closed on unsupported syntax, missing fields, duplicates, or target drift. This keeps the existing normal-release matrix authoritative without requiring it to consume installer-specific configuration.
+The installer workflow exports its public build matrix directly from the normal workflow and validates every public build flag against `targets.json`. Matrix parsing fails closed on unsupported syntax, missing fields, duplicates, or target drift. Private target identities remain public, but their TFT implementation and build configuration do not.
 
 Each installer build reads Arduino CLI's expanded upload recipe and concrete build properties; it does not guess offsets, flash size, mode, frequency, or segment paths. It copies each actual flash segment into a target-specific asset, calculates its size and SHA-256 digest, and emits:
 
@@ -12,7 +12,7 @@ Each installer build reads Arduino CLI's expanded upload recipe and concrete bui
 - a factory plan containing every emitted flash segment and requiring erase;
 - a per-target manifest used only as an intermediate CI artifact.
 
-The combine job refuses to create `firmware-manifest.json` unless every registry target is present exactly once and every target agrees on stable channel, version, and full source commit.
+For stable releases, the combine job refuses to create `firmware-manifest.json` unless every public and private registry target is present exactly once and every target agrees on stable channel, version, and full source commit.
 
 ## Triggers and release relationship
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,6 +1,6 @@
 # Installer manifest
 
-`targets.json` is the canonical installer identity registry for all stable firmware build targets. It maps each build flag to a stable target ID, aliases, release asset suffix, browser-facing chip family, and esptool chip name. `privateBuildFlags` identifies the three C5 display targets built only in the private TFT repository.
+`targets.json` is the canonical installer identity registry for all stable firmware build targets. It maps each build flag to a stable target ID, aliases, release asset suffix, browser-facing chip family, and esptool chip name. `privateBuildFlags` identifies Marauder v8, which is built only in the private TFT repository. Marauder Mini v3 and Dual C5 Mini will be added when their private TFT setup is available.
 
 The normal release workflow, `.github/workflows/build_parallel.yml`, remains unchanged and continues producing its existing downloadable application binaries. Installer automation lives only in the additive `.github/workflows/build_installer_manifests.yml` workflow.
 

--- a/installer/targets.json
+++ b/installer/targets.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": 1,
   "sourceWorkflow": ".github/workflows/build_parallel.yml",
+  "privateBuildFlags": ["MARAUDER_V8", "MARAUDER_MINI_V3", "DUAL_MINI_C5"],
   "targets": [
     {
       "id": "flipper-zero-wifi-dev-board",
@@ -197,6 +198,33 @@
       "aliases": ["Pancake Marauder V8"],
       "buildFlag": "MARAUDER_PANCAKE",
       "assetSuffix": "pancake",
+      "chipFamily": "ESP32-C5",
+      "esptoolChip": "esp32c5"
+    },
+    {
+      "id": "marauder-v8",
+      "displayName": "Marauder v8",
+      "aliases": [],
+      "buildFlag": "MARAUDER_V8",
+      "assetSuffix": "v8",
+      "chipFamily": "ESP32-C5",
+      "esptoolChip": "esp32c5"
+    },
+    {
+      "id": "marauder-mini-v3",
+      "displayName": "Marauder Mini v3",
+      "aliases": ["Mini v3"],
+      "buildFlag": "MARAUDER_MINI_V3",
+      "assetSuffix": "mini_v3",
+      "chipFamily": "ESP32-C5",
+      "esptoolChip": "esp32c5"
+    },
+    {
+      "id": "dual-c5-mini",
+      "displayName": "Dual C5 Mini",
+      "aliases": ["Dual Mini C5"],
+      "buildFlag": "DUAL_MINI_C5",
+      "assetSuffix": "dual_c5_mini",
       "chipFamily": "ESP32-C5",
       "esptoolChip": "esp32c5"
     }

--- a/installer/targets.json
+++ b/installer/targets.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "sourceWorkflow": ".github/workflows/build_parallel.yml",
-  "privateBuildFlags": ["MARAUDER_V8", "MARAUDER_MINI_V3", "DUAL_MINI_C5"],
+  "privateBuildFlags": ["MARAUDER_V8"],
   "targets": [
     {
       "id": "flipper-zero-wifi-dev-board",
@@ -207,24 +207,6 @@
       "aliases": [],
       "buildFlag": "MARAUDER_V8",
       "assetSuffix": "v8",
-      "chipFamily": "ESP32-C5",
-      "esptoolChip": "esp32c5"
-    },
-    {
-      "id": "marauder-mini-v3",
-      "displayName": "Marauder Mini v3",
-      "aliases": ["Mini v3"],
-      "buildFlag": "MARAUDER_MINI_V3",
-      "assetSuffix": "mini_v3",
-      "chipFamily": "ESP32-C5",
-      "esptoolChip": "esp32c5"
-    },
-    {
-      "id": "dual-c5-mini",
-      "displayName": "Dual C5 Mini",
-      "aliases": ["Dual Mini C5"],
-      "buildFlag": "DUAL_MINI_C5",
-      "assetSuffix": "dual_c5_mini",
       "chipFamily": "ESP32-C5",
       "esptoolChip": "esp32c5"
     }

--- a/tools/installer_manifest.py
+++ b/tools/installer_manifest.py
@@ -71,6 +71,13 @@ def load_registry(path: Path) -> dict[str, Any]:
     targets = registry.get("targets")
     if not isinstance(targets, list) or not targets:
         raise ManifestError("Target registry must contain at least one target.")
+    private_build_flags = registry.get("privateBuildFlags", [])
+    if not isinstance(private_build_flags, list) or not all(
+        isinstance(flag, str) for flag in private_build_flags
+    ):
+        raise ManifestError("privateBuildFlags must be an array of build-flag strings.")
+    if len(private_build_flags) != len(set(private_build_flags)):
+        raise ManifestError("privateBuildFlags contains duplicates.")
 
     ids: set[str] = set()
     flags: set[str] = set()
@@ -92,6 +99,12 @@ def load_registry(path: Path) -> dict[str, Any]:
             if value in seen:
                 raise ManifestError(f"Duplicate {label}: {value}.")
             seen.add(value)
+
+    unknown_private_flags = set(private_build_flags) - flags
+    if unknown_private_flags:
+        raise ManifestError(
+            f"privateBuildFlags contains unknown targets: {sorted(unknown_private_flags)}."
+        )
 
     return registry
 
@@ -159,12 +172,14 @@ def load_normal_build_matrix(
 
     registry = load_registry(registry_path)
     registry_flags = {target["buildFlag"] for target in registry["targets"]}
+    private_flags = set(registry.get("privateBuildFlags", []))
+    public_registry_flags = registry_flags - private_flags
     matrix_flags = {board["flag"] for board in boards}
-    if matrix_flags != registry_flags:
+    if matrix_flags != public_registry_flags:
         raise ManifestError(
-            "Installer target registry does not match the normal build workflow; "
-            f"missing={sorted(matrix_flags - registry_flags)}, "
-            f"extra={sorted(registry_flags - matrix_flags)}."
+            "Public installer targets do not match the normal build workflow; "
+            f"unregistered={sorted(matrix_flags - public_registry_flags)}, "
+            f"missing={sorted(public_registry_flags - matrix_flags)}."
         )
     return boards
 

--- a/tools/test_installer_manifest.py
+++ b/tools/test_installer_manifest.py
@@ -57,6 +57,7 @@ class InstallerManifestTests(unittest.TestCase):
         boards = load_normal_build_matrix(NORMAL_WORKFLOW, REGISTRY)
         workflow_flags = {board["flag"] for board in boards}
         registry_flags = {target["buildFlag"] for target in registry["targets"]}
+        private_flags = set(registry["privateBuildFlags"])
         normal_workflow = NORMAL_WORKFLOW.read_text(encoding="utf-8")
         installer_workflow = INSTALLER_WORKFLOW.read_text(encoding="utf-8")
 
@@ -65,9 +66,10 @@ class InstallerManifestTests(unittest.TestCase):
         self.assertIn("set-build-path: true", installer_workflow)
         self.assertIn("--show-properties=expanded", installer_workflow)
         self.assertIn("github.event_name == 'release'", installer_workflow)
-        self.assertEqual(len(registry["targets"]), 22)
+        self.assertEqual(len(registry["targets"]), 25)
         self.assertEqual(len(boards), 22)
-        self.assertEqual(registry_flags, workflow_flags)
+        self.assertEqual(private_flags, {"MARAUDER_V8", "MARAUDER_MINI_V3", "DUAL_MINI_C5"})
+        self.assertEqual(registry_flags - private_flags, workflow_flags)
         self.assertEqual(
             len(registry_flags),
             len(registry["targets"]),
@@ -180,7 +182,7 @@ class InstallerManifestTests(unittest.TestCase):
             self.assertEqual(release["metadataStatus"], "authoritative")
             self.assertEqual(release["channel"], "stable")
             self.assertEqual(release["sourceCommit"], "a" * 40)
-            self.assertEqual(len(release["targets"]), 22)
+            self.assertEqual(len(release["targets"]), 25)
             self.assertIn("/" + "a" * 40 + "/", release["$schema"])
 
 

--- a/tools/test_installer_manifest.py
+++ b/tools/test_installer_manifest.py
@@ -66,9 +66,9 @@ class InstallerManifestTests(unittest.TestCase):
         self.assertIn("set-build-path: true", installer_workflow)
         self.assertIn("--show-properties=expanded", installer_workflow)
         self.assertIn("github.event_name == 'release'", installer_workflow)
-        self.assertEqual(len(registry["targets"]), 25)
+        self.assertEqual(len(registry["targets"]), 23)
         self.assertEqual(len(boards), 22)
-        self.assertEqual(private_flags, {"MARAUDER_V8", "MARAUDER_MINI_V3", "DUAL_MINI_C5"})
+        self.assertEqual(private_flags, {"MARAUDER_V8"})
         self.assertEqual(registry_flags - private_flags, workflow_flags)
         self.assertEqual(
             len(registry_flags),
@@ -182,7 +182,7 @@ class InstallerManifestTests(unittest.TestCase):
             self.assertEqual(release["metadataStatus"], "authoritative")
             self.assertEqual(release["channel"], "stable")
             self.assertEqual(release["sourceCommit"], "a" * 40)
-            self.assertEqual(len(release["targets"]), 25)
+            self.assertEqual(len(release["targets"]), 23)
             self.assertIn("/" + "a" * 40 + "/", release["$schema"])
 
 


### PR DESCRIPTION
## Summary
- dispatch an exact-SHA private build for Marauder v8
- extend the installer registry to 23 targets while keeping the public matrix at 22
- fail closed until the sanitized Marauder v8 installer fragment is present
- wait for the private v8 binary before completing draft-release automation
- defer Marauder Mini v3 and Dual C5 Mini until their correct TFT setup is available

## Security boundary
- public runners never check out private TFT source
- no `pull_request_target` execution
- dispatch and release publication use separate least-privilege tokens
- only the binary and sanitized installer JSON cross the repository boundary

## Validation
- `python3 -m unittest tools/test_installer_manifest.py -v` (7 passed)
- registry validation passed (23 targets)
- public matrix export passed (22 targets)
- JSON, YAML, and whitespace validation passed

## Coordination
This PR is paired with draft TFT_eSPI_JCMK PR #1, now narrowed to Marauder v8. Keep both draft/unmerged until the disposable end-to-end release test passes. Mini v3 and Dual C5 Mini will be added later.