### PR TITLE
Use scoped tokens for draft release handoff

### DIFF
--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -346,9 +346,11 @@ jobs:
 
       - name: Dispatch private Marauder v8 build
         env:
-          GH_TOKEN: ${{ secrets.PRIVATE_TFT_BUILD_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          PRIVATE_TFT_BUILD_TOKEN: ${{ secrets.PRIVATE_TFT_BUILD_TOKEN }}
         run: |
           test -n "$GH_TOKEN"
+          test -n "$PRIVATE_TFT_BUILD_TOKEN"
           RELEASE_ID=$(gh api --paginate --slurp \
             "repos/${{ github.repository }}/releases?per_page=100" \
             | jq -er --arg tag "${{ env.version_dot }}" \
@@ -361,7 +363,7 @@ jobs:
             '{ref:"main",inputs:{mode:"release",source_sha:$source_sha,release_tag:$release_tag,release_id:$release_id}}')
           curl --fail-with-body --silent --show-error \
             --request POST \
-            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "Authorization: Bearer $PRIVATE_TFT_BUILD_TOKEN" \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
             --header 'Content-Type: application/json' \


### PR DESCRIPTION
## Summary
- use the repository Actions token to resolve the public repository draft release ID
- reserve the private token for cross-repository workflow dispatch

## Cause
The private dispatch token can invoke the TFT workflow but cannot enumerate ESP32Marauder draft releases, so the corrected release-list lookup returned zero matches.

## Validation
- `git diff --check`
- exact base: `develop@f4a3a8520948e510b9fe816e35d30dfe3fd17213`
- live disposable E2E will be rerun after exact-head PR checks and merge