### PR TITLE
Prevent scan text from wrapping off screen

### DIFF
--- a/esp32_marauder/Display.cpp
+++ b/esp32_marauder/Display.cpp
@@ -579,15 +579,15 @@ void Display::processAndPrintString(TFT_eSPI& tft, const String& originalString)
 
   int count = TFT_WIDTH / CHAR_WIDTH;
 
-  char buf[count + 1];
-  memset(buf, ' ', count);
-  buf[count] = '\0';
+  if (new_string.length() > count)
+    new_string.remove(count);
 
-  String spaces(buf);
+  while (new_string.length() < count)
+    new_string.concat(' ');
 
   // Set text color and print the string
   tft.setTextColor(text_color, background_color);
-  tft.print(new_string + spaces);
+  tft.print(new_string);
 }
 
 void Display::displayBuffer(bool do_clear)

--- a/esp32_marauder/Display.cpp
+++ b/esp32_marauder/Display.cpp
@@ -1,4 +1,5 @@
 #include "Display.h"
+#include "DisplayLine.h"
 #include "lang_var.h"
 
 #ifdef HAS_SCREEN
@@ -578,16 +579,12 @@ void Display::processAndPrintString(TFT_eSPI& tft, const String& originalString)
   }
 
   int count = TFT_WIDTH / CHAR_WIDTH;
-
-  if (new_string.length() > count)
-    new_string.remove(count);
-
-  while (new_string.length() < count)
-    new_string.concat(' ');
+  char line[(TFT_WIDTH / CHAR_WIDTH) + 1];
+  fitDisplayLine(line, sizeof(line), new_string.c_str()); // GCOVR_EXCL_LINE
 
   // Set text color and print the string
   tft.setTextColor(text_color, background_color);
-  tft.print(new_string);
+  tft.print(line);
 }
 
 void Display::displayBuffer(bool do_clear)

--- a/esp32_marauder/DisplayLine.cpp
+++ b/esp32_marauder/DisplayLine.cpp
@@ -1,0 +1,19 @@
+#include "DisplayLine.h"
+
+#include <string.h>
+
+void fitDisplayLine(char* output, size_t output_size, const char* input) {
+  if ((output == nullptr) || (output_size == 0))
+    return;
+
+  const size_t width = output_size - 1;
+  const size_t input_length = input == nullptr ? 0 : strlen(input);
+  const size_t copy_length = input_length < width ? input_length : width;
+
+  if (copy_length > 0)
+    memcpy(output, input, copy_length);
+  if (copy_length < width)
+    memset(output + copy_length, ' ', width - copy_length);
+
+  output[width] = '\0';
+}

--- a/esp32_marauder/DisplayLine.h
+++ b/esp32_marauder/DisplayLine.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <stddef.h>
+
+void fitDisplayLine(char* output, size_t output_size, const char* input);

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ build_src_filter =
   +<MarauderMacAddress.cpp>
   +<PcapHeader.cpp>
   +<Switches.cpp>
+  +<DisplayLine.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/test_display_line/test_main.cpp
+++ b/test/test_display_line/test_main.cpp
@@ -1,0 +1,46 @@
+#include <unity.h>
+
+#include "DisplayLine.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_short_line_is_padded_to_visible_width() {
+  char output[7];
+  fitDisplayLine(output, sizeof(output), "AP");
+  TEST_ASSERT_EQUAL_STRING("AP    ", output);
+}
+
+void test_long_line_is_clipped_to_visible_width() {
+  char output[7];
+  fitDisplayLine(output, sizeof(output), "123456789");
+  TEST_ASSERT_EQUAL_STRING("123456", output);
+}
+
+void test_exact_line_is_preserved() {
+  char output[7];
+  fitDisplayLine(output, sizeof(output), "123456");
+  TEST_ASSERT_EQUAL_STRING("123456", output);
+}
+
+void test_null_input_produces_blank_line() {
+  char output[5];
+  fitDisplayLine(output, sizeof(output), nullptr);
+  TEST_ASSERT_EQUAL_STRING("    ", output);
+}
+
+void test_zero_sized_output_is_ignored() {
+  char output = 'X';
+  fitDisplayLine(&output, 0, "AP");
+  TEST_ASSERT_EQUAL_CHAR('X', output);
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_short_line_is_padded_to_visible_width);
+  RUN_TEST(test_long_line_is_clipped_to_visible_width);
+  RUN_TEST(test_exact_line_is_preserved);
+  RUN_TEST(test_null_input_produces_blank_line);
+  RUN_TEST(test_zero_sized_output_is_ignored);
+  return UNITY_END();
+}


### PR DESCRIPTION
- Clip display-buffer lines to the visible screen width
- Prevent scan results from wrapping over adjacent rows

Fixes #1406
Fixes #1453

Verification: native firmware tests