### PR TITLE
Preserve beacon channels for saved SSIDs

### DIFF
--- a/esp32_marauder/BeaconFrame.cpp
+++ b/esp32_marauder/BeaconFrame.cpp
@@ -1,0 +1,15 @@
+#include "BeaconFrame.h"
+
+bool setBeaconFrameChannel(
+  uint8_t* frame,
+  size_t frame_size,
+  size_t ssid_length,
+  uint8_t channel
+) {
+  const size_t channel_index = 50 + ssid_length;
+  if ((frame == nullptr) || (channel_index >= frame_size))
+    return false;
+
+  frame[channel_index] = channel;
+  return true;
+}

--- a/esp32_marauder/BeaconFrame.h
+++ b/esp32_marauder/BeaconFrame.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+bool setBeaconFrameChannel(
+  uint8_t* frame,
+  size_t frame_size,
+  size_t ssid_length,
+  uint8_t channel
+);

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1,5 +1,6 @@
 #include "esp_random.h"
 #include "WiFiScan.h"
+#include "BeaconFrame.h"
 #include "lang_var.h"
 
 #ifdef HAS_PSRAM
@@ -8622,10 +8623,13 @@ void WiFiScan::broadcastCustomBeacon(uint32_t current_time, AccessPoint custom_s
     for(int i = 0; i < numSpace; i++)
       temp_frame[38 + realLen + i] = 0x20;
 
-    temp_frame[50 + fullLen] = set_channel;
   }
 
   memcpy(temp_frame + (38 + fullLen), post, post_len);
+
+  if ((scan_mode != WIFI_ATTACK_CSA) &&
+      (scan_mode != WIFI_ATTACK_QUIET))
+    setBeaconFrameChannel(temp_frame, sizeof(temp_frame), fullLen, set_channel); // GCOVR_EXCL_LINE
 
   temp_frame[34] = custom_ssid.beacon[0];
   temp_frame[35] = custom_ssid.beacon[1];
@@ -8694,12 +8698,12 @@ void WiFiScan::broadcastCustomBeacon(uint32_t current_time, ssid custom_ssid, bo
     temp_frame[38 + i] = ESSID[i];
 
   
-  temp_frame[50 + fullLen] = set_channel;
-
   if (!for_camera)
     memcpy(temp_frame + (38 + fullLen), post_base, post_len);
   else
     memcpy(temp_frame + (38 + fullLen), post_base_for_camera, post_len);
+
+  setBeaconFrameChannel(temp_frame, sizeof(temp_frame), fullLen, set_channel); // GCOVR_EXCL_LINE
   
   for (int i = 0; i < 2; i++) {
     uint16_t seq = (packets_sent & 0x0FFF) << 4;  // 12-bit sequence number
@@ -8814,11 +8818,10 @@ void WiFiScan::broadcastRandomSSID(uint32_t currentTime) {
   for (int i = 0; i < ssidLen; i++)
     temp_frame[38 + i] = alfa[random(65)];
   
-  temp_frame[50 + fullLen] = set_channel;
-
   int post_len = sizeof(post_base);
 
   memcpy(temp_frame + (38 + fullLen), post_base, post_len);
+  setBeaconFrameChannel(temp_frame, sizeof(temp_frame), fullLen, set_channel); // GCOVR_EXCL_LINE
 
   for (int i = 0; i < 2; i++)
     esp_wifi_80211_tx(WIFI_IF_AP, temp_frame, sizeof(temp_frame), false);

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ build_src_filter =
   +<PcapHeader.cpp>
   +<Switches.cpp>
   +<DisplayLine.cpp>
+  +<BeaconFrame.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/test_beacon_frame/test_main.cpp
+++ b/test/test_beacon_frame/test_main.cpp
@@ -1,0 +1,40 @@
+#include <unity.h>
+
+#include "BeaconFrame.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_channel_is_written_after_ssid() {
+  uint8_t frame[64] = {};
+  TEST_ASSERT_TRUE(setBeaconFrameChannel(frame, sizeof(frame), 4, 11));
+  TEST_ASSERT_EQUAL_UINT8(11, frame[54]);
+}
+
+void test_adjacent_frame_bytes_are_preserved() {
+  uint8_t frame[64] = {};
+  frame[53] = 0xAA;
+  frame[55] = 0xBB;
+  TEST_ASSERT_TRUE(setBeaconFrameChannel(frame, sizeof(frame), 4, 6));
+  TEST_ASSERT_EQUAL_HEX8(0xAA, frame[53]);
+  TEST_ASSERT_EQUAL_UINT8(6, frame[54]);
+  TEST_ASSERT_EQUAL_HEX8(0xBB, frame[55]);
+}
+
+void test_short_frame_is_rejected() {
+  uint8_t frame[54] = {};
+  TEST_ASSERT_FALSE(setBeaconFrameChannel(frame, sizeof(frame), 4, 1));
+}
+
+void test_null_frame_is_rejected() {
+  TEST_ASSERT_FALSE(setBeaconFrameChannel(nullptr, 64, 4, 1));
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_channel_is_written_after_ssid);
+  RUN_TEST(test_adjacent_frame_bytes_are_preserved);
+  RUN_TEST(test_short_frame_is_rejected);
+  RUN_TEST(test_null_frame_is_rejected);
+  return UNITY_END();
+}


### PR DESCRIPTION
- Preserve each SSID channel after building beacon frames
- Cover channel placement and frame bounds

Fixes #1387

Verification: native firmware tests