### PR TITLE
Bump firmware version to v1.14.2

### DIFF
--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -41,7 +41,7 @@
 
   #define JSON_SETTING_SIZE 2048
 
-  #define MARAUDER_VERSION "v1.14.1"
+#define MARAUDER_VERSION "v1.14.2"
 
   #define GRAPH_REFRESH   100
 


### PR DESCRIPTION
## Summary
- update `MARAUDER_VERSION` from `v1.14.1` to `v1.14.2`
- leave release publication and tagging unchanged

## Verification
- 31 native firmware tests passed
- 7 installer-manifest tests passed
- 25 installer targets validated