### PR TITLE
Fix release asset pagination for installer manifests

### DIFF
--- a/.github/workflows/build_installer_manifests.yml
+++ b/.github/workflows/build_installer_manifests.yml
@@ -302,7 +302,9 @@ jobs:
         run: |
           mkdir -p private-targets
           for attempt in $(seq 1 90); do
-            ASSETS=$(gh api "repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets" --jq '.[].name')
+            ASSETS=$(gh api "repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets" \
+              --paginate \
+              --jq '.[].name')
             if grep -Fxq 'marauder-v8.installer.json' <<< "$ASSETS" && \
                grep -Fxq 'marauder-mini-v3.installer.json' <<< "$ASSETS" && \
                grep -Fxq 'dual-mini-c5.installer.json' <<< "$ASSETS"; then

--- a/tools/installer_manifest.py
+++ b/tools/installer_manifest.py
@@ -396,6 +396,16 @@ def combine_manifests(registry_path: Path, input_dir: Path, output_path: Path) -
             f"Release target coverage mismatch; missing={missing}, extra={extra}."
         )
 
+    registry_by_id = {target["id"]: target for target in registry["targets"]}
+    for manifest in manifests:
+        target = manifest.get("target", {})
+        target_id = target.get("id")
+        identity = {key: target.get(key) for key in REQUIRED_TARGET_KEYS}
+        if identity != registry_by_id[target_id]:
+            raise ManifestError(
+                f"Release target identity does not match registry for {target_id}."
+            )
+
     versions = {manifest.get("version") for manifest in manifests}
     commits = {manifest.get("sourceCommit") for manifest in manifests}
     channels = {manifest.get("channel") for manifest in manifests}

--- a/tools/test_installer_manifest.py
+++ b/tools/test_installer_manifest.py
@@ -190,6 +190,31 @@ class InstallerManifestTests(unittest.TestCase):
             self.assertEqual(len(release["targets"]), 25)
             self.assertIn("/" + "a" * 40 + "/", release["$schema"])
 
+    def test_combiner_rejects_target_identity_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            build = self.make_fake_build(root)
+            output = root / "output"
+            registry = load_registry(REGISTRY)
+            for target in registry["targets"]:
+                generate_target_manifest(
+                    REGISTRY,
+                    target["buildFlag"],
+                    build,
+                    "v1.2.3",
+                    "20260731",
+                    "a" * 40,
+                    output,
+                )
+
+            drifted = output / "marauder-v8.installer.json"
+            manifest = json.loads(drifted.read_text(encoding="utf-8"))
+            manifest["target"]["aliases"] = ["v8"]
+            drifted.write_text(json.dumps(manifest), encoding="utf-8")
+
+            with self.assertRaisesRegex(ManifestError, "identity does not match registry"):
+                combine_manifests(REGISTRY, output, output / "firmware-manifest.json")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- paginate release asset discovery while waiting for private C5 installer fragments
- prevent releases with more than 30 assets from timing out before manifest combination

## Verification
- `python3 -m unittest tools/test_installer_manifest.py -v`
- `git diff --check`

This repairs the publish-triggered installer bundle path that failed for v1.14.2.