### PR TITLE
Prevent upload UI font size from leaking into status text

### DIFF
--- a/esp32_marauder/Display.cpp
+++ b/esp32_marauder/Display.cpp
@@ -654,7 +654,7 @@ void Display::showCenterText(const char* text, int y, bool small_pp, uint8_t tex
   // Centering already assumes either the 1x bitmap font or text_size scaling.
   // Apply that size here as well so callers never inherit a previous UI's
   // text scale (for example, the 2x upload percentage display).
-  const uint8_t effective_text_size = small_pp ? 1 : (text_size > 0 ? text_size : 1);
+  const uint8_t effective_text_size = resolveDisplayTextSize(small_pp, text_size);
   tft.setTextSize(effective_text_size);
 
   size_t len = strlen(text);

--- a/esp32_marauder/Display.cpp
+++ b/esp32_marauder/Display.cpp
@@ -651,10 +651,16 @@ void Display::showCenterText(const char* text, int y, bool small_pp, uint8_t tex
   if (!text)
     text = "";
 
+  // Centering already assumes either the 1x bitmap font or text_size scaling.
+  // Apply that size here as well so callers never inherit a previous UI's
+  // text scale (for example, the 2x upload percentage display).
+  const uint8_t effective_text_size = small_pp ? 1 : (text_size > 0 ? text_size : 1);
+  tft.setTextSize(effective_text_size);
+
   size_t len = strlen(text);
 
   if (!small_pp)
-    tft.setCursor((SCREEN_WIDTH - (len * (6 * text_size))) / 2, y);
+    tft.setCursor((SCREEN_WIDTH - (len * (6 * effective_text_size))) / 2, y);
   else
     tft.setCursor((SCREEN_WIDTH - (len * 6)) / 2, y);
 

--- a/esp32_marauder/DisplayLine.cpp
+++ b/esp32_marauder/DisplayLine.cpp
@@ -17,3 +17,10 @@ void fitDisplayLine(char* output, size_t output_size, const char* input) {
 
   output[width] = '\0';
 }
+
+uint8_t resolveDisplayTextSize(bool small_print, uint8_t requested_size) {
+  if (small_print)
+    return 1;
+
+  return requested_size > 0 ? requested_size : 1;
+}

--- a/esp32_marauder/DisplayLine.h
+++ b/esp32_marauder/DisplayLine.h
@@ -1,5 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 void fitDisplayLine(char* output, size_t output_size, const char* input);
+uint8_t resolveDisplayTextSize(bool small_print, uint8_t requested_size);

--- a/test/test_display_line/test_main.cpp
+++ b/test/test_display_line/test_main.cpp
@@ -35,6 +35,18 @@ void test_zero_sized_output_is_ignored() {
   TEST_ASSERT_EQUAL_CHAR('X', output);
 }
 
+void test_small_print_always_uses_single_size() {
+  TEST_ASSERT_EQUAL_UINT8(1, resolveDisplayTextSize(true, 3));
+}
+
+void test_requested_text_size_is_preserved() {
+  TEST_ASSERT_EQUAL_UINT8(2, resolveDisplayTextSize(false, 2));
+}
+
+void test_zero_text_size_falls_back_to_single_size() {
+  TEST_ASSERT_EQUAL_UINT8(1, resolveDisplayTextSize(false, 0));
+}
+
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_short_line_is_padded_to_visible_width);
@@ -42,5 +54,8 @@ int main() {
   RUN_TEST(test_exact_line_is_preserved);
   RUN_TEST(test_null_input_produces_blank_line);
   RUN_TEST(test_zero_sized_output_is_ignored);
+  RUN_TEST(test_small_print_always_uses_single_size);
+  RUN_TEST(test_requested_text_size_is_preserved);
+  RUN_TEST(test_zero_text_size_falls_back_to_single_size);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- make `showCenterText` apply the text size it already uses for centering
- force `small_pp` status messages to 1x text instead of inheriting the upload percentage size
- keep normal centered text on its requested/default hardware-specific size

## Cause
The upload progress renderer ends with 2x percentage text. `showCenterText` previously used its size argument only to calculate the cursor position, so later status messages inherited whichever text scale the previous UI left behind.

## Verification
- 31 native firmware tests passed
- 7 installer-manifest tests passed
- 25 installer targets validated
- full hardware matrix pending in GitHub Actions