### PR TITLE
Release v1.14.3

### DIFF
--- a/esp32_marauder/Display.cpp
+++ b/esp32_marauder/Display.cpp
@@ -578,8 +578,10 @@ void Display::processAndPrintString(TFT_eSPI& tft, const String& originalString)
     }
   }
 
-  int count = TFT_WIDTH / CHAR_WIDTH;
-  char line[(TFT_WIDTH / CHAR_WIDTH) + 1];
+  // Scan output uses the built-in 6-pixel font. CHAR_WIDTH describes larger
+  // menu/layout cells on full-size displays, so using it here cut their line
+  // capacity in half and truncated values such as MAC addresses.
+  char line[STANDARD_FONT_CHAR_LIMIT + 1];
   fitDisplayLine(line, sizeof(line), new_string.c_str()); // GCOVR_EXCL_LINE
 
   // Set text color and print the string

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -41,7 +41,7 @@
 
   #define JSON_SETTING_SIZE 2048
 
-#define MARAUDER_VERSION "v1.14.2"
+#define MARAUDER_VERSION "v1.14.3"
 
   #define GRAPH_REFRESH   100
 

--- a/test/test_display_line/test_main.cpp
+++ b/test/test_display_line/test_main.cpp
@@ -23,6 +23,12 @@ void test_exact_line_is_preserved() {
   TEST_ASSERT_EQUAL_STRING("123456", output);
 }
 
+void test_large_display_scan_line_preserves_full_mac_address() {
+  char output[41];
+  fitDisplayLine(output, sizeof(output), "AP AA:BB:CC:DD:EE:FF ch 11");
+  TEST_ASSERT_EQUAL_STRING("AP AA:BB:CC:DD:EE:FF ch 11              ", output);
+}
+
 void test_null_input_produces_blank_line() {
   char output[5];
   fitDisplayLine(output, sizeof(output), nullptr);
@@ -52,6 +58,7 @@ int main() {
   RUN_TEST(test_short_line_is_padded_to_visible_width);
   RUN_TEST(test_long_line_is_clipped_to_visible_width);
   RUN_TEST(test_exact_line_is_preserved);
+  RUN_TEST(test_large_display_scan_line_preserves_full_mac_address);
   RUN_TEST(test_null_input_produces_blank_line);
   RUN_TEST(test_zero_sized_output_is_ignored);
   RUN_TEST(test_small_print_always_uses_single_size);


### PR DESCRIPTION
## Release summary
- fix large-display scan text clipping so full MAC addresses remain visible
- add regression coverage for full MAC scan lines on large displays
- bump firmware version to `v1.14.3`

## Included work
- #1471
- #1472

## Verification
- 22-target hardware build matrix passed
- native Unity tests passed
- Codecov project and patch checks passed
- installer manifest unit tests passed