### PR TITLE
Add Mini v3 and Dual Mini C5 release builds

### DIFF
--- a/.github/workflows/build_installer_manifests.yml
+++ b/.github/workflows/build_installer_manifests.yml
@@ -296,14 +296,16 @@ jobs:
             --data "$PAYLOAD" \
             'https://api.github.com/repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches'
 
-      - name: Wait for sanitized Marauder v8 installer assets
+      - name: Wait for sanitized private C5 installer assets
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p private-targets
           for attempt in $(seq 1 90); do
             ASSETS=$(gh api "repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets" --jq '.[].name')
-            if grep -Fxq 'marauder-v8.installer.json' <<< "$ASSETS"; then
+            if grep -Fxq 'marauder-v8.installer.json' <<< "$ASSETS" && \
+               grep -Fxq 'marauder-mini-v3.installer.json' <<< "$ASSETS" && \
+               grep -Fxq 'dual-mini-c5.installer.json' <<< "$ASSETS"; then
               gh release download "${{ github.event.release.tag_name }}" \
                 --repo "${{ github.repository }}" \
                 --dir private-targets \
@@ -311,14 +313,14 @@ jobs:
               gh release download "${{ github.event.release.tag_name }}" \
                 --repo "${{ github.repository }}" \
                 --dir private-targets \
-                --pattern 'esp32_marauder_installer_*_v8*.bin'
-              test "$(find private-targets -maxdepth 1 -name '*.installer.json' | wc -l)" -eq 1
-              test "$(find private-targets -maxdepth 1 -name 'esp32_marauder_installer_*_v8*.bin' | wc -l)" -eq 4
+                --pattern 'esp32_marauder_installer_*.bin'
+              test "$(find private-targets -maxdepth 1 -name '*.installer.json' | wc -l)" -eq 3
+              test "$(find private-targets -maxdepth 1 -name 'esp32_marauder_installer_*.bin' | wc -l)" -eq 12
               exit 0
             fi
             sleep 10
           done
-          echo "Timed out waiting for the Marauder v8 installer fragment" >&2
+          echo "Timed out waiting for the private C5 installer fragments" >&2
           exit 1
 
       - name: Upload sanitized private installer assets
@@ -397,13 +399,13 @@ jobs:
           fail_on_unmatched_files: true
           files: release-assets/marauder-installer-assets.zip
 
-      - name: Remove temporary private v8 handoff assets
+      - name: Remove temporary private C5 handoff assets
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh api "repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets" \
             --paginate \
-            --jq '.[] | select(.name == "marauder-v8.installer.json" or (.name | startswith("esp32_marauder_installer_") and contains("_v8"))) | .id' |
+            --jq '.[] | select(.name == "marauder-v8.installer.json" or .name == "marauder-mini-v3.installer.json" or .name == "dual-mini-c5.installer.json" or (.name | startswith("esp32_marauder_installer_") and (contains("_v8") or contains("_mini_v3") or contains("_dual_mini_c5")))) | .id' |
           while read -r asset_id; do
             test -n "$asset_id"
             gh api --method DELETE "repos/${{ github.repository }}/releases/assets/$asset_id"

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -329,6 +329,7 @@ jobs:
             | Kit | `_kit.bin` |
             | Mini | `_mini.bin` |
             | Mini v3 | `_mini_v3.bin` |
+            | Dual Mini C5 | `_dual_mini_c5.bin` |
             | Flipper Zero | `_flipper.bin` |
             | MutliBoard S3 | `_multiboardS3.bin` |
             | LDDB/NodeMCU/Wemos | `_lddb.bin` |
@@ -345,7 +346,7 @@ jobs:
             | AWOK V2 flipper (orange usb) | `_flipper.bin` |
             | AWOK V3 flipper (orange usb) | `_marauder_dev_board_pro.bin` |
 
-      - name: Dispatch private Marauder v8 build
+      - name: Dispatch private C5 builds
         env:
           PRIVATE_TFT_BUILD_TOKEN: ${{ secrets.PRIVATE_TFT_BUILD_TOKEN }}
           RELEASE_ID: ${{ steps.create_release.outputs.id }}
@@ -368,16 +369,18 @@ jobs:
             --data "$PAYLOAD" \
             'https://api.github.com/repos/justcallmekoko/TFT_eSPI_JCMK/actions/workflows/private-c5-build.yml/dispatches'
 
-      - name: Wait for private Marauder v8 binary
+      - name: Wait for private C5 binaries
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           for attempt in $(seq 1 60); do
             ASSETS=$(gh api "repos/${{ github.repository }}/releases/${{ env.release_id }}" --jq '.assets[].name')
-            if grep -Eq '_v8\.bin$' <<< "$ASSETS"; then
+            if grep -Eq '_v8\.bin$' <<< "$ASSETS" && \
+               grep -Eq '_mini_v3\.bin$' <<< "$ASSETS" && \
+               grep -Eq '_dual_mini_c5\.bin$' <<< "$ASSETS"; then
               exit 0
             fi
             sleep 10
           done
-          echo "Timed out waiting for the private Marauder v8 binary" >&2
+          echo "Timed out waiting for the private C5 binaries" >&2
           exit 1

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,6 +1,6 @@
 # Installer manifest
 
-`targets.json` is the canonical installer identity registry for all stable firmware build targets. It maps each build flag to a stable target ID, aliases, release asset suffix, browser-facing chip family, and esptool chip name. `privateBuildFlags` identifies Marauder v8, which is built only in the private TFT repository. Marauder Mini v3 and Dual C5 Mini will be added when their private TFT setup is available.
+`targets.json` is the canonical installer identity registry for all stable firmware build targets. It maps each build flag to a stable target ID, aliases, release asset suffix, browser-facing chip family, and esptool chip name. `privateBuildFlags` identifies Marauder v8, Marauder Mini v3, and Dual Mini C5, which are built only in the private TFT repository.
 
 The normal release workflow, `.github/workflows/build_parallel.yml`, remains unchanged and continues producing its existing downloadable application binaries. Installer automation lives only in the additive `.github/workflows/build_installer_manifests.yml` workflow.
 

--- a/installer/targets.json
+++ b/installer/targets.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "sourceWorkflow": ".github/workflows/build_parallel.yml",
-  "privateBuildFlags": ["MARAUDER_V8"],
+  "privateBuildFlags": ["MARAUDER_V8", "MARAUDER_MINI_V3", "DUAL_MINI_C5"],
   "targets": [
     {
       "id": "flipper-zero-wifi-dev-board",
@@ -207,6 +207,24 @@
       "aliases": [],
       "buildFlag": "MARAUDER_V8",
       "assetSuffix": "v8",
+      "chipFamily": "ESP32-C5",
+      "esptoolChip": "esp32c5"
+    },
+    {
+      "id": "marauder-mini-v3",
+      "displayName": "Marauder Mini v3",
+      "aliases": ["Mini v3"],
+      "buildFlag": "MARAUDER_MINI_V3",
+      "assetSuffix": "mini_v3",
+      "chipFamily": "ESP32-C5",
+      "esptoolChip": "esp32c5"
+    },
+    {
+      "id": "dual-mini-c5",
+      "displayName": "Dual Mini C5",
+      "aliases": ["Dual C5 Mini"],
+      "buildFlag": "DUAL_MINI_C5",
+      "assetSuffix": "dual_mini_c5",
       "chipFamily": "ESP32-C5",
       "esptoolChip": "esp32c5"
     }

--- a/tools/test_installer_manifest.py
+++ b/tools/test_installer_manifest.py
@@ -68,9 +68,12 @@ class InstallerManifestTests(unittest.TestCase):
         self.assertIn("github.event_name == 'release'", installer_workflow)
         self.assertIn('marauder-installer-assets.zip', installer_workflow)
         self.assertNotIn('release-assets/*.bin\n', installer_workflow)
-        self.assertEqual(len(registry["targets"]), 23)
+        self.assertEqual(len(registry["targets"]), 25)
         self.assertEqual(len(boards), 22)
-        self.assertEqual(private_flags, {"MARAUDER_V8"})
+        self.assertEqual(
+            private_flags,
+            {"MARAUDER_V8", "MARAUDER_MINI_V3", "DUAL_MINI_C5"},
+        )
         self.assertEqual(registry_flags - private_flags, workflow_flags)
         self.assertEqual(
             len(registry_flags),
@@ -184,7 +187,7 @@ class InstallerManifestTests(unittest.TestCase):
             self.assertEqual(release["metadataStatus"], "authoritative")
             self.assertEqual(release["channel"], "stable")
             self.assertEqual(release["sourceCommit"], "a" * 40)
-            self.assertEqual(len(release["targets"]), 23)
+            self.assertEqual(len(release["targets"]), 25)
             self.assertIn("/" + "a" * 40 + "/", release["$schema"])
 
 


### PR DESCRIPTION
- Register Mini v3 and Dual Mini C5 as private installer targets
- Wait for all three private C5 release binaries
- Package all private C5 installer fragments and segments in the installer ZIP
- Remove the temporary private handoff assets after packaging

Verification:
- 7 installer manifest tests pass
- Workflow YAML and target registry validation pass