### PR TITLE
ci: harden private v8 release handoff

### DIFF
--- a/.github/workflows/build_installer_manifests.yml
+++ b/.github/workflows/build_installer_manifests.yml
@@ -282,14 +282,19 @@ jobs:
           GH_TOKEN: ${{ secrets.PRIVATE_TFT_BUILD_TOKEN }}
         run: |
           test -n "$GH_TOKEN"
-          jq -n \
+          PAYLOAD=$(jq -n \
             --arg source_sha "${{ needs.prepare.outputs.source_sha }}" \
             --arg release_tag "${{ github.event.release.tag_name }}" \
             --arg release_id "${{ github.event.release.id }}" \
-            '{ref:"main",inputs:{mode:"installer",source_sha:$source_sha,release_tag:$release_tag,release_id:$release_id}}' \
-            | gh api --method POST \
-                repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches \
-                --input -
+            '{ref:"main",inputs:{mode:"installer",source_sha:$source_sha,release_tag:$release_tag,release_id:$release_id}}')
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --header 'Content-Type: application/json' \
+            --data "$PAYLOAD" \
+            'https://api.github.com/repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches'
 
       - name: Wait for sanitized Marauder v8 target fragment
         env:

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -292,6 +292,7 @@ jobs:
         with:
           name: "Marauder Release ${{ github.ref_name }}"
           tag_name: ${{ env.version_dot }}
+          target_commitish: ${{ github.sha }}
           generate_release_notes: false
           draft: true
           files: |
@@ -349,14 +350,19 @@ jobs:
         run: |
           test -n "$GH_TOKEN"
           RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases/tags/${{ env.version_dot }}" --jq .id)
-          jq -n \
+          PAYLOAD=$(jq -n \
             --arg source_sha "${{ github.sha }}" \
             --arg release_tag "${{ env.version_dot }}" \
             --arg release_id "$RELEASE_ID" \
-            '{ref:"main",inputs:{mode:"release",source_sha:$source_sha,release_tag:$release_tag,release_id:$release_id}}' \
-            | gh api --method POST \
-                repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches \
-                --input -
+            '{ref:"main",inputs:{mode:"release",source_sha:$source_sha,release_tag:$release_tag,release_id:$release_id}}')
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --header 'Content-Type: application/json' \
+            --data "$PAYLOAD" \
+            'https://api.github.com/repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches'
 
       - name: Wait for private Marauder v8 binary
         env:


### PR DESCRIPTION
## Summary
- pin draft releases to the exact workflow SHA
- dispatch the private workflow using a direct fail-closed GitHub API request
- apply the same dispatch correction to stable installer generation

## Evidence
The disposable run built all 22 public targets successfully, then the prior `gh api --input -` handoff returned 404. A direct authenticated dispatch succeeded.

## Validation
- both workflow YAML files parse
- 7 installer manifest unit tests pass
- registry validation passes for 23 targets
- `git diff --check` passes

Paired with TFT_eSPI_JCMK path-leak fix PR.