### PR TITLE
Bump firmware version to v1.14.3

### DIFF
--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -41,7 +41,7 @@
 
   #define JSON_SETTING_SIZE 2048
 
-#define MARAUDER_VERSION "v1.14.2"
+#define MARAUDER_VERSION "v1.14.3"
 
   #define GRAPH_REFRESH   100
 


### PR DESCRIPTION
## Summary
- bump `MARAUDER_VERSION` from `v1.14.2` to `v1.14.3`
- prepare the validated large-display scan-text fix for release

## Verification
- installer manifest unit tests: 8 passed
- `git diff --check`: passed
- full hardware matrix and native firmware tests will run in CI