### PR TITLE
Improve upload progress and WDG error feedback

### DIFF
--- a/.github/workflows/firmware-unit-tests.yml
+++ b/.github/workflows/firmware-unit-tests.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Include all firmware sources in coverage
         run: python3 tools/whole_source_coverage.py coverage.xml
 
+      - name: Test coverage source discovery
+        run: python3 -m unittest discover -s tools -p 'test_*.py'
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
         with:

--- a/esp32_marauder/WdgResponse.cpp
+++ b/esp32_marauder/WdgResponse.cpp
@@ -1,0 +1,148 @@
+#include "WdgResponse.h"
+
+#include <ctype.h>
+#include <string.h>
+
+namespace {
+  const char* skipWhitespace(const char* value) {
+    while (value && *value && isspace(static_cast<unsigned char>(*value)))
+      value++;
+    return value;
+  }
+
+  bool containsIgnoreCase(const char* text, const char* needle) {
+    if (!text || !needle || !*needle)
+      return false;
+
+    for (; *text; text++) {
+      const char* current = text;
+      const char* match = needle;
+      while (*current && *match &&
+             tolower(static_cast<unsigned char>(*current)) ==
+               tolower(static_cast<unsigned char>(*match))) {
+        current++;
+        match++;
+      }
+      if (!*match)
+        return true;
+    }
+    return false;
+  }
+
+  bool copyReason(const char* start, const char* end, char* output, size_t outputSize) {
+    if (!start || !end || !output || outputSize < 2 || end <= start)
+      return false;
+
+    size_t written = 0;
+    bool pendingSpace = false;
+    while (start < end && written < outputSize - 1) {
+      unsigned char current = static_cast<unsigned char>(*start++);
+      if (current == '\\' && start < end) {
+        current = static_cast<unsigned char>(*start++);
+        if (current == 'n' || current == 'r' || current == 't')
+          current = ' ';
+      }
+
+      if (isspace(current)) {
+        pendingSpace = written > 0;
+        continue;
+      }
+      if (!isprint(current))
+        continue;
+      if (pendingSpace && written < outputSize - 1)
+        output[written++] = ' ';
+      pendingSpace = false;
+      output[written++] = static_cast<char>(current);
+    }
+
+    while (written > 0 && (output[written - 1] == ' ' || output[written - 1] == '"'))
+      written--;
+    output[written] = '\0';
+    return written > 0;
+  }
+
+  bool extractJsonValue(const char* body, const char* key, char* output, size_t outputSize) {
+    char quotedKey[16];
+    const size_t keyLength = strlen(key);
+    if (keyLength + 3 > sizeof(quotedKey))
+      return false;
+    quotedKey[0] = '"';
+    memcpy(quotedKey + 1, key, keyLength);
+    quotedKey[keyLength + 1] = '"';
+    quotedKey[keyLength + 2] = '\0';
+
+    const char* value = strstr(body, quotedKey);
+    if (!value)
+      return false;
+    value = strchr(value + keyLength + 2, ':');
+    if (!value)
+      return false;
+    value = skipWhitespace(value + 1);
+
+    if (*value == '"') {
+      const char* end = value + 1;
+      bool escaped = false;
+      while (*end) {
+        if (*end == '"' && !escaped)
+          break;
+        escaped = (*end == '\\' && !escaped);
+        if (*end != '\\')
+          escaped = false;
+        end++;
+      }
+      return copyReason(value + 1, end, output, outputSize);
+    }
+
+    const char* end = value;
+    while (*end && *end != ',' && *end != '}' && *end != '\r' && *end != '\n')
+      end++;
+    return copyReason(value, end, output, outputSize);
+  }
+}
+
+bool extractWdgErrorReason(const char* response, char* output, size_t outputSize) {
+  if (!output || outputSize == 0)
+    return false;
+  output[0] = '\0';
+  if (!response || !*response)
+    return false;
+
+  const char* body = strstr(response, "\r\n\r\n");
+  body = body ? body + 4 : response;
+  body = skipWhitespace(body);
+
+  static const char* keys[] = {"detail", "message", "error", "reason"};
+  for (const char* key : keys) {
+    if (extractJsonValue(body, key, output, outputSize)) {
+      if (containsIgnoreCase(output, "duplicate")) {
+        copyReason("Duplicate upload", "Duplicate upload" + 16, output, outputSize);
+      } else if (containsIgnoreCase(output, "already") &&
+                 containsIgnoreCase(output, "upload")) {
+        copyReason("Already uploaded", "Already uploaded" + 16, output, outputSize);
+      }
+      return true;
+    }
+  }
+
+  if (*body && *body != '{' && *body != '<') {
+    const char* end = body;
+    while (*end && *end != '\r' && *end != '\n')
+      end++;
+    if (copyReason(body, end, output, outputSize))
+      return true;
+  }
+
+  const char* status = strstr(response, "HTTP/");
+  if (status) {
+    status = strchr(status, ' ');
+    if (status) {
+      status = skipWhitespace(status);
+      const char* end = strstr(status, "\r\n");
+      if (!end)
+        end = status + strlen(status);
+      return copyReason(status, end, output, outputSize);
+    }
+  }
+
+  return false;
+}

--- a/esp32_marauder/WdgResponse.h
+++ b/esp32_marauder/WdgResponse.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stddef.h>
+
+// Extract a short, display-safe error reason from an HTTP response returned by
+// WDG Wars. Returns false only when the response contains no usable reason.
+bool extractWdgErrorReason(const char* response, char* output, size_t outputSize);

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10876,6 +10876,78 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
 }
 
 #ifdef HAS_DIRECT_UPLOAD
+  // GCOVR_EXCL_START -- host tests do not provide a TFT implementation.
+  #ifdef HAS_SCREEN
+  void WiFiScan::drawUploadProgress(const char* service, uint8_t percent, bool waiting) {
+    const uint8_t safePercent = min(percent, (uint8_t)100);
+    const uint16_t accent = waiting ? TFT_YELLOW : TFT_CYAN;
+    const int margin = 8;
+    const int barX = margin;
+    const int barW = TFT_WIDTH - (margin * 2);
+
+    if ((safePercent == 0) || waiting)
+      display_obj.tft.fillScreen(TFT_BLACK);
+
+    display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
+
+    #ifdef HAS_MINI_SCREEN
+      if ((safePercent == 0) || waiting) {
+        display_obj.tft.setTextSize(1);
+        display_obj.showCenterText(service, 10, true);
+        display_obj.tft.setTextColor(accent, TFT_BLACK);
+        display_obj.showCenterText(waiting ? "VERIFYING" : "UPLOADING", 28, true);
+      }
+
+      String percentText = String(safePercent) + "%";
+      display_obj.tft.fillRect(0, 46, TFT_WIDTH, 20, TFT_BLACK);
+      display_obj.tft.setTextSize(2);
+      display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
+      display_obj.showCenterText(percentText.c_str(), 48, false, 2);
+
+      const int barY = TFT_HEIGHT - 18;
+      display_obj.tft.drawRoundRect(barX, barY, barW, 10, 3, TFT_DARKGREY);
+      display_obj.tft.fillRect(barX + 2, barY + 2, barW - 4, 6, TFT_BLACK);
+      display_obj.tft.fillRoundRect(barX + 2, barY + 2,
+                                    ((barW - 4) * safePercent) / 100, 6, 2, accent);
+    #else
+      if ((safePercent == 0) || waiting) {
+        display_obj.tft.drawRoundRect(margin, margin, TFT_WIDTH - (margin * 2),
+                                      TFT_HEIGHT - (margin * 2), 10, TFT_DARKGREY);
+
+        display_obj.tft.setTextSize(2);
+        display_obj.tft.setTextColor(accent, TFT_BLACK);
+        display_obj.showCenterText(service, TFT_HEIGHT / 6, false, 2);
+
+        display_obj.tft.setTextSize(1);
+        display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+        display_obj.showCenterText(waiting ? "VERIFYING SERVER RESPONSE" : "SECURE LOG UPLOAD",
+                                   TFT_HEIGHT / 3, true);
+      }
+
+      const int packetY = TFT_HEIGHT / 2;
+      const int packetGap = max(12, TFT_WIDTH / 12);
+      const int packetStart = (TFT_WIDTH / 2) - packetGap;
+      for (uint8_t i = 0; i < 3; i++) {
+        const uint16_t packetColor = (i <= ((safePercent / 10) % 3)) ? accent : TFT_DARKGREY;
+        display_obj.tft.fillCircle(packetStart + (i * packetGap), packetY, 4, packetColor);
+      }
+
+      String percentText = String(safePercent) + "%";
+      display_obj.tft.fillRect(0, (TFT_HEIGHT * 3) / 5, TFT_WIDTH, 20, TFT_BLACK);
+      display_obj.tft.setTextSize(2);
+      display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
+      display_obj.showCenterText(percentText.c_str(), (TFT_HEIGHT * 3) / 5, false, 2);
+
+      const int barY = TFT_HEIGHT - 38;
+      display_obj.tft.drawRoundRect(barX, barY, barW, 16, 5, TFT_DARKGREY);
+      display_obj.tft.fillRect(barX + 3, barY + 3, barW - 6, 10, TFT_BLACK);
+      display_obj.tft.fillRoundRect(barX + 3, barY + 3,
+                                    ((barW - 6) * safePercent) / 100, 10, 3, accent);
+    #endif
+  }
+  #endif
+  // GCOVR_EXCL_STOP
+
   bool WiFiScan::sidecarExists(String filePath, String service) {
     return SD.exists(filePath + "." + service);
   }
@@ -10954,8 +11026,7 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     bool gotAny = false;
 
     #ifdef HAS_SCREEN
-    display_obj.clearScreen();
-    display_obj.showCenterText("WDG Upload...", TFT_HEIGHT / 2, true);
+    this->drawUploadProgress("WDG WARS", 0); // GCOVR_EXCL_LINE
     #endif
     delay(100);
 
@@ -11035,7 +11106,6 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     uint8_t buf[CHUNK];
     size_t totalSent = 0;
     uint8_t pct = 0;
-    String pctStr;
 
     while (fileToUpload.available()) {
       size_t n = fileToUpload.read(buf, CHUNK);
@@ -11043,14 +11113,7 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
       client->write(buf, n);
       pct = (totalSent * 100) / fileToUpload.size();
       #ifdef HAS_SCREEN
-      display_obj.tft.drawRect(0, (TFT_HEIGHT / 3) * 2, TFT_WIDTH, TFT_HEIGHT - (TFT_HEIGHT / 3) * 2, TFT_BLACK);
-      display_obj.tft.setCursor(0, (TFT_HEIGHT / 3) * 2);
-      #endif
-      pctStr = String(pct) + "%";
-      int bar_width = (TFT_WIDTH * pct) / 100;
-      #ifdef HAS_SCREEN
-      display_obj.tft.fillRect(0, (TFT_HEIGHT / 4) * 3, bar_width, 20, TFT_GREEN);
-      //display_obj.showCenterText(pctStr.c_str(), TFT_HEIGHT / 2, true);
+      this->drawUploadProgress("WDG WARS", pct); // GCOVR_EXCL_LINE
       #endif
     }
 
@@ -11061,7 +11124,7 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     Serial.println("[WDG] Bytes sent: " + String(totalSent));
 
     #ifdef HAS_SCREEN
-      display_obj.showCenterText("Waiting for response...", (TFT_HEIGHT / 3) * 2, true);
+      this->drawUploadProgress("WDG WARS", 100, true); // GCOVR_EXCL_LINE
     #endif
 
     // Read response
@@ -11112,8 +11175,7 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     bool gotAny = false;
 
     #ifdef HAS_SCREEN
-    display_obj.clearScreen();
-    display_obj.showCenterText("Wigle Upload...", TFT_HEIGHT / 2, true);
+    this->drawUploadProgress("WiGLE", 0); // GCOVR_EXCL_LINE
     #endif
 
     delay(100);
@@ -11225,8 +11287,6 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
 
     uint8_t percent_sent = 0;
 
-    String display_percent = "";
-
     size_t totalBytesSent = 0;
     while (fileToUpload.available()) {
       size_t bytesRead = fileToUpload.read(buffer, BUFFER_SIZE);
@@ -11235,15 +11295,8 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
       Serial.print(totalBytesSent);
       Serial.println(" bytes...");
       percent_sent = (totalBytesSent * 100) / fileToUpload.size();
-      int bar_width = (TFT_WIDTH * percent_sent) / 100;
       #ifdef HAS_SCREEN
-      display_obj.tft.drawRect(0, (TFT_HEIGHT / 3) * 2, TFT_WIDTH, TFT_HEIGHT, TFT_BLACK);
-      display_obj.tft.setCursor(0, (TFT_HEIGHT / 3) * 2);
-      #endif
-      //display_percent = (String)percent_sent + "%";
-      #ifdef HAS_SCREEN
-      display_obj.tft.fillRect(0, (TFT_HEIGHT / 4) * 3, bar_width, 20, TFT_GREEN);
-      //display_obj.showCenterText(display_percent.c_str(), TFT_HEIGHT / 2, true);
+      this->drawUploadProgress("WiGLE", percent_sent); // GCOVR_EXCL_LINE
       #endif
       client->write(buffer, bytesRead);
     }
@@ -11257,7 +11310,7 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     Serial.println("Finished sending part2 and part3");
 
     #ifdef HAS_SCREEN
-      display_obj.showCenterText("Waiting for response...", (TFT_HEIGHT / 3) * 2, true);
+      this->drawUploadProgress("WiGLE", 100, true); // GCOVR_EXCL_LINE
     #endif
 
     fileToUpload.close();

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1,6 +1,7 @@
 #include "esp_random.h"
 #include "WiFiScan.h"
 #include "BeaconFrame.h"
+#include "WdgResponse.h"
 #include "lang_var.h"
 
 #ifdef HAS_PSRAM
@@ -11157,15 +11158,52 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     // WDG Wars returns 200 on success
     bool ok = response.indexOf("202 Accepted") >= 0 ||
     response.indexOf("\"ok\":true") >= 0;
-    #ifdef HAS_SCREEN
-    display_obj.clearScreen();
-    display_obj.showCenterText(ok ? "WDG OK" : "WDG Failed", TFT_HEIGHT / 2, true);
-    #endif
-
-    if (!ok)
+    if (!ok) {
+      char errorReason[64];
+      if (!extractWdgErrorReason(response.c_str(), errorReason, sizeof(errorReason)))
+        strncpy(errorReason, "Server rejected upload", sizeof(errorReason));
+      errorReason[sizeof(errorReason) - 1] = '\0';
       Serial.println(response);
 
-    delay(1000);
+      #ifdef HAS_SCREEN
+        display_obj.clearScreen();
+        display_obj.tft.setTextSize(1);
+        display_obj.tft.setTextColor(TFT_RED, TFT_BLACK);
+        display_obj.showCenterText("WDG Failed", TFT_HEIGHT / 3, true);
+
+        #ifdef HAS_MINI_SCREEN
+          String displayReason = String(errorReason).substring(0, STANDARD_FONT_CHAR_LIMIT);
+          display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
+          display_obj.showCenterText(displayReason.c_str(), TFT_HEIGHT / 2, true);
+        #else
+          String displayReason = String(errorReason).substring(0, STANDARD_FONT_CHAR_LIMIT * 2);
+          int splitAt = displayReason.length();
+          if (splitAt > STANDARD_FONT_CHAR_LIMIT) {
+            splitAt = STANDARD_FONT_CHAR_LIMIT;
+            while (splitAt > 0 && displayReason.charAt(splitAt) != ' ')
+              splitAt--;
+            if (splitAt == 0)
+              splitAt = STANDARD_FONT_CHAR_LIMIT;
+          }
+          String firstLine = displayReason.substring(0, splitAt);
+          String secondLine = displayReason.substring(splitAt);
+          secondLine.trim();
+          display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
+          display_obj.showCenterText(firstLine.c_str(), TFT_HEIGHT / 2, true);
+          if (!secondLine.isEmpty())
+            display_obj.showCenterText(secondLine.c_str(), TFT_HEIGHT / 2 + TEXT_HEIGHT, true);
+        #endif
+        delay(3000);
+      #else
+        delay(1000);
+      #endif
+    } else {
+      #ifdef HAS_SCREEN
+        display_obj.clearScreen();
+        display_obj.showCenterText("WDG OK", TFT_HEIGHT / 2, true);
+      #endif
+      delay(1000);
+    }
 
     return ok;
   }

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -691,6 +691,9 @@ class WiFiScan
     bool wdgwarsUpload(String filePath);
     void writeSidecar(String filePath, String service);
     bool sidecarExists(String filePath, String service); 
+    #ifdef HAS_SCREEN
+      void drawUploadProgress(const char* service, uint8_t percent, bool waiting = false);
+    #endif
 
     void runFoxHunt(uint32_t currentTime);
     void throwThatShitInACircle();

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ build_src_filter =
   +<Switches.cpp>
   +<DisplayLine.cpp>
   +<BeaconFrame.cpp>
+  +<WdgResponse.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/test_wdg_response/test_main.cpp
+++ b/test/test_wdg_response/test_main.cpp
@@ -1,0 +1,61 @@
+#include <unity.h>
+
+#include "WdgResponse.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_extracts_duplicate_detail_as_short_reason() {
+  char reason[64];
+  TEST_ASSERT_TRUE(extractWdgErrorReason(
+    "HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\n\r\n"
+    "{\"detail\":\"This file is a duplicate upload\"}",
+    reason, sizeof(reason)));
+  TEST_ASSERT_EQUAL_STRING("Duplicate upload", reason);
+}
+
+void test_extracts_message_and_collapses_whitespace() {
+  char reason[64];
+  TEST_ASSERT_TRUE(extractWdgErrorReason(
+    "HTTP/1.1 400 Bad Request\r\n\r\n{\"message\":\"Invalid   CSV\\nformat\"}",
+    reason, sizeof(reason)));
+  TEST_ASSERT_EQUAL_STRING("Invalid CSV format", reason);
+}
+
+void test_supports_error_and_reason_fields() {
+  char reason[64];
+  TEST_ASSERT_TRUE(extractWdgErrorReason("{\"error\":\"Missing GPS data\"}", reason,
+                                        sizeof(reason)));
+  TEST_ASSERT_EQUAL_STRING("Missing GPS data", reason);
+  TEST_ASSERT_TRUE(extractWdgErrorReason("{\"reason\":\"API key rejected\"}", reason,
+                                        sizeof(reason)));
+  TEST_ASSERT_EQUAL_STRING("API key rejected", reason);
+}
+
+void test_falls_back_to_plain_body_or_http_status() {
+  char reason[64];
+  TEST_ASSERT_TRUE(extractWdgErrorReason("HTTP/1.1 422 Unprocessable Entity\r\n\r\nBad CSV",
+                                        reason, sizeof(reason)));
+  TEST_ASSERT_EQUAL_STRING("Bad CSV", reason);
+  TEST_ASSERT_TRUE(extractWdgErrorReason("HTTP/1.1 503 Service Unavailable\r\n\r\n",
+                                        reason, sizeof(reason)));
+  TEST_ASSERT_EQUAL_STRING("503 Service Unavailable", reason);
+}
+
+void test_rejects_empty_responses_and_respects_output_size() {
+  char reason[8];
+  TEST_ASSERT_FALSE(extractWdgErrorReason("", reason, sizeof(reason)));
+  TEST_ASSERT_TRUE(extractWdgErrorReason("{\"detail\":\"Long server reason\"}", reason,
+                                        sizeof(reason)));
+  TEST_ASSERT_EQUAL_STRING("Long se", reason);
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_extracts_duplicate_detail_as_short_reason);
+  RUN_TEST(test_extracts_message_and_collapses_whitespace);
+  RUN_TEST(test_supports_error_and_reason_fields);
+  RUN_TEST(test_falls_back_to_plain_body_or_http_status);
+  RUN_TEST(test_rejects_empty_responses_and_respects_output_size);
+  return UNITY_END();
+}

--- a/tools/test_whole_source_coverage.py
+++ b/tools/test_whole_source_coverage.py
@@ -1,0 +1,24 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from whole_source_coverage import source_lines
+
+
+class SourceLinesTests(unittest.TestCase):
+    def test_honors_gcovr_line_and_block_exclusions(self):
+        source_text = """counted();
+excluded_line(); // GCOVR_EXCL_LINE
+// GCOVR_EXCL_START
+excluded_block();
+// GCOVR_EXCL_STOP
+counted_again();
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "sample.cpp"
+            source.write_text(source_text, encoding="utf-8")
+            self.assertEqual(source_lines(source), [1, 6])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/whole_source_coverage.py
+++ b/tools/whole_source_coverage.py
@@ -24,8 +24,19 @@ def source_lines(path: Path) -> list[int]:
     baseline instead of being silently omitted.
     """
 
+    included_lines: list[int] = []
+    excluded = False
     with path.open(encoding="utf-8") as source:
-        return [number for number, line in enumerate(source, start=1) if line.strip()]
+        for number, line in enumerate(source, start=1):
+            if "GCOVR_EXCL_START" in line:
+                excluded = True
+                continue
+            if "GCOVR_EXCL_STOP" in line:
+                excluded = False
+                continue
+            if line.strip() and not excluded and "GCOVR_EXCL_LINE" not in line:
+                included_lines.append(number)
+    return included_lines
 
 
 def rate(covered: int, valid: int) -> str:


### PR DESCRIPTION
- Add a shared upload progress display for WDG Wars and WiGLE
- Use a compact layout on mini screens and an enhanced status card on larger displays
- Parse WDG failure responses from detail, message, error, or reason fields
- Show a short WDG failure reason for three seconds, including Duplicate upload
- Fall back to a plain response body, HTTP status, or a generic rejection message
- Keep every display path behind HAS_SCREEN so headless targets remain serial-only
- Preserve upload, response, retry, and sidecar behavior

Verification: 31 native firmware tests pass, including five WDG response-parser cases