### PR TITLE
Integrate Flock probe fingerprint without replacing wardrive scans

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -251,6 +251,7 @@ void CommandLine::runCommand(String input) {
     Serial.println(HELP_SNIFF_RAW_CMD);
     Serial.println(HELP_SNIFF_BEACON_CMD);
     Serial.println(HELP_SNIFF_PROBE_CMD);
+    Serial.println(HELP_SNIFF_FLOCK_CMD);
     Serial.println(HELP_SNIFF_PWN_CMD);
     Serial.println(HELP_SNIFF_PINESCAN_CMD);
     Serial.println(HELP_SNIFF_MULTISSID_CMD);
@@ -787,6 +788,9 @@ void CommandLine::runCommand(String input) {
     else if (cmd_args.get(0) == SNIFF_PROBE_CMD) {
       this->startScanFromCLI(WIFI_SCAN_PROBE, TFT_MAGENTA, "Probe sniff");
     }
+    else if (cmd_args.get(0) == SNIFF_FLOCK_CMD) {
+      this->startScanFromCLI(WIFI_SCAN_FLOCK, TFT_ORANGE, "Flock sniff");
+    }
     // Deauth sniff
     else if (cmd_args.get(0) == SNIFF_DEAUTH_CMD) {
       this->startScanFromCLI(WIFI_SCAN_DEAUTH, TFT_RED, "Deauth sniff");
@@ -1108,9 +1112,6 @@ void CommandLine::runCommand(String input) {
           }
           else if (bt_type == "flipper") {
             this->startScanFromCLI(BT_SCAN_FLIPPER, TFT_ORANGE, "Flipper sniff");
-          }
-          else if (bt_type == "flock") {
-            this->startScanFromCLI(BT_SCAN_FLOCK, TFT_ORANGE, "Flock sniff");
           }
           else if (bt_type == "meta") {
             this->startScanFromCLI(BT_SCAN_RAYBAN, TFT_ORANGE, "Meta sniff");

--- a/esp32_marauder/CommandLine.h
+++ b/esp32_marauder/CommandLine.h
@@ -72,6 +72,7 @@ const char PROGMEM SCAN_ALL_CMD[] = "scanall";
 const char PROGMEM SNIFF_RAW_CMD[] = "sniffraw";
 const char PROGMEM SNIFF_BEACON_CMD[] = "sniffbeacon";
 const char PROGMEM SNIFF_PROBE_CMD[] = "sniffprobe";
+const char PROGMEM SNIFF_FLOCK_CMD[] = "sniffflock";
 const char PROGMEM SNIFF_PWN_CMD[] = "sniffpwn";
 const char PROGMEM SNIFF_PINESCAN_CMD[] = "sniffpinescan";
 const char PROGMEM SNIFF_MULTISSID_CMD[] = "sniffmultissid";
@@ -150,6 +151,7 @@ const char PROGMEM HELP_SCAN_ALL_CMD[] = "scanall";
 const char PROGMEM HELP_SNIFF_RAW_CMD[] = "sniffraw";
 const char PROGMEM HELP_SNIFF_BEACON_CMD[] = "sniffbeacon";
 const char PROGMEM HELP_SNIFF_PROBE_CMD[] = "sniffprobe";
+const char PROGMEM HELP_SNIFF_FLOCK_CMD[] = "sniffflock";
 const char PROGMEM HELP_SNIFF_PWN_CMD[] = "sniffpwn";
 const char PROGMEM HELP_SNIFF_PINESCAN_CMD[] = "sniffpinescan";
 const char PROGMEM HELP_SNIFF_MULTISSID_CMD[] = "sniffmultissid";
@@ -193,7 +195,7 @@ const char PROGMEM HELP_ADD_CMD_B[] = "add -c -b <mac> -ap <ap_index>";
 const char PROGMEM HELP_UPLOAD_CMD[] = "upload -d <wdg/wigle/both>";
 
 // Bluetooth sniff/scan
-const char PROGMEM HELP_BT_SNIFF_CMD[] = "sniffbt [-t] <airtag/flipper/flock/meta>";
+const char PROGMEM HELP_BT_SNIFF_CMD[] = "sniffbt [-t] <airtag/flipper/meta>";
 const char PROGMEM HELP_BT_FINDMY_CMD[] = "findmy -t <index>";
 const char PROGMEM HELP_BT_SPAM_CMD[] = "blespam -t <sourapple/applejuice/google/samsung/windows/flipper/all>";
 const char PROGMEM HELP_BT_SPOOFAT_CMD[] = "spoofat -t <index>";

--- a/esp32_marauder/FlockDetector.cpp
+++ b/esp32_marauder/FlockDetector.cpp
@@ -1,0 +1,82 @@
+#include "FlockDetector.h"
+
+#include <string.h>
+
+namespace {
+constexpr size_t kProbeHeaderLength = 24;
+constexpr uint8_t kSsidTag = 0;
+constexpr uint8_t kVendorTag = 221;
+constexpr uint8_t kHtCapabilitiesTag = 45;
+constexpr uint8_t kVhtCapabilitiesTag = 191;
+constexpr uint8_t kLiteOnFingerprint[] = {0x50, 0x6f, 0x9a, 0x16, 0x03, 0x01, 0x03};
+constexpr uint8_t kWpaFingerprint[] = {0x00, 0x50, 0xf2, 0x08, 0x00, 0x00, 0x00};
+
+bool tlvFits(size_t offset, size_t value_len, size_t body_len) {
+  return offset <= body_len && value_len <= body_len - offset && 2 <= body_len - offset - value_len;
+}
+
+bool vendorMatches(const uint8_t* body, size_t body_len, size_t offset,
+                   const uint8_t* fingerprint, size_t fingerprint_len) {
+  return offset + 2 <= body_len && body[offset] == kVendorTag &&
+         body[offset + 1] == fingerprint_len &&
+         tlvFits(offset, fingerprint_len, body_len) &&
+         memcmp(body + offset + 2, fingerprint, fingerprint_len) == 0;
+}
+
+bool exactSuffixMatches(const uint8_t* body, size_t body_len, size_t offset) {
+  if (!vendorMatches(body, body_len, offset, kLiteOnFingerprint, sizeof(kLiteOnFingerprint)))
+    return false;
+  offset += 2 + sizeof(kLiteOnFingerprint);
+
+  const uint8_t tags[] = {kHtCapabilitiesTag, kVhtCapabilitiesTag};
+  for (uint8_t tag : tags) {
+    if (offset + 2 > body_len || body[offset] != tag)
+      return false;
+    size_t value_len = body[offset + 1];
+    if (!tlvFits(offset, value_len, body_len))
+      return false;
+    offset += 2 + value_len;
+  }
+
+  if (!vendorMatches(body, body_len, offset, kWpaFingerprint, sizeof(kWpaFingerprint)))
+    return false;
+  return offset + 2 + sizeof(kWpaFingerprint) == body_len;
+}
+
+bool primaryBodyMatches(const uint8_t* body, size_t body_len) {
+  if (body_len < 2 || body[0] != kSsidTag || body[1] != 0)
+    return false;
+
+  size_t offset = 2;
+  while (offset + 2 <= body_len && body[offset] == kSsidTag && body[offset + 1] == 0)
+    offset += 2;
+
+  while (offset + 2 <= body_len) {
+    size_t value_len = body[offset + 1];
+    if (!tlvFits(offset, value_len, body_len))
+      return false;
+    if (exactSuffixMatches(body, body_len, offset))
+      return true;
+    offset += 2 + value_len;
+  }
+  return false;
+}
+}  // namespace
+
+bool flockProbeBodyMatches(const uint8_t* body, size_t body_len) {
+  if (body == nullptr)
+    return false;
+  if (primaryBodyMatches(body, body_len))
+    return true;
+  return body_len > 4 && primaryBodyMatches(body, body_len - 4);
+}
+
+bool flockProbeRequestMatches(const uint8_t* frame, size_t frame_len) {
+  if (frame == nullptr || frame_len < kProbeHeaderLength + 2)
+    return false;
+  uint16_t frame_control = (uint16_t)frame[0] | ((uint16_t)frame[1] << 8);
+  if ((frame_control & 0x000c) != 0 || (frame_control & 0x00f0) != 0x0040)
+    return false;
+  return flockProbeBodyMatches(frame + kProbeHeaderLength, frame_len - kProbeHeaderLength);
+}
+

--- a/esp32_marauder/FlockDetector.h
+++ b/esp32_marauder/FlockDetector.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+bool flockProbeBodyMatches(const uint8_t* body, size_t body_len);
+bool flockProbeRequestMatches(const uint8_t* frame, size_t frame_len);
+

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -454,7 +454,7 @@ void MenuFunctions::main(uint32_t currentTime)
             (wifi_scan_obj.currentScanMode == BT_SCAN_AIRTAG) ||
             (wifi_scan_obj.currentScanMode == BT_SCAN_AIRTAG_MON) ||
             (wifi_scan_obj.currentScanMode == BT_SCAN_FLIPPER) ||
-            (wifi_scan_obj.currentScanMode == BT_SCAN_FLOCK) ||
+            (wifi_scan_obj.currentScanMode == WIFI_SCAN_FLOCK) ||
             (wifi_scan_obj.currentScanMode == BT_SCAN_SIMPLE) ||
             (wifi_scan_obj.currentScanMode == BT_SCAN_SIMPLE_TWO) ||
             (wifi_scan_obj.currentScanMode == BT_ATTACK_SOUR_APPLE) ||
@@ -526,7 +526,7 @@ void MenuFunctions::main(uint32_t currentTime)
         (wifi_scan_obj.currentScanMode != WIFI_SCAN_CHAN_ACT) &&
         (wifi_scan_obj.currentScanMode != WIFI_SCAN_SIG_STREN) &&
         (wifi_scan_obj.currentScanMode != WIFI_SCAN_AP) &&
-        (wifi_scan_obj.currentScanMode != BT_SCAN_FLOCK) &&
+        (wifi_scan_obj.currentScanMode != WIFI_SCAN_FLOCK) &&
         (wifi_scan_obj.currentScanMode != WIFI_SCAN_PROBE) &&
         (wifi_scan_obj.currentScanMode != WIFI_SCAN_DEAUTH) &&
 		    (wifi_scan_obj.currentScanMode != WIFI_ATTACK_FUNNY_BEACON) &&
@@ -579,7 +579,7 @@ void MenuFunctions::main(uint32_t currentTime)
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_PACKET_RATE) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_RAW_CAPTURE) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_AP) ||
-                  (wifi_scan_obj.currentScanMode == BT_SCAN_FLOCK) ||
+                  (wifi_scan_obj.currentScanMode == WIFI_SCAN_FLOCK) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_PROBE) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_DEAUTH) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_SIG_STREN)) {
@@ -648,7 +648,7 @@ void MenuFunctions::main(uint32_t currentTime)
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_PACKET_RATE) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_RAW_CAPTURE) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_AP) ||
-                  (wifi_scan_obj.currentScanMode == BT_SCAN_FLOCK) ||
+                  (wifi_scan_obj.currentScanMode == WIFI_SCAN_FLOCK) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_PROBE) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_DEAUTH) ||
                   (wifi_scan_obj.currentScanMode == WIFI_SCAN_SIG_STREN)) {
@@ -736,7 +736,7 @@ void MenuFunctions::main(uint32_t currentTime)
                       (wifi_scan_obj.currentScanMode == WIFI_SCAN_PACKET_RATE) ||
                       (wifi_scan_obj.currentScanMode == WIFI_SCAN_RAW_CAPTURE) ||
                       (wifi_scan_obj.currentScanMode == WIFI_SCAN_AP) ||
-                      (wifi_scan_obj.currentScanMode == BT_SCAN_FLOCK) ||
+                      (wifi_scan_obj.currentScanMode == WIFI_SCAN_FLOCK) ||
                       (wifi_scan_obj.currentScanMode == WIFI_SCAN_PROBE) ||
                       (wifi_scan_obj.currentScanMode == WIFI_SCAN_DEAUTH) ||
                       (wifi_scan_obj.currentScanMode == WIFI_SCAN_SIG_STREN)) {
@@ -813,7 +813,7 @@ void MenuFunctions::main(uint32_t currentTime)
                 (wifi_scan_obj.currentScanMode == WIFI_SCAN_PACKET_RATE) ||
                 (wifi_scan_obj.currentScanMode == WIFI_SCAN_RAW_CAPTURE) ||
                 (wifi_scan_obj.currentScanMode == WIFI_SCAN_AP) ||
-                (wifi_scan_obj.currentScanMode == BT_SCAN_FLOCK) ||
+                (wifi_scan_obj.currentScanMode == WIFI_SCAN_FLOCK) ||
                 (wifi_scan_obj.currentScanMode == WIFI_SCAN_PROBE) ||
                 (wifi_scan_obj.currentScanMode == WIFI_SCAN_DEAUTH) ||
                 (wifi_scan_obj.currentScanMode == WIFI_SCAN_SIG_STREN)) {
@@ -1991,6 +1991,11 @@ void MenuFunctions::RunSetup()
     display_obj.clearScreen();
     this->drawStatusBar();
     wifi_scan_obj.StartScan(WIFI_SCAN_PROBE, TFT_CYAN);
+  });
+  this->addNodes(&wifiSnifferMenu, "Flock Sniff", TFTORANGE, FLOCK, [this]() {
+    display_obj.clearScreen();
+    this->drawStatusBar();
+    wifi_scan_obj.StartScan(WIFI_SCAN_FLOCK, TFT_ORANGE);
   });
   this->addNodes(&wifiSnifferMenu, text_table1[43], TFTMAGENTA, BEACON_SNIFF, [this]() {
     display_obj.clearScreen();
@@ -3213,11 +3218,6 @@ void MenuFunctions::RunSetup()
     this->drawStatusBar();
     this->renderGraphUI(BT_SCAN_ANALYZER);
     wifi_scan_obj.StartScan(BT_SCAN_ANALYZER, TFT_CYAN);
-  });
-  this->addNodes(&bluetoothSnifferMenu, "Flock Sniff", TFTORANGE, FLOCK, [this]() {
-    display_obj.clearScreen();
-    this->drawStatusBar();
-    wifi_scan_obj.StartScan(BT_SCAN_FLOCK, TFT_ORANGE);
   });
   this->addNodes(&bluetoothSnifferMenu, "Meta Detect", TFTWHITE, BLUETOOTH_SNIFF, [this]() {
     display_obj.clearScreen();

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1,6 +1,7 @@
 #include "esp_random.h"
 #include "WiFiScan.h"
 #include "FoxHuntTarget.h"
+#include "FlockDetector.h"
 #include "BeaconFrame.h"
 #include "WdgResponse.h"
 #include "lang_var.h"
@@ -664,22 +665,6 @@ extern "C" {
 
                   wifi_scan_obj.bt_frames++;
 
-                  #ifndef HAS_NIMBLE_2
-                    uint8_t* payLoad = advertisedDevice->getPayload();
-                    size_t len = advertisedDevice->getPayloadLength();
-                  #else
-                    const std::vector<unsigned char>& payloadVec = advertisedDevice->getPayload();
-                    const uint8_t* payLoad = payloadVec.data();
-                    size_t len = payloadVec.size();
-                  #endif
-
-                  String name = advertisedDevice->getName().c_str();
-
-                  String serial;
-
-                  // Final decision on marking as Flock Penguin battery
-                  if ((wifi_scan_obj.isFlockCamera(payLoad, len, name, &serial)) || (wifi_scan_obj.checkFlockOUI(mac_char)))
-                    wifi_scan_obj.flock_devices++;
                 }
               }
             #endif
@@ -702,170 +687,6 @@ extern "C" {
               wifi_scan_obj.analyzer_frames_recvd = 0;
               wifi_scan_obj.analyzer_name_string = display_string;
               wifi_scan_obj.analyzer_name_update = true;
-            }
-          }
-          else if (wifi_scan_obj.currentScanMode == BT_SCAN_FLOCK) {
-            #ifndef HAS_NIMBLE_2
-              uint8_t* payLoad = advertisedDevice->getPayload();
-              size_t len = advertisedDevice->getPayloadLength();
-            #else
-              const std::vector<unsigned char>& payLoad = advertisedDevice->getPayload();
-              size_t len = payLoad.size();
-            #endif
-
-            bool hasXuntongMfg = false;
-            size_t mfgIndex = 0;  // index of 0xFF (AD type)
-
-            // Look for Company ID XUNTONG (0x09C8),
-            for (size_t i = 1; i + 3 < len; i++) {
-              if (payLoad[i] == 0xFF &&      // AD type: Manufacturer Specific
-                  payLoad[i + 1] == 0xC8 &&
-                  payLoad[i + 2] == 0x09) {
-                hasXuntongMfg = true;
-                mfgIndex = i;
-                break;
-              }
-            }
-
-            String name = advertisedDevice->getName().c_str();
-
-            // Check for old penguin name
-            bool penguin = false;
-
-            if (name.length() > 0) {
-              // Old firmware: "Penguin-XXXXXXXXXX"
-              if (name.startsWith("Penguin-") && name.length() == 18) {
-                bool allDigits = true;
-                for (int i = 8; i < name.length(); i++) {
-                  char c = name.charAt(i);
-                  if (c < '0' || c > '9') {
-                    allDigits = false;
-                    break;
-                  }
-                }
-                if (allDigits) {
-                  penguin = true;
-                }
-              }
-
-              // Legacy name: "FS Ext Battery"
-              if (name == "FS Ext Battery") {
-                penguin = true;
-              }
-
-              // New firmware: "NNNNNNNNNN" (10 digits)
-              if (name.length() == 10) {
-                bool allDigits = true;
-                for (int i = 0; i < name.length(); i++) {
-                  char c = name.charAt(i);
-                  if (c < '0' || c > '9') {
-                    allDigits = false;
-                    break;
-                  }
-                }
-                if (allDigits) {
-                  penguin = true;
-                }
-              }
-            }
-
-            // Try to extract serial number from the XUNTONG manufacturer data
-            String serial = "";
-
-            if (hasXuntongMfg && mfgIndex > 0) {
-              uint8_t adLen = payLoad[mfgIndex - 1];         // length byte for this AD structure
-              size_t adStart = mfgIndex - 1;
-              size_t adEnd = adStart + adLen;                // exclusive end index
-
-              if (adEnd > len) {
-                adEnd = len;
-              }
-
-              size_t vendorStart = mfgIndex + 3;
-              if (vendorStart < adEnd) {
-                bool started = false;
-
-                for (size_t k = vendorStart; k < adEnd; k++) {
-                  char c = (char)payLoad[k];
-
-                  if (!started) {
-                    if (c == 'T' && (k + 1) < adEnd && (char)payLoad[k + 1] == 'N') {
-                      started = true;
-                      serial += 'T';
-                      serial += 'N';
-                      k++;
-                    }
-                  } else {
-                    // Once started, append digits (skip separators; stop on anything else)
-                    if (c >= '0' && c <= '9') {
-                      serial += c;
-                    } else if (c == ' ' || c == '#' || c == '-') {
-                      continue;
-                    } else {
-                      break;
-                    }
-                  }
-                }
-              }
-            }
-
-            // Final decision on marking as Flock Penguin battery
-            if ((hasXuntongMfg && (penguin || name.length() == 0)) || (wifi_scan_obj.checkFlockOUI(mac_char))) {
-              String mac = advertisedDevice->getAddress().toString().c_str();
-              mac.toUpperCase();
-              int rssi = advertisedDevice->getRSSI();
-
-              Serial.println(rssi);
-              Serial.print(F(" "));
-              Serial.println(mac);
-              Serial.print(F("  Name: "));
-              Serial.println(name);
-              Serial.print(F("  Serial: "));
-              Serial.println(serial.length() ? serial : "N/A");
-
-              //Serial.print(F("  Payload: "));
-              //for (size_t i = 0; i < len; i++) {
-              //  Serial.printf("%02X ", payLoad[i]);
-              //}
-              //Serial.println();
-              //Serial.println();
-
-              #ifdef HAS_SCREEN
-                String display_string = "";
-                display_string.concat(CYAN_KEY);
-                display_string.concat(String(rssi));
-                display_string.concat(" ");
-                if (serial.length()) {
-                  display_string.concat(serial);
-                  display_string.concat(" ");
-                }
-
-                if (name.length() == 0) {
-                  display_string.concat(" MAC:");
-                  display_string.concat(mac);
-                }
-                else {
-                  display_string.concat(" ");
-                  display_string.concat(name);
-                }
-
-                uint8_t temp_len = display_string.length();
-                for (uint8_t i = 0; i < 40 - temp_len; i++) {
-                  display_string.concat(" ");
-                }
-
-                if (!display_obj.printing) {
-                  display_obj.loading = true;
-                  display_obj.display_buffer->add(display_string);
-                  display_obj.loading = false;
-                }
-              #endif
-
-              wifi_scan_obj.flock_devices++;
-
-              // To-do:
-              // track in a list like AirTag / Flipper, if you want
-              // (struct FlockBattery { String mac; String name; String serial; int rssi; uint32_t last_seen; }; etc.)
             }
           }
           else if (wifi_scan_obj.currentScanMode == BT_SCAN_SIMPLE) {
@@ -1408,22 +1229,6 @@ extern "C" {
                     
                   wifi_scan_obj.save_mac(mac_char);
 
-                  #ifndef HAS_NIMBLE_2
-                    uint8_t* payLoad = advertisedDevice->getPayload();
-                    size_t len = advertisedDevice->getPayloadLength();
-                  #else
-                    const std::vector<unsigned char>& payloadVec = advertisedDevice->getPayload();
-                    const uint8_t* payLoad = payloadVec.data();
-                    size_t len = payloadVec.size();
-                  #endif
-
-                  String serial;
-
-                  // Final decision on marking as Flock Penguin battery
-                  if ((wifi_scan_obj.isFlockCamera(payLoad, len, name, &serial)) || (wifi_scan_obj.checkFlockOUI(mac_char))) {
-                    wifi_scan_obj.flock_devices++;
-                  }
-
                   wifi_scan_obj.bt_frames++;
                 }
               }
@@ -1447,61 +1252,6 @@ extern "C" {
               wifi_scan_obj.analyzer_frames_recvd = 0;
               wifi_scan_obj.analyzer_name_string = display_string;
               wifi_scan_obj.analyzer_name_update = true;
-            }
-          }
-          else if (wifi_scan_obj.currentScanMode == BT_SCAN_FLOCK) {
-            #ifndef HAS_NIMBLE_2
-              uint8_t* payLoad = advertisedDevice->getPayload();
-              size_t len = advertisedDevice->getPayloadLength();
-            #else
-              const std::vector<unsigned char>& payloadVec = advertisedDevice->getPayload();
-              const uint8_t* payLoad = payloadVec.data();
-              size_t len = payloadVec.size();
-            #endif
-
-            String serial;
-
-            // Final decision on marking as Flock Penguin battery
-            if ((wifi_scan_obj.isFlockCamera(payLoad, len, name, &serial)) || (wifi_scan_obj.checkFlockOUI(mac_char))) {
-              mac.toUpperCase();
-
-              Serial.print((String)rssi + " " + mac + "\n Name: " + name + "\n Serial: ");
-              Serial.println(serial.length() ? serial : "N/A");
-
-              #ifdef HAS_SCREEN
-                String display_string = "";
-                display_string.concat(CYAN_KEY);
-                display_string.concat(String(rssi));
-                display_string.concat(" ");
-                if (serial.length()) {
-                  display_string.concat(serial);
-                  display_string.concat(" ");
-                }
-
-                if (name.length() == 0) {
-                  display_string.concat(" MAC:");
-                  display_string.concat(mac);
-                }
-                else {
-                  display_string.concat(" ");
-                  display_string.concat(name);
-                }
-
-                uint8_t temp_len = display_string.length();
-                for (uint8_t i = 0; i < 40 - temp_len; i++) {
-                  display_string.concat(" ");
-                }
-
-                if (!display_obj.printing) {
-                  display_obj.loading = true;
-                  display_obj.display_buffer->add(display_string);
-                  display_obj.loading = false;
-                }
-              #endif
-
-              // To-do:
-              // track in a list like AirTag / Flipper, if you want
-              // (struct FlockBattery { String mac; String name; String serial; int rssi; uint32_t last_seen; }; etc.)
             }
           }
           else if (wifi_scan_obj.currentScanMode == BT_SCAN_SKIMMERS) {
@@ -1669,119 +1419,6 @@ int WiFiScan::seenBLEDevice(BleDevice ble_device) {
     }
   }
   return -1;
-}
-
-bool WiFiScan::isFlockCamera(const uint8_t* payload, size_t len, const String& name, String* serial_out) {
-  if (payload == nullptr || len < 4) {
-    return false;
-  }
-
-  bool hasXuntongMfg = false;
-  size_t mfgIndex = 0;
-
-  // Find XUNTONG manufacturer data (0xFF, 0xC8, 0x09)
-  for (size_t i = 1; i + 2 < len; i++) {
-    if (payload[i] == 0xFF &&
-        payload[i + 1] == 0xC8 &&
-        payload[i + 2] == 0x09) {
-      hasXuntongMfg = true;
-      mfgIndex = i;
-      break;
-    }
-  }
-
-  if (!hasXuntongMfg) {
-    return false;
-  }
-
-  // --- Penguin name detection ---
-  bool penguin = false;
-
-  if (name.length() > 0) {
-
-    // "Penguin-XXXXXXXXXX"
-    if (name.startsWith("Penguin-") && name.length() == 18) {
-      bool allDigits = true;
-      for (int i = 8; i < name.length(); i++) {
-        char c = name.charAt(i);
-        if (c < '0' || c > '9') {
-          allDigits = false;
-          break;
-        }
-      }
-      if (allDigits) penguin = true;
-    }
-
-    // "FS Ext Battery"
-    if (name == "FS Ext Battery") {
-      penguin = true;
-    }
-
-    // "NNNNNNNNNN"
-    if (name.length() == 10) {
-      bool allDigits = true;
-      for (int i = 0; i < name.length(); i++) {
-        char c = name.charAt(i);
-        if (c < '0' || c > '9') {
-          allDigits = false;
-          break;
-        }
-      }
-      if (allDigits) penguin = true;
-    }
-  }
-
-  bool isFlock = (penguin || name.length() == 0);
-
-  if (!isFlock) {
-    return false;
-  }
-
-  // --- Serial extraction ---
-  if (serial_out != nullptr) {
-    *serial_out = "";
-
-    if (mfgIndex > 0) {
-      uint8_t adLen = payload[mfgIndex - 1];
-      size_t adStart = mfgIndex - 1;
-      size_t adEnd = adStart + adLen;
-
-      if (adEnd > len) {
-        adEnd = len;
-      }
-
-      size_t vendorStart = mfgIndex + 3;
-
-      if (vendorStart < adEnd) {
-        bool started = false;
-
-        for (size_t k = vendorStart; k < adEnd; k++) {
-          char c = (char)payload[k];
-
-          if (!started) {
-            if (c == 'T' &&
-                (k + 1) < adEnd &&
-                (char)payload[k + 1] == 'N') {
-              started = true;
-              *serial_out += 'T';
-              *serial_out += 'N';
-              k++;
-            }
-          } else {
-            if (c >= '0' && c <= '9') {
-              *serial_out += c;
-            } else if (c == ' ' || c == '#' || c == '-') {
-              continue;
-            } else {
-              break;
-            }
-          }
-        }
-      }
-    }
-  }
-
-  return true;
 }
 
 void WiFiScan::RunSetup() {
@@ -2280,6 +1917,8 @@ void WiFiScan::StartScan(uint8_t scan_mode, uint16_t color) {
 
   if (scan_mode == WIFI_SCAN_PROBE)
     RunProbeScan(scan_mode, color);
+  else if (scan_mode == WIFI_SCAN_FLOCK)
+    RunProbeScan(scan_mode, color);
   else if ((scan_mode == WIFI_SCAN_SAE_COMMIT) || (scan_mode == WIFI_ATTACK_SAE_COMMIT))
     RunSAEScan(scan_mode, color);
   else if (scan_mode == WIFI_SCAN_DETECT_FOLLOW) {
@@ -2366,13 +2005,9 @@ void WiFiScan::StartScan(uint8_t scan_mode, uint16_t color) {
           (scan_mode == BT_SCAN_AIRTAG) ||
           (scan_mode == BT_SCAN_AIRTAG_MON) ||
           (scan_mode == BT_SCAN_FLIPPER) ||
-          (scan_mode == BT_SCAN_FLOCK) ||
           (scan_mode == BT_SCAN_ANALYZER) ||
           (scan_mode == BT_SCAN_SIMPLE) ||
           (scan_mode == BT_SCAN_SIMPLE_TWO)) {
-    if (scan_mode == BT_SCAN_FLOCK)
-      this->RunProbeScan(scan_mode, color);
-
     #ifdef HAS_BT
       RunBluetoothScan(scan_mode, color);
     #endif
@@ -2687,7 +2322,7 @@ void WiFiScan::StopScan(uint8_t scan_mode) {
   (currentScanMode == WIFI_SCAN_CHAN_ACT) ||
   (currentScanMode == WIFI_SCAN_PACKET_RATE) ||
   (currentScanMode == WIFI_CONNECTED) ||
-  (currentScanMode == BT_SCAN_FLOCK) ||
+  (currentScanMode == WIFI_SCAN_FLOCK) ||
   (currentScanMode == WIFI_SCAN_DETECT_FOLLOW) ||
   (currentScanMode == LV_JOIN_WIFI) ||
   (this->wifi_initialized))
@@ -2754,7 +2389,6 @@ void WiFiScan::StopScan(uint8_t scan_mode) {
   (currentScanMode == BT_SCAN_AIRTAG) ||
   (currentScanMode == BT_SCAN_AIRTAG_MON) ||
   (currentScanMode == BT_SCAN_FLIPPER) ||
-  (currentScanMode == BT_SCAN_FLOCK) ||
   (currentScanMode == BT_ATTACK_FINDMY_LIVE) ||
   (currentScanMode == BT_ATTACK_SOUR_APPLE) ||
   (currentScanMode == BT_ATTACK_APPLE_JUICE) ||
@@ -5776,6 +5410,59 @@ void WiFiScan::closePoiFile() {
   #endif
 }
 
+void WiFiScan::resetFlockLog() {
+  flockFileName = "";
+  flockFileOpen = false;
+  flockMacCount = 0;
+  memset(flockMacHistory, 0, sizeof(flockMacHistory));
+}
+
+bool WiFiScan::rememberFlockMac(const uint8_t mac[6]) {
+  for (uint8_t i = 0; i < flockMacCount; i++) {
+    if (memcmp(flockMacHistory[i], mac, 6) == 0)
+      return false;
+  }
+  if (flockMacCount >= sizeof(flockMacHistory) / sizeof(flockMacHistory[0]))
+    return false;
+  memcpy(flockMacHistory[flockMacCount++], mac, 6);
+  return true;
+}
+
+void WiFiScan::logWardriveFlock(const uint8_t mac[6], int8_t rssi, uint8_t channel) {
+  #ifdef HAS_GPS
+    if (!gps_obj.getGpsModuleStatus() || !gps_obj.getFixStatus())
+      return;
+
+    String line = macToString(mac) + "," + gps_obj.getDatetime() + "," +
+      String(channel) + "," + String(rssi) + "," + gps_obj.getLat() + "," +
+      gps_obj.getLon() + "," + gps_obj.getAlt() + "," + gps_obj.getAccuracy() +
+      ",probe-ie-oui\n";
+    Serial.print("Flock | " + line);
+
+    #ifdef HAS_SD
+      if (!flockFileOpen) {
+        int file_index = 0;
+        do {
+          flockFileName = "/wardrive_flock_" + String(file_index++) + ".log";
+        } while (SD.exists(flockFileName));
+        flockFile = SD.open(flockFileName, FILE_WRITE);
+        if (flockFile) {
+          flockFile.print("MAC,FirstSeen,Channel,RSSI,Latitude,Longitude,AltitudeMeters,AccuracyMeters,Method\n");
+          flockFile.close();
+          flockFileOpen = true;
+        }
+      }
+      if (flockFileOpen) {
+        flockFile = SD.open(flockFileName, FILE_APPEND);
+        if (flockFile) {
+          flockFile.print(line);
+          flockFile.close();
+        }
+      }
+    #endif
+  #endif
+}
+
 void WiFiScan::tagPOI(const char* label) {
   #if defined(HAS_GPS) && defined(HAS_SD)
     if (currentScanMode != WIFI_SCAN_WAR_DRIVE && currentScanMode != WIFI_SCAN_STATION_WAR_DRIVE) {
@@ -6009,6 +5696,7 @@ void WiFiScan::RunBeaconScan(uint8_t scan_mode, uint16_t color) {
         startLog("wardrive");
         buffer_obj.append(this->header_line);
         this->openPoiFile();
+        this->resetFlockLog();
       } else {
         return;
       }
@@ -6213,10 +5901,12 @@ void WiFiScan::throwThatShitInACircle() {
 void WiFiScan::RunProbeScan(uint8_t scan_mode, uint16_t color) {
   if (scan_mode == WIFI_SCAN_PROBE)
     probe_req_ssids->clear();
+  else if (scan_mode == WIFI_SCAN_FLOCK)
+    resetFlockLog();
 
   if (scan_mode == WIFI_SCAN_PROBE)
     startPcap("probe");
-  else if (scan_mode == BT_SCAN_FLOCK)
+  else if (scan_mode == WIFI_SCAN_FLOCK)
     startPcap("flock");
   else if (scan_mode == WIFI_SCAN_DETECT_FOLLOW)
     startPcap("mac_track");
@@ -6237,7 +5927,7 @@ void WiFiScan::RunProbeScan(uint8_t scan_mode, uint16_t color) {
     #endif
     #ifdef HAS_ILI9341
       if ((scan_mode != WIFI_SCAN_PROBE) &&
-          (scan_mode != BT_SCAN_FLOCK))
+          (scan_mode != WIFI_SCAN_FLOCK))
         display_obj.touchToExit();
     #endif
     display_obj.tft.setTextColor(TFT_GREEN, TFT_BLACK);
@@ -6254,12 +5944,7 @@ void WiFiScan::RunProbeScan(uint8_t scan_mode, uint16_t color) {
     esp_wifi_set_country(&country);
     esp_event_loop_create_default();
   #endif
-  if (scan_mode != BT_SCAN_FLOCK)
-    this->setWiFiMode(WIFI_MODE_NULL, beaconSnifferCallback);
-  else {
-    this->throwThatShitInACircle();
-    this->setWiFiMode(WIFI_MODE_AP, beaconSnifferCallback);
-  }
+  this->setWiFiMode(WIFI_MODE_NULL, beaconSnifferCallback);
   this->changeChannel(this->set_channel);
   this->wifi_initialized = true;
   initTime = millis();
@@ -6350,8 +6035,7 @@ void WiFiScan::RunBluetoothScan(uint8_t scan_mode, uint16_t color) {
       display_obj.print_delay_2 = 20;
     #endif
 
-    if ((scan_mode == BT_SCAN_FLOCK) ||
-        (scan_mode == WIFI_SCAN_WAR_DRIVE) ||
+    if ((scan_mode == WIFI_SCAN_WAR_DRIVE) ||
         (scan_mode == WIFI_SCAN_DETECT_FOLLOW) ||
         (scan_mode == BT_SCAN_SIMPLE) ||
         (scan_mode == BT_SCAN_SIMPLE_TWO) ||
@@ -6372,7 +6056,6 @@ void WiFiScan::RunBluetoothScan(uint8_t scan_mode, uint16_t color) {
         (scan_mode == BT_SCAN_AIRTAG) ||
         (scan_mode == BT_SCAN_AIRTAG_MON) ||
         (scan_mode == BT_SCAN_FLIPPER) ||
-        (scan_mode == BT_SCAN_FLOCK) ||
         (scan_mode == BT_SCAN_SIMPLE) ||
         (scan_mode == BT_SCAN_SIMPLE_TWO))
     {
@@ -6391,8 +6074,6 @@ void WiFiScan::RunBluetoothScan(uint8_t scan_mode, uint16_t color) {
             display_obj.tft.drawCentreString("FindMy Monitor",TFT_WIDTH / 2,16,2);
           else if (scan_mode == BT_SCAN_FLIPPER)
             display_obj.tft.drawCentreString("Flipper Sniff", TFT_WIDTH / 2, 16, 2);
-          else if (scan_mode == BT_SCAN_FLOCK)
-            display_obj.tft.drawCentreString("Flock Sniff", TFT_WIDTH / 2, 16, 2);
           else if (scan_mode == BT_SCAN_SIMPLE)
             display_obj.tft.drawCentreString("Simple Sniff", TFT_WIDTH / 2, 16, 2);
           else if (scan_mode == BT_SCAN_SIMPLE_TWO)
@@ -6400,8 +6081,7 @@ void WiFiScan::RunBluetoothScan(uint8_t scan_mode, uint16_t color) {
           else if (scan_mode == BT_SCAN_RAYBAN)
             display_obj.tft.drawCentreString("Meta Detect",TFT_WIDTH / 2, 16, 2);
           #ifdef HAS_ILI9341
-            if (scan_mode != BT_SCAN_FLOCK)
-              display_obj.touchToExit();
+            display_obj.touchToExit();
           #endif
         #endif
         display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
@@ -6423,7 +6103,6 @@ void WiFiScan::RunBluetoothScan(uint8_t scan_mode, uint16_t color) {
       }
       else if ((scan_mode == BT_SCAN_FLIPPER) ||
                 (scan_mode == BT_SCAN_RAYBAN) ||
-                (scan_mode == BT_SCAN_FLOCK) ||
                 (scan_mode == BT_SCAN_SIMPLE) ||
                 (scan_mode == BT_SCAN_AIRTAG) ||
                 (scan_mode == BT_SCAN_AIRTAG_MON) ||
@@ -6465,8 +6144,7 @@ void WiFiScan::RunBluetoothScan(uint8_t scan_mode, uint16_t color) {
           display_obj.tft.fillRect(0,16,TFT_WIDTH,16, color);
           display_obj.tft.drawCentreString("Bluetooth Analyzer", TFT_WIDTH / 2, 16, 2);
           #ifdef HAS_ILI9341
-            if (scan_mode != BT_SCAN_FLOCK)
-              display_obj.touchToExit();
+            display_obj.touchToExit();
           #endif
         #endif
         display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
@@ -6493,7 +6171,6 @@ void WiFiScan::RunBluetoothScan(uint8_t scan_mode, uint16_t color) {
     if ((scan_mode == BT_SCAN_RAYBAN) ||
         (scan_mode == WIFI_SCAN_WAR_DRIVE) ||
         (scan_mode == BT_SCAN_ANALYZER) ||
-        (scan_mode == BT_SCAN_FLOCK) ||
         (scan_mode == BT_SCAN_SIMPLE) ||
         (scan_mode == BT_SCAN_SIMPLE_TWO))
       pBLEScan->setDuplicateFilter(false);
@@ -8023,6 +7700,10 @@ bool WiFiScan::checkFlockOUI(const uint8_t mac[6]) {
   return false;
 }
 
+bool WiFiScan::probeReqMatchesFlock(const uint8_t* frame, size_t frame_len, const uint8_t src_mac[6]) {
+  return checkFlockOUI(src_mac) && flockProbeRequestMatches(frame, frame_len);
+}
+
 String WiFiScan::checkEmptyProbe(String essid) {
   if (essid == "")
     return "<hidden>";
@@ -8248,148 +7929,38 @@ void WiFiScan::beaconSnifferCallback(void* buf, wifi_promiscuous_pkt_type_t type
     Serial.println(wifi_scan_obj.fox_hunt_target.name + " RSSI: " + String(wifi_scan_obj.fox_hunt_target.rssi));
     buffer_obj.append(snifferPacket, len);
   }
-  else if (wifi_scan_obj.currentScanMode == BT_SCAN_FLOCK) {
-    if (type == WIFI_PKT_MGMT) {
-      bool do_write = false;
+  else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_FLOCK) {
+    if (type != WIFI_PKT_MGMT || len < 26 ||
+        !wifi_scan_obj.probeReqMatchesFlock(snifferPacket->payload, len, src_addr))
+      return;
 
-      len -= 4;
-      if (snifferPacket->payload[0] == 0x40) {
-        String probe_req_essid;
-
-        for (int i = 0; i < snifferPacket->payload[25]; i++)
-          probe_req_essid.concat((char)snifferPacket->payload[26 + i]);
-
-        // Check name in probe req
-        for (int i = 0; i < sizeof(flock_ssid)/sizeof(wifi_scan_obj.flock_ssid[0]); i++) {
-          if (strcasestr(probe_req_essid.c_str(), wifi_scan_obj.flock_ssid[i]))
-            do_write = true;
-        }
-
-        probe_req_essid = wifi_scan_obj.checkEmptyProbe(probe_req_essid);
-
-        // Check OUIs
-        if ((wifi_scan_obj.checkFlockOUI(src_addr)) && (!do_write))
-          do_write = true;
-
-        if (do_write) {
-          #ifdef HAS_SCREEN
-            display_string.concat(MAGENTA_KEY);
-            display_string.concat((String)snifferPacket->rx_ctrl.rssi);
-            display_string.concat(" ");
-            display_string.concat(addr);
-            display_string.concat(" -> ");
-            display_string.concat(probe_req_essid);
-
-            int temp_len = display_string.length();
-
-            for (int i = 0; i < 40; i++)
-            {
-              display_string.concat(" ");
-            }
-
-            if (!display_obj.printing) {
-              display_obj.loading = true;
-              display_obj.display_buffer->add(display_string);
-              display_obj.loading = false;
-            }
-          #endif
-
-          Serial.println(display_string);
-
-          buffer_obj.append(snifferPacket, len);
-          return;
-        }
+    if (!wifi_scan_obj.rememberFlockMac(src_addr))
+      return;
+    wifi_scan_obj.flock_devices++;
+    #ifdef HAS_SCREEN
+      display_string.concat(MAGENTA_KEY);
+      display_string.concat(String(snifferPacket->rx_ctrl.rssi));
+      display_string.concat(" ");
+      display_string.concat(addr);
+      display_string.concat(" Flock");
+      for (int i = display_string.length(); i < 40; i++)
+        display_string.concat(" ");
+      if (!display_obj.printing) {
+        display_obj.loading = true;
+        display_obj.display_buffer->add(display_string);
+        display_obj.loading = false;
       }
-
-      else if (snifferPacket->payload[0] == 0x80) {
-        if (snifferPacket->payload[37] > 0) {
-          for (int i = 0; i < snifferPacket->payload[37]; i++)
-            essid.concat((char)snifferPacket->payload[i + 38]);
-
-          //Serial.println(essid);
-
-          for (int i = 0; i < sizeof(flock_ssid)/sizeof(wifi_scan_obj.flock_ssid[0]); i++) {
-            if (strcasestr(essid.c_str(), wifi_scan_obj.flock_ssid[i])) {
-
-              #ifdef HAS_SCREEN
-                display_string.concat(GREEN_KEY);
-                display_string.concat((String)snifferPacket->rx_ctrl.rssi);
-                display_string.concat(" ");
-                display_string.concat(addr);
-                display_string.concat(" -> ");
-                display_string.concat(essid);
-
-                int temp_len = display_string.length();
-
-                for (int i = 0; i < 40; i++)
-                {
-                  display_string.concat(" ");
-                }
-
-                if (!display_obj.printing) {
-                  display_obj.loading = true;
-                  display_obj.display_buffer->add(display_string);
-                  display_obj.loading = false;
-                }
-              #endif
-
-              Serial.println(display_string);
-
-              buffer_obj.append(snifferPacket, len);
-              break;
-            }
-          }
-        }
-      }
-    }
+    #endif
+    Serial.println(display_string);
+    buffer_obj.append(snifferPacket, len > 4 ? len - 4 : len);
   }
   else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_WAR_DRIVE) {
-    if (type == WIFI_PKT_MGMT) {
-      bool do_write = false;
-      len -= 4;
-      if (snifferPacket->payload[0] == 0x40) {
-        String probe_req_essid;
-
-        for (int i = 0; i < snifferPacket->payload[25]; i++)
-          probe_req_essid.concat((char)snifferPacket->payload[26 + i]);
-
-        // Check Probe Request Names
-        for (int i = 0; i < sizeof(flock_ssid)/sizeof(wifi_scan_obj.flock_ssid[0]); i++) {
-          if (strcasestr(probe_req_essid.c_str(), wifi_scan_obj.flock_ssid[i])) {
-            do_write = true;
-            break;
-          }
-        }
-
-        // Check OUIs
-        if ((wifi_scan_obj.checkFlockOUI(src_addr)) && (!do_write)) {
-          do_write = true;
-        }
-
-        if ((do_write) && (!wifi_scan_obj.seen_mac(src_addr))) {
-          wifi_scan_obj.save_mac(src_addr);
-          #ifdef HAS_GPS
-            wifi_scan_obj.flock_devices++;
-            String wardrive_line =
-              macToString(src_addr) + "," +
-              "Flock," +
-              wifi_scan_obj.security_int_to_string(WIFI_AUTH_WPA2_PSK) + "," +
-              gps_obj.getDatetime() + "," +
-              (String)wifi_scan_obj.set_channel + "," +
-              (String)snifferPacket->rx_ctrl.rssi + "," +
-              gps_obj.getLat() + "," +
-              gps_obj.getLon() + "," +
-              gps_obj.getAlt() + "," +
-              gps_obj.getAccuracy() + ",WIFI\n";
-
-            Serial.print((String)wifi_scan_obj.mac_history_cursor + " | " + wardrive_line);
-
-            if (gps_obj.getFixStatus()) {
-              buffer_obj.append(wardrive_line);
-            }
-          #endif
-        }
-      }
+    if (type == WIFI_PKT_MGMT && len >= 26 &&
+        wifi_scan_obj.probeReqMatchesFlock(snifferPacket->payload, len, src_addr) &&
+        wifi_scan_obj.rememberFlockMac(src_addr)) {
+      wifi_scan_obj.flock_devices++;
+      wifi_scan_obj.logWardriveFlock(src_addr, snifferPacket->rx_ctrl.rssi,
+                                    snifferPacket->rx_ctrl.channel);
     }
   }
   else if (wifi_scan_obj.currentScanMode == WIFI_SCAN_DETECT_FOLLOW) {
@@ -9962,7 +9533,7 @@ void WiFiScan::channelHop(bool filtered, bool ranged) {
        (this->currentScanMode == WIFI_SCAN_RAW_CAPTURE) ||
        (this->currentScanMode == WIFI_SCAN_SIG_STREN) ||
        (this->currentScanMode == WIFI_SCAN_PACKET_RATE) ||
-       (this->currentScanMode == BT_SCAN_FLOCK)))
+       (this->currentScanMode == WIFI_SCAN_FLOCK)))
     return;
 
   if (!filtered) {
@@ -11621,8 +11192,16 @@ void WiFiScan::main(uint32_t currentTime)
       this->updateTrackerUI();
     }
   }
-  else if ((currentScanMode == BT_SCAN_FLOCK) ||
-          (currentScanMode == BT_SCAN_FLIPPER) ||
+  else if (currentScanMode == WIFI_SCAN_FLOCK) {
+    if (currentTime - initTime >= this->channel_hop_delay * HOP_DELAY) {
+      initTime = millis();
+      this->channelHop();
+    }
+    #ifdef HAS_ILI9341
+      this->signalAnalyzerLoop(currentTime);
+    #endif
+  }
+  else if ((currentScanMode == BT_SCAN_FLIPPER) ||
           (currentScanMode == BT_SCAN_AIRTAG) ||
           (currentScanMode == BT_SCAN_RAYBAN)) {
 
@@ -11649,19 +11228,6 @@ void WiFiScan::main(uint32_t currentTime)
             return;
           }
         }
-      #endif
-      if (currentScanMode == BT_SCAN_FLOCK) {
-        this->channelHop();
-        uint8_t ap_mac[6];
-        esp_read_mac(ap_mac, ESP_MAC_WIFI_STA);
-        broadcastCustomBeacon(currentTime, {"Flock", this->set_channel, {ap_mac[0], ap_mac[1], ap_mac[2], ap_mac[3], ap_mac[4], ap_mac[5]}, false}, true);
-        //broadcastSetSSID(currentTime, "Flock", 1, true);
-      }
-    }
-
-    if (currentScanMode == BT_SCAN_FLOCK) {
-      #ifdef HAS_ILI9341
-        this->signalAnalyzerLoop(currentTime);
       #endif
     }
   }

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -151,10 +151,9 @@
 #define WIFI_HOSTSPOT 69 // Nice
 #define BT_SCAN_AIRTAG_MON 70
 #define WIFI_SCAN_CHAN_ACT 71
-#define BT_SCAN_FLOCK 72
+#define WIFI_SCAN_FLOCK 72
 #define BT_SCAN_SIMPLE 73
 #define BT_SCAN_SIMPLE_TWO 74
-#define BT_SCAN_FLOCK_WARDRIVE 75
 #define WIFI_SCAN_DETECT_FOLLOW 76
 #define WIFI_SCAN_SAE_COMMIT 77
 #define WIFI_ATTACK_SAE_COMMIT 78
@@ -728,6 +727,15 @@ class WiFiScan
     void openPoiFile();
     void closePoiFile();
 
+    File flockFile;
+    String flockFileName = "";
+    bool flockFileOpen = false;
+    uint8_t flockMacHistory[64][6] = {};
+    uint8_t flockMacCount = 0;
+    void resetFlockLog();
+    bool rememberFlockMac(const uint8_t mac[6]);
+    void logWardriveFlock(const uint8_t mac[6], int8_t rssi, uint8_t channel);
+
     void executeWarDrive();
     void executeBLESpam(EBLEPayloadType type);
     void startWardriverWiFi();
@@ -809,7 +817,7 @@ class WiFiScan
 
     uint8_t dual_band_channels[DUAL_BAND_CHANNELS] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84, 88, 92, 96, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161, 165, 169, 173, 177};
 
-    uint8_t oui_list[27][3] = {
+    uint8_t oui_list[40][3] = {
     {0x58, 0x8E, 0x81},
     {0xCC, 0xCC, 0xCC},
     {0xEC, 0x1B, 0xBD},
@@ -836,7 +844,20 @@ class WiFiScan
     {0x00, 0xF4, 0x8D},
     {0xD0, 0x39, 0x57},
     {0xE8, 0xD0, 0xFC},
-    {0xB4, 0x1E, 0x52}
+    {0xB4, 0x1E, 0x52},
+    {0xB8, 0x35, 0x32},
+    {0xC0, 0x35, 0x32},
+    {0x24, 0xB2, 0xB9},
+    {0xE0, 0x4F, 0x43},
+    {0xB8, 0x1E, 0xA4},
+    {0x70, 0x08, 0x94},
+    {0x3C, 0x71, 0xBF},
+    {0x58, 0x00, 0xE3},
+    {0x5C, 0x93, 0xA2},
+    {0x64, 0x6E, 0x69},
+    {0x48, 0x27, 0xEA},
+    {0xA4, 0xCF, 0x12},
+    {0x82, 0x6B, 0xF2}
     };
 
     uint8_t dual_band_channel_index = 0;
@@ -879,14 +900,6 @@ class WiFiScan
     bool save_pcap = false;
     bool ep_deauth = false;
     bool ble_scanning = false;
-
-    char* flock_ssid[5] = {
-      "flock",
-      "penguin",
-      "pigvision",
-      "fs ext battery",
-      "Flock"
-    };
 
     #ifdef HAS_DUAL_BAND
       uint8_t channel_activity[DUAL_BAND_CHANNELS] = {};
@@ -986,8 +999,8 @@ class WiFiScan
     bool uploadFile(String filePath, bool retry = false, uint8_t upload_type = WIGLE_UPLOAD);
     String checkEmptyProbe(String essid);
     bool checkFlockOUI(const uint8_t mac[6]);
+    bool probeReqMatchesFlock(const uint8_t* frame, size_t frame_len, const uint8_t src_mac[6]);
     bool startWiFi(String ssid, String password, bool gui = true);
-    bool isFlockCamera(const uint8_t* payload, size_t len, const String& name, String* serial_out);
     int seenBLEDevice(BleDevice ble_device);
     uint16_t rssiToColor(int8_t rssi);
     bool isMetaIdentifier(uint16_t id);

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,7 @@ build_src_filter =
   +<BeaconFrame.cpp>
   +<WdgResponse.cpp>
   +<FoxHuntTarget.cpp>
+  +<FlockDetector.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/test_flock_detector/test_main.cpp
+++ b/test/test_flock_detector/test_main.cpp
@@ -1,0 +1,67 @@
+#include <unity.h>
+
+#include <vector>
+
+#include "FlockDetector.h"
+
+static std::vector<uint8_t> validProbe() {
+  std::vector<uint8_t> frame(24, 0);
+  frame[0] = 0x40;
+  const uint8_t ies[] = {
+    0x00, 0x00,
+    0x01, 0x02, 0x82, 0x84,
+    0xdd, 0x07, 0x50, 0x6f, 0x9a, 0x16, 0x03, 0x01, 0x03,
+    0x2d, 0x02, 0x01, 0x02,
+    0xbf, 0x01, 0x03,
+    0xdd, 0x07, 0x00, 0x50, 0xf2, 0x08, 0x00, 0x00, 0x00
+  };
+  frame.insert(frame.end(), ies, ies + sizeof(ies));
+  return frame;
+}
+
+void test_accepts_exact_fingerprint() {
+  auto frame = validProbe();
+  TEST_ASSERT_TRUE(flockProbeRequestMatches(frame.data(), frame.size()));
+}
+
+void test_accepts_optional_fcs() {
+  auto frame = validProbe();
+  frame.insert(frame.end(), {0xde, 0xad, 0xbe, 0xef});
+  TEST_ASSERT_TRUE(flockProbeRequestMatches(frame.data(), frame.size()));
+}
+
+void test_requires_probe_request() {
+  auto frame = validProbe();
+  frame[0] = 0x80;
+  TEST_ASSERT_FALSE(flockProbeRequestMatches(frame.data(), frame.size()));
+}
+
+void test_requires_wildcard_ssid() {
+  auto frame = validProbe();
+  frame[25] = 1;
+  TEST_ASSERT_FALSE(flockProbeRequestMatches(frame.data(), frame.size()));
+}
+
+void test_rejects_changed_vendor_fingerprint() {
+  auto frame = validProbe();
+  frame[24 + 6 + 4] ^= 0x01;
+  TEST_ASSERT_FALSE(flockProbeRequestMatches(frame.data(), frame.size()));
+}
+
+void test_rejects_trailing_information_element() {
+  auto frame = validProbe();
+  frame.insert(frame.end(), {0x01, 0x00});
+  TEST_ASSERT_FALSE(flockProbeRequestMatches(frame.data(), frame.size()));
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_accepts_exact_fingerprint);
+  RUN_TEST(test_accepts_optional_fcs);
+  RUN_TEST(test_requires_probe_request);
+  RUN_TEST(test_requires_wildcard_ssid);
+  RUN_TEST(test_rejects_changed_vendor_fingerprint);
+  RUN_TEST(test_rejects_trailing_information_element);
+  return UNITY_END();
+}
+


### PR DESCRIPTION
## Summary
- adopt the Flock wildcard probe fingerprint and infrastructure OUI set from #1348
- move Flock detection to passive Wi-Fi without replacing current wardrive behavior
- keep Flock deduplication and logs separate from normal AP and BLE wardrive data
- credit @DeflockJoplin and the upstream research cited in #1348