### PR TITLE
Add stable sort and filter controls to fox hunt lists

### DIFF
--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1566,17 +1566,17 @@ const char* MenuFunctions::foxFilterLabel() const {
 }
 
 bool MenuFunctions::foxListSupportsRecent() const {
-  return fox_target_list == FoxTargetList::WIFI_AP ||
-         fox_target_list == FoxTargetList::STATION_AP ||
-         fox_target_list == FoxTargetList::FINDMY;
+  return fox_target_list == FoxHuntListKind::AP_TARGETS ||
+         fox_target_list == FoxHuntListKind::APS_WITH_STATIONS ||
+         fox_target_list == FoxHuntListKind::FINDMY_TARGETS;
 }
 
 bool MenuFunctions::foxListSupportsBand() const {
-  return fox_target_list == FoxTargetList::WIFI_AP ||
-         fox_target_list == FoxTargetList::STATION_AP ||
-         fox_target_list == FoxTargetList::STATION ||
-         fox_target_list == FoxTargetList::PINEAPPLE ||
-         fox_target_list == FoxTargetList::MULTISSID;
+  return fox_target_list == FoxHuntListKind::AP_TARGETS ||
+         fox_target_list == FoxHuntListKind::APS_WITH_STATIONS ||
+         fox_target_list == FoxHuntListKind::STATION_TARGETS ||
+         fox_target_list == FoxHuntListKind::PINEAPPLE_TARGETS ||
+         fox_target_list == FoxHuntListKind::MULTISSID_TARGETS;
 }
 
 void MenuFunctions::buildFoxSortMenu() {
@@ -1629,7 +1629,7 @@ void MenuFunctions::buildFoxFilterMenu() {
   this->changeMenu(&foxFilterMenu, true);
 }
 
-void MenuFunctions::buildFoxTargetList(FoxTargetList type, int context_ap) {
+void MenuFunctions::buildFoxTargetList(FoxHuntListKind type, int context_ap) {
   fox_target_list = type;
   fox_target_context_ap = context_ap;
   if (!foxListSupportsRecent() && fox_filter_mode == TargetFilterMode::RECENT_30S)
@@ -1639,9 +1639,9 @@ void MenuFunctions::buildFoxTargetList(FoxTargetList type, int context_ap) {
   if (!foxListSupportsBand() && fox_sort_mode == TargetSortMode::CHANNEL_ASC)
     fox_sort_mode = TargetSortMode::SIGNAL_DESC;
 
-  Menu* menu = type == FoxTargetList::STATION ? &wifiStationMenu : &wifiAPMenu;
+  Menu* menu = type == FoxHuntListKind::STATION_TARGETS ? &wifiStationMenu : &wifiAPMenu;
   menu->list->clear();
-  menu->parentMenu = type == FoxTargetList::STATION ? &wifiAPMenu : &foxHuntMenu;
+  menu->parentMenu = type == FoxHuntListKind::STATION_TARGETS ? &wifiAPMenu : &foxHuntMenu;
   this->addNodes(menu, text09, TFTLIGHTGREY, 0, [this, menu]() { this->changeMenu(menu->parentMenu, true); });
   String sort_row = "Sort: " + String(foxSortLabel());
   this->addNodes(menu, sort_row.c_str(), TFTCYAN, 255, [this]() { buildFoxSortMenu(); });
@@ -1656,32 +1656,32 @@ void MenuFunctions::buildFoxTargetList(FoxTargetList type, int context_ap) {
     items.push_back(item);
   };
 
-  if (type == FoxTargetList::WIFI_AP || type == FoxTargetList::STATION_AP) {
+  if (type == FoxHuntListKind::AP_TARGETS || type == FoxHuntListKind::APS_WITH_STATIONS) {
     for (int i = 0; i < access_points->size(); i++) {
       const AccessPoint& ap = access_points->get(i);
-      if (type == FoxTargetList::STATION_AP && ap.stations->size() == 0)
+      if (type == FoxHuntListKind::APS_WITH_STATIONS && ap.stations->size() == 0)
         continue;
       add_item(i, ap.rssi, ap.channel, ap.last_seen_ms, ap.essid.length() ? ap.essid : macToString(ap.bssid));
     }
-  } else if (type == FoxTargetList::STATION && context_ap >= 0 && context_ap < access_points->size()) {
+  } else if (type == FoxHuntListKind::STATION_TARGETS && context_ap >= 0 && context_ap < access_points->size()) {
     const AccessPoint& ap = access_points->get(context_ap);
     for (int x = 0; x < ap.stations->size(); x++) {
       int station_index = ap.stations->get(x);
       add_item(station_index, -128, ap.channel, 0, macToString(stations->get(station_index).mac));
     }
-  } else if (type == FoxTargetList::PINEAPPLE) {
+  } else if (type == FoxHuntListKind::PINEAPPLE_TARGETS) {
     for (size_t i = 0; i < wifi_scan_obj.getPineScanCount(); i++)
       add_item(i, wifi_scan_obj.getPineScanRssi(i), wifi_scan_obj.getPineScanChannel(i), 0, wifi_scan_obj.getPineScanLabel(i));
-  } else if (type == FoxTargetList::MULTISSID) {
+  } else if (type == FoxHuntListKind::MULTISSID_TARGETS) {
     for (size_t i = 0; i < wifi_scan_obj.getMultiSSIDCount(); i++)
       add_item(i, wifi_scan_obj.getMultiSSIDRssi(i), wifi_scan_obj.getMultiSSIDChannel(i), 0, wifi_scan_obj.getMultiSSIDLabel(i));
-  } else if (type == FoxTargetList::BLE_DEVICE) {
+  } else if (type == FoxHuntListKind::BLE_TARGETS) {
     for (int i = 0; i < ble_devices->size(); i++)
       add_item(i, ble_devices->get(i).rssi, 0, 0, ble_devices->get(i).name.length() ? ble_devices->get(i).name : macToString(ble_devices->get(i).mac));
-  } else if (type == FoxTargetList::FINDMY) {
+  } else if (type == FoxHuntListKind::FINDMY_TARGETS) {
     for (int i = 0; i < airtags->size(); i++)
       add_item(i, airtags->get(i).rssi, 0, airtags->get(i).last_seen, airtags->get(i).mac);
-  } else if (type == FoxTargetList::FLIPPER) {
+  } else if (type == FoxHuntListKind::FLIPPER_TARGETS) {
     for (int i = 0; i < flippers->size(); i++)
       add_item(i, -128, 0, 0, flippers->get(i).name.length() ? flippers->get(i).name : flippers->get(i).mac);
   }
@@ -1698,27 +1698,27 @@ void MenuFunctions::buildFoxTargetList(FoxTargetList type, int context_ap) {
     int index = item.source_index;
     String label;
     uint16_t color = TFTCYAN;
-    if (type == FoxTargetList::WIFI_AP) {
+    if (type == FoxHuntListKind::AP_TARGETS) {
       const AccessPoint& ap = access_points->get(index);
       label = String(ap.rssi) + " " + ap.essid;
       color = rssiToMenuColor(ap.rssi);
-    } else if (type == FoxTargetList::STATION_AP) {
+    } else if (type == FoxHuntListKind::APS_WITH_STATIONS) {
       const AccessPoint& ap = access_points->get(index);
       label = ap.essid + " (" + String(ap.stations->size()) + ")";
       color = TFTMAGENTA;
-    } else if (type == FoxTargetList::STATION) {
+    } else if (type == FoxHuntListKind::STATION_TARGETS) {
       label = macToString(stations->get(index).mac);
       color = TFTMAGENTA;
-    } else if (type == FoxTargetList::PINEAPPLE) {
+    } else if (type == FoxHuntListKind::PINEAPPLE_TARGETS) {
       label = wifi_scan_obj.getPineScanLabel(index);
       color = TFTYELLOW;
-    } else if (type == FoxTargetList::MULTISSID) {
+    } else if (type == FoxHuntListKind::MULTISSID_TARGETS) {
       label = wifi_scan_obj.getMultiSSIDLabel(index);
       color = TFTORANGE;
-    } else if (type == FoxTargetList::BLE_DEVICE) {
+    } else if (type == FoxHuntListKind::BLE_TARGETS) {
       label = String(ble_devices->get(index).rssi) + " " + ble_devices->get(index).name;
       color = rssiToMenuColor(ble_devices->get(index).rssi);
-    } else if (type == FoxTargetList::FINDMY) {
+    } else if (type == FoxHuntListKind::FINDMY_TARGETS) {
       label = String(airtags->get(index).rssi) + " " + airtags->get(index).mac;
       color = TFTWHITE;
     } else {
@@ -1727,29 +1727,29 @@ void MenuFunctions::buildFoxTargetList(FoxTargetList type, int context_ap) {
     }
 
     this->addNodes(menu, label.c_str(), color, 255, [this, type, context_ap, index]() {
-      if (type == FoxTargetList::STATION_AP) {
-        buildFoxTargetList(FoxTargetList::STATION, index);
+      if (type == FoxHuntListKind::APS_WITH_STATIONS) {
+        buildFoxTargetList(FoxHuntListKind::STATION_TARGETS, index);
         return;
       }
-      if (type == FoxTargetList::PINEAPPLE) {
+      if (type == FoxHuntListKind::PINEAPPLE_TARGETS) {
         if (!wifi_scan_obj.selectPineScanFoxTarget(index)) return;
-      } else if (type == FoxTargetList::MULTISSID) {
+      } else if (type == FoxHuntListKind::MULTISSID_TARGETS) {
         if (!wifi_scan_obj.selectMultiSSIDFoxTarget(index)) return;
-      } else if (type == FoxTargetList::WIFI_AP) {
+      } else if (type == FoxHuntListKind::AP_TARGETS) {
         const AccessPoint& ap = access_points->get(index);
         wifi_scan_obj.setFoxHuntTarget(ap.bssid, ap.essid, ap.rssi, ap.channel, false);
-      } else if (type == FoxTargetList::STATION) {
+      } else if (type == FoxHuntListKind::STATION_TARGETS) {
         const AccessPoint& ap = access_points->get(context_ap);
         const Station& station = stations->get(index);
         wifi_scan_obj.setFoxHuntTarget(station.mac, macToString(station.mac), -128, ap.channel, false);
-      } else if (type == FoxTargetList::BLE_DEVICE) {
+      } else if (type == FoxHuntListKind::BLE_TARGETS) {
         const BleDevice& device = ble_devices->get(index);
         wifi_scan_obj.setFoxHuntTarget(device.mac, device.name, device.rssi, 0, true, macToString(device.mac));
-      } else if (type == FoxTargetList::FINDMY) {
+      } else if (type == FoxHuntListKind::FINDMY_TARGETS) {
         uint8_t mac[6];
         convertMacStringToUint8(airtags->get(index).mac, mac);
         wifi_scan_obj.setFoxHuntTarget(mac, airtags->get(index).mac, airtags->get(index).rssi, 0, true, airtags->get(index).mac);
-      } else if (type == FoxTargetList::FLIPPER) {
+      } else if (type == FoxHuntListKind::FLIPPER_TARGETS) {
         uint8_t mac[6];
         convertMacStringToUint8(flippers->get(index).mac, mac);
         String name = flippers->get(index).name.length() ? flippers->get(index).name : flippers->get(index).mac;
@@ -1757,7 +1757,7 @@ void MenuFunctions::buildFoxTargetList(FoxTargetList type, int context_ap) {
       }
       display_obj.clearScreen();
       this->drawStatusBar();
-      wifi_scan_obj.StartScan(type == FoxTargetList::BLE_DEVICE || type == FoxTargetList::FINDMY || type == FoxTargetList::FLIPPER ? BT_SCAN_FOX_HUNT : WIFI_SCAN_SIG_STREN, TFT_CYAN);
+      wifi_scan_obj.StartScan(type == FoxHuntListKind::BLE_TARGETS || type == FoxHuntListKind::FINDMY_TARGETS || type == FoxHuntListKind::FLIPPER_TARGETS ? BT_SCAN_FOX_HUNT : WIFI_SCAN_SIG_STREN, TFT_CYAN);
     });
   }
   this->changeMenu(menu, true);
@@ -1767,10 +1767,10 @@ void MenuFunctions::buildWiFiFoxHuntMenu() {
   foxHuntMenu.list->clear();
   foxHuntMenu.parentMenu = &wifiSnifferMenu;
   this->addNodes(&foxHuntMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(foxHuntMenu.parentMenu, true); });
-  this->addNodes(&foxHuntMenu, "APs", TFTLIME, WIFI, [this]() { buildFoxTargetList(FoxTargetList::WIFI_AP); });
-  this->addNodes(&foxHuntMenu, "Stations", TFTMAGENTA, WIFI, [this]() { buildFoxTargetList(FoxTargetList::STATION_AP); });
-  this->addNodes(&foxHuntMenu, "WiFi Pineapples", TFTYELLOW, PINESCAN_SNIFF, [this]() { buildFoxTargetList(FoxTargetList::PINEAPPLE); });
-  this->addNodes(&foxHuntMenu, "MultiSSID", TFTORANGE, MULTISSID_SNIFF, [this]() { buildFoxTargetList(FoxTargetList::MULTISSID); });
+  this->addNodes(&foxHuntMenu, "APs", TFTLIME, WIFI, [this]() { buildFoxTargetList(FoxHuntListKind::AP_TARGETS); });
+  this->addNodes(&foxHuntMenu, "Stations", TFTMAGENTA, WIFI, [this]() { buildFoxTargetList(FoxHuntListKind::APS_WITH_STATIONS); });
+  this->addNodes(&foxHuntMenu, "WiFi Pineapples", TFTYELLOW, PINESCAN_SNIFF, [this]() { buildFoxTargetList(FoxHuntListKind::PINEAPPLE_TARGETS); });
+  this->addNodes(&foxHuntMenu, "MultiSSID", TFTORANGE, MULTISSID_SNIFF, [this]() { buildFoxTargetList(FoxHuntListKind::MULTISSID_TARGETS); });
   this->changeMenu(&foxHuntMenu, true);
 }
 
@@ -1778,9 +1778,9 @@ void MenuFunctions::buildBluetoothFoxHuntMenu() {
   foxHuntMenu.list->clear();
   foxHuntMenu.parentMenu = &bluetoothSnifferMenu;
   this->addNodes(&foxHuntMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(foxHuntMenu.parentMenu, true); });
-  this->addNodes(&foxHuntMenu, "BLE Devices", TFTCYAN, BLUETOOTH, [this]() { buildFoxTargetList(FoxTargetList::BLE_DEVICE); });
-  this->addNodes(&foxHuntMenu, "FindMy", TFTWHITE, BLUETOOTH, [this]() { buildFoxTargetList(FoxTargetList::FINDMY); });
-  this->addNodes(&foxHuntMenu, "Flipper Zero", TFTORANGE, FLIPPER, [this]() { buildFoxTargetList(FoxTargetList::FLIPPER); });
+  this->addNodes(&foxHuntMenu, "BLE Devices", TFTCYAN, BLUETOOTH, [this]() { buildFoxTargetList(FoxHuntListKind::BLE_TARGETS); });
+  this->addNodes(&foxHuntMenu, "FindMy", TFTWHITE, BLUETOOTH, [this]() { buildFoxTargetList(FoxHuntListKind::FINDMY_TARGETS); });
+  this->addNodes(&foxHuntMenu, "Flipper Zero", TFTORANGE, FLIPPER, [this]() { buildFoxTargetList(FoxHuntListKind::FLIPPER_TARGETS); });
   this->changeMenu(&foxHuntMenu, true);
 }
 

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1546,160 +1546,241 @@ bool MenuFunctions::isKeyPressed(char c)
   }
 #endif
 
+const char* MenuFunctions::foxSortLabel() const {
+  switch (fox_sort_mode) {
+    case TargetSortMode::SIGNAL_DESC: return "Signal v";
+    case TargetSortMode::NAME_ASC: return "Name A-Z";
+    case TargetSortMode::CHANNEL_ASC: return "Channel 1-177";
+  }
+  return "Signal v";
+}
+
+const char* MenuFunctions::foxFilterLabel() const {
+  switch (fox_filter_mode) {
+    case TargetFilterMode::ALL: return "All";
+    case TargetFilterMode::RECENT_30S: return "Seen <30s";
+    case TargetFilterMode::BAND_24_GHZ: return "2.4 GHz";
+    case TargetFilterMode::BAND_5_GHZ: return "5 GHz";
+  }
+  return "All";
+}
+
+bool MenuFunctions::foxListSupportsRecent() const {
+  return fox_target_list == FoxTargetList::WIFI_AP ||
+         fox_target_list == FoxTargetList::STATION_AP ||
+         fox_target_list == FoxTargetList::FINDMY;
+}
+
+bool MenuFunctions::foxListSupportsBand() const {
+  return fox_target_list == FoxTargetList::WIFI_AP ||
+         fox_target_list == FoxTargetList::STATION_AP ||
+         fox_target_list == FoxTargetList::STATION ||
+         fox_target_list == FoxTargetList::PINEAPPLE ||
+         fox_target_list == FoxTargetList::MULTISSID;
+}
+
+void MenuFunctions::buildFoxSortMenu() {
+  foxSortMenu.list->clear();
+  foxSortMenu.parentMenu = current_menu;
+  this->addNodes(&foxSortMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(foxSortMenu.parentMenu, true); });
+  this->addNodes(&foxSortMenu, "Signal: Strongest", TFTCYAN, 255, [this]() {
+    fox_sort_mode = TargetSortMode::SIGNAL_DESC;
+    buildFoxTargetList(fox_target_list, fox_target_context_ap);
+  });
+  this->addNodes(&foxSortMenu, "Name/MAC: A-Z", TFTCYAN, 255, [this]() {
+    fox_sort_mode = TargetSortMode::NAME_ASC;
+    buildFoxTargetList(fox_target_list, fox_target_context_ap);
+  });
+  if (foxListSupportsBand()) {
+    this->addNodes(&foxSortMenu, "Channel: Low-High", TFTCYAN, 255, [this]() {
+      fox_sort_mode = TargetSortMode::CHANNEL_ASC;
+      buildFoxTargetList(fox_target_list, fox_target_context_ap);
+    });
+  }
+  this->changeMenu(&foxSortMenu, true);
+}
+
+void MenuFunctions::buildFoxFilterMenu() {
+  foxFilterMenu.list->clear();
+  foxFilterMenu.parentMenu = current_menu;
+  this->addNodes(&foxFilterMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(foxFilterMenu.parentMenu, true); });
+  this->addNodes(&foxFilterMenu, "All", TFTGREEN, 255, [this]() {
+    fox_filter_mode = TargetFilterMode::ALL;
+    buildFoxTargetList(fox_target_list, fox_target_context_ap);
+  });
+  if (foxListSupportsRecent()) {
+    this->addNodes(&foxFilterMenu, "Seen in 30 Seconds", TFTGREEN, 255, [this]() {
+      fox_filter_mode = TargetFilterMode::RECENT_30S;
+      buildFoxTargetList(fox_target_list, fox_target_context_ap);
+    });
+  }
+  if (foxListSupportsBand()) {
+    this->addNodes(&foxFilterMenu, "2.4 GHz", TFTGREEN, 255, [this]() {
+      fox_filter_mode = TargetFilterMode::BAND_24_GHZ;
+      buildFoxTargetList(fox_target_list, fox_target_context_ap);
+    });
+    #ifdef HAS_DUAL_BAND
+      this->addNodes(&foxFilterMenu, "5 GHz", TFTGREEN, 255, [this]() {
+        fox_filter_mode = TargetFilterMode::BAND_5_GHZ;
+        buildFoxTargetList(fox_target_list, fox_target_context_ap);
+      });
+    #endif
+  }
+  this->changeMenu(&foxFilterMenu, true);
+}
+
+void MenuFunctions::buildFoxTargetList(FoxTargetList type, int context_ap) {
+  fox_target_list = type;
+  fox_target_context_ap = context_ap;
+  if (!foxListSupportsRecent() && fox_filter_mode == TargetFilterMode::RECENT_30S)
+    fox_filter_mode = TargetFilterMode::ALL;
+  if (!foxListSupportsBand() && (fox_filter_mode == TargetFilterMode::BAND_24_GHZ || fox_filter_mode == TargetFilterMode::BAND_5_GHZ))
+    fox_filter_mode = TargetFilterMode::ALL;
+  if (!foxListSupportsBand() && fox_sort_mode == TargetSortMode::CHANNEL_ASC)
+    fox_sort_mode = TargetSortMode::SIGNAL_DESC;
+
+  Menu* menu = type == FoxTargetList::STATION ? &wifiStationMenu : &wifiAPMenu;
+  menu->list->clear();
+  menu->parentMenu = type == FoxTargetList::STATION ? &wifiAPMenu : &foxHuntMenu;
+  this->addNodes(menu, text09, TFTLIGHTGREY, 0, [this, menu]() { this->changeMenu(menu->parentMenu, true); });
+  String sort_row = "Sort: " + String(foxSortLabel());
+  this->addNodes(menu, sort_row.c_str(), TFTCYAN, 255, [this]() { buildFoxSortMenu(); });
+  String filter_row = "Filter: " + String(foxFilterLabel());
+  this->addNodes(menu, filter_row.c_str(), TFTGREEN, 255, [this]() { buildFoxFilterMenu(); });
+  this->addNodes(menu, "Refresh List", TFTYELLOW, 255, [this]() { buildFoxTargetList(fox_target_list, fox_target_context_ap); });
+
+  std::vector<TargetListItem> items;
+  auto add_item = [&items](size_t index, int16_t rssi, uint8_t channel, uint32_t last_seen, const String& name) {
+    TargetListItem item = {index, rssi, channel, last_seen, {}};
+    strncpy(item.name, name.c_str(), sizeof(item.name) - 1);
+    items.push_back(item);
+  };
+
+  if (type == FoxTargetList::WIFI_AP || type == FoxTargetList::STATION_AP) {
+    for (int i = 0; i < access_points->size(); i++) {
+      const AccessPoint& ap = access_points->get(i);
+      if (type == FoxTargetList::STATION_AP && ap.stations->size() == 0)
+        continue;
+      add_item(i, ap.rssi, ap.channel, ap.last_seen_ms, ap.essid.length() ? ap.essid : macToString(ap.bssid));
+    }
+  } else if (type == FoxTargetList::STATION && context_ap >= 0 && context_ap < access_points->size()) {
+    const AccessPoint& ap = access_points->get(context_ap);
+    for (int x = 0; x < ap.stations->size(); x++) {
+      int station_index = ap.stations->get(x);
+      add_item(station_index, -128, ap.channel, 0, macToString(stations->get(station_index).mac));
+    }
+  } else if (type == FoxTargetList::PINEAPPLE) {
+    for (size_t i = 0; i < wifi_scan_obj.getPineScanCount(); i++)
+      add_item(i, wifi_scan_obj.getPineScanRssi(i), wifi_scan_obj.getPineScanChannel(i), 0, wifi_scan_obj.getPineScanLabel(i));
+  } else if (type == FoxTargetList::MULTISSID) {
+    for (size_t i = 0; i < wifi_scan_obj.getMultiSSIDCount(); i++)
+      add_item(i, wifi_scan_obj.getMultiSSIDRssi(i), wifi_scan_obj.getMultiSSIDChannel(i), 0, wifi_scan_obj.getMultiSSIDLabel(i));
+  } else if (type == FoxTargetList::BLE_DEVICE) {
+    for (int i = 0; i < ble_devices->size(); i++)
+      add_item(i, ble_devices->get(i).rssi, 0, 0, ble_devices->get(i).name.length() ? ble_devices->get(i).name : macToString(ble_devices->get(i).mac));
+  } else if (type == FoxTargetList::FINDMY) {
+    for (int i = 0; i < airtags->size(); i++)
+      add_item(i, airtags->get(i).rssi, 0, airtags->get(i).last_seen, airtags->get(i).mac);
+  } else if (type == FoxTargetList::FLIPPER) {
+    for (int i = 0; i < flippers->size(); i++)
+      add_item(i, -128, 0, 0, flippers->get(i).name.length() ? flippers->get(i).name : flippers->get(i).mac);
+  }
+
+  std::vector<TargetListItem> filtered;
+  uint32_t now = millis();
+  for (const TargetListItem& item : items) {
+    if (targetListItemMatchesFilter(item, fox_filter_mode, now))
+      filtered.push_back(item);
+  }
+  sortTargetList(filtered, fox_sort_mode);
+
+  for (const TargetListItem& item : filtered) {
+    int index = item.source_index;
+    String label;
+    uint16_t color = TFTCYAN;
+    if (type == FoxTargetList::WIFI_AP) {
+      const AccessPoint& ap = access_points->get(index);
+      label = String(ap.rssi) + " " + ap.essid;
+      color = rssiToMenuColor(ap.rssi);
+    } else if (type == FoxTargetList::STATION_AP) {
+      const AccessPoint& ap = access_points->get(index);
+      label = ap.essid + " (" + String(ap.stations->size()) + ")";
+      color = TFTMAGENTA;
+    } else if (type == FoxTargetList::STATION) {
+      label = macToString(stations->get(index).mac);
+      color = TFTMAGENTA;
+    } else if (type == FoxTargetList::PINEAPPLE) {
+      label = wifi_scan_obj.getPineScanLabel(index);
+      color = TFTYELLOW;
+    } else if (type == FoxTargetList::MULTISSID) {
+      label = wifi_scan_obj.getMultiSSIDLabel(index);
+      color = TFTORANGE;
+    } else if (type == FoxTargetList::BLE_DEVICE) {
+      label = String(ble_devices->get(index).rssi) + " " + ble_devices->get(index).name;
+      color = rssiToMenuColor(ble_devices->get(index).rssi);
+    } else if (type == FoxTargetList::FINDMY) {
+      label = String(airtags->get(index).rssi) + " " + airtags->get(index).mac;
+      color = TFTWHITE;
+    } else {
+      label = flippers->get(index).name.length() ? flippers->get(index).name : flippers->get(index).mac;
+      color = TFTORANGE;
+    }
+
+    this->addNodes(menu, label.c_str(), color, 255, [this, type, context_ap, index]() {
+      if (type == FoxTargetList::STATION_AP) {
+        buildFoxTargetList(FoxTargetList::STATION, index);
+        return;
+      }
+      if (type == FoxTargetList::PINEAPPLE) {
+        if (!wifi_scan_obj.selectPineScanFoxTarget(index)) return;
+      } else if (type == FoxTargetList::MULTISSID) {
+        if (!wifi_scan_obj.selectMultiSSIDFoxTarget(index)) return;
+      } else if (type == FoxTargetList::WIFI_AP) {
+        const AccessPoint& ap = access_points->get(index);
+        wifi_scan_obj.setFoxHuntTarget(ap.bssid, ap.essid, ap.rssi, ap.channel, false);
+      } else if (type == FoxTargetList::STATION) {
+        const AccessPoint& ap = access_points->get(context_ap);
+        const Station& station = stations->get(index);
+        wifi_scan_obj.setFoxHuntTarget(station.mac, macToString(station.mac), -128, ap.channel, false);
+      } else if (type == FoxTargetList::BLE_DEVICE) {
+        const BleDevice& device = ble_devices->get(index);
+        wifi_scan_obj.setFoxHuntTarget(device.mac, device.name, device.rssi, 0, true, macToString(device.mac));
+      } else if (type == FoxTargetList::FINDMY) {
+        uint8_t mac[6];
+        convertMacStringToUint8(airtags->get(index).mac, mac);
+        wifi_scan_obj.setFoxHuntTarget(mac, airtags->get(index).mac, airtags->get(index).rssi, 0, true, airtags->get(index).mac);
+      } else if (type == FoxTargetList::FLIPPER) {
+        uint8_t mac[6];
+        convertMacStringToUint8(flippers->get(index).mac, mac);
+        String name = flippers->get(index).name.length() ? flippers->get(index).name : flippers->get(index).mac;
+        wifi_scan_obj.setFoxHuntTarget(mac, name, -128, 0, true, flippers->get(index).mac);
+      }
+      display_obj.clearScreen();
+      this->drawStatusBar();
+      wifi_scan_obj.StartScan(type == FoxTargetList::BLE_DEVICE || type == FoxTargetList::FINDMY || type == FoxTargetList::FLIPPER ? BT_SCAN_FOX_HUNT : WIFI_SCAN_SIG_STREN, TFT_CYAN);
+    });
+  }
+  this->changeMenu(menu, true);
+}
+
 void MenuFunctions::buildWiFiFoxHuntMenu() {
   foxHuntMenu.list->clear();
   foxHuntMenu.parentMenu = &wifiSnifferMenu;
-  this->addNodes(&foxHuntMenu, text09, TFTLIGHTGREY, 0, [this]() {
-    this->changeMenu(foxHuntMenu.parentMenu, true);
-  });
-
-  this->addNodes(&foxHuntMenu, "APs", TFTLIME, WIFI, [this]() {
-    wifiAPMenu.list->clear();
-    wifiAPMenu.parentMenu = &foxHuntMenu;
-    this->addNodes(&wifiAPMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(wifiAPMenu.parentMenu, true); });
-    for (int i = 0; i < access_points->size(); i++) {
-      String label = String(access_points->get(i).rssi) + " " + access_points->get(i).essid;
-      this->addNodes(&wifiAPMenu, label.c_str(), rssiToMenuColor(access_points->get(i).rssi), 255, [this, i]() {
-        const AccessPoint& ap = access_points->get(i);
-        wifi_scan_obj.setFoxHuntTarget(ap.bssid, ap.essid, ap.rssi, ap.channel, false);
-        display_obj.clearScreen();
-        this->drawStatusBar();
-        wifi_scan_obj.StartScan(WIFI_SCAN_SIG_STREN, TFT_CYAN);
-      });
-    }
-    this->changeMenu(&wifiAPMenu, true);
-  });
-
-  this->addNodes(&foxHuntMenu, "Stations", TFTMAGENTA, WIFI, [this]() {
-    wifiAPMenu.list->clear();
-    wifiAPMenu.parentMenu = &foxHuntMenu;
-    this->addNodes(&wifiAPMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(wifiAPMenu.parentMenu, true); });
-    for (int i = 0; i < access_points->size(); i++) {
-      if (access_points->get(i).stations->size() == 0)
-        continue;
-      String label = access_points->get(i).essid + " (" + String(access_points->get(i).stations->size()) + ")";
-      this->addNodes(&wifiAPMenu, label.c_str(), TFTMAGENTA, 255, [this, i]() {
-        wifiStationMenu.list->clear();
-        wifiStationMenu.parentMenu = &wifiAPMenu;
-        this->addNodes(&wifiStationMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(wifiStationMenu.parentMenu, true); });
-        const AccessPoint& ap = access_points->get(i);
-        for (int x = 0; x < ap.stations->size(); x++) {
-          int station_index = ap.stations->get(x);
-          String station_name = macToString(stations->get(station_index).mac);
-          this->addNodes(&wifiStationMenu, station_name.c_str(), TFTMAGENTA, 255, [this, i, station_index]() {
-            const AccessPoint& station_ap = access_points->get(i);
-            const Station& station = stations->get(station_index);
-            String name = macToString(station.mac);
-            wifi_scan_obj.setFoxHuntTarget(station.mac, name, -128, station_ap.channel, false);
-            display_obj.clearScreen();
-            this->drawStatusBar();
-            wifi_scan_obj.StartScan(WIFI_SCAN_SIG_STREN, TFT_CYAN);
-          });
-        }
-        this->changeMenu(&wifiStationMenu, true);
-      });
-    }
-    this->changeMenu(&wifiAPMenu, true);
-  });
-
-  this->addNodes(&foxHuntMenu, "WiFi Pineapples", TFTYELLOW, PINESCAN_SNIFF, [this]() {
-    wifiAPMenu.list->clear();
-    wifiAPMenu.parentMenu = &foxHuntMenu;
-    this->addNodes(&wifiAPMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(wifiAPMenu.parentMenu, true); });
-    for (size_t i = 0; i < wifi_scan_obj.getPineScanCount(); i++) {
-      String label = wifi_scan_obj.getPineScanLabel(i);
-      this->addNodes(&wifiAPMenu, label.c_str(), TFTYELLOW, 255, [this, i]() {
-        if (wifi_scan_obj.selectPineScanFoxTarget(i)) {
-          display_obj.clearScreen();
-          this->drawStatusBar();
-          wifi_scan_obj.StartScan(WIFI_SCAN_SIG_STREN, TFT_CYAN);
-        }
-      });
-    }
-    this->changeMenu(&wifiAPMenu, true);
-  });
-
-  this->addNodes(&foxHuntMenu, "MultiSSID", TFTORANGE, MULTISSID_SNIFF, [this]() {
-    wifiAPMenu.list->clear();
-    wifiAPMenu.parentMenu = &foxHuntMenu;
-    this->addNodes(&wifiAPMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(wifiAPMenu.parentMenu, true); });
-    for (size_t i = 0; i < wifi_scan_obj.getMultiSSIDCount(); i++) {
-      String label = wifi_scan_obj.getMultiSSIDLabel(i);
-      this->addNodes(&wifiAPMenu, label.c_str(), TFTORANGE, 255, [this, i]() {
-        if (wifi_scan_obj.selectMultiSSIDFoxTarget(i)) {
-          display_obj.clearScreen();
-          this->drawStatusBar();
-          wifi_scan_obj.StartScan(WIFI_SCAN_SIG_STREN, TFT_CYAN);
-        }
-      });
-    }
-    this->changeMenu(&wifiAPMenu, true);
-  });
-
+  this->addNodes(&foxHuntMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(foxHuntMenu.parentMenu, true); });
+  this->addNodes(&foxHuntMenu, "APs", TFTLIME, WIFI, [this]() { buildFoxTargetList(FoxTargetList::WIFI_AP); });
+  this->addNodes(&foxHuntMenu, "Stations", TFTMAGENTA, WIFI, [this]() { buildFoxTargetList(FoxTargetList::STATION_AP); });
+  this->addNodes(&foxHuntMenu, "WiFi Pineapples", TFTYELLOW, PINESCAN_SNIFF, [this]() { buildFoxTargetList(FoxTargetList::PINEAPPLE); });
+  this->addNodes(&foxHuntMenu, "MultiSSID", TFTORANGE, MULTISSID_SNIFF, [this]() { buildFoxTargetList(FoxTargetList::MULTISSID); });
   this->changeMenu(&foxHuntMenu, true);
 }
 
 void MenuFunctions::buildBluetoothFoxHuntMenu() {
   foxHuntMenu.list->clear();
   foxHuntMenu.parentMenu = &bluetoothSnifferMenu;
-  this->addNodes(&foxHuntMenu, text09, TFTLIGHTGREY, 0, [this]() {
-    this->changeMenu(foxHuntMenu.parentMenu, true);
-  });
-
-  this->addNodes(&foxHuntMenu, "BLE Devices", TFTCYAN, BLUETOOTH, [this]() {
-    wifiAPMenu.list->clear();
-    wifiAPMenu.parentMenu = &foxHuntMenu;
-    this->addNodes(&wifiAPMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(wifiAPMenu.parentMenu, true); });
-    for (int i = 0; i < ble_devices->size(); i++) {
-      String label = String(ble_devices->get(i).rssi) + " " + ble_devices->get(i).name;
-      this->addNodes(&wifiAPMenu, label.c_str(), rssiToMenuColor(ble_devices->get(i).rssi), 255, [this, i]() {
-        const BleDevice& device = ble_devices->get(i);
-        wifi_scan_obj.setFoxHuntTarget(device.mac, device.name, device.rssi, 0, true, macToString(device.mac));
-        display_obj.clearScreen();
-        this->drawStatusBar();
-        wifi_scan_obj.StartScan(BT_SCAN_FOX_HUNT, TFT_CYAN);
-      });
-    }
-    this->changeMenu(&wifiAPMenu, true);
-  });
-
-  this->addNodes(&foxHuntMenu, "FindMy", TFTWHITE, BLUETOOTH, [this]() {
-    wifiAPMenu.list->clear();
-    wifiAPMenu.parentMenu = &foxHuntMenu;
-    this->addNodes(&wifiAPMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(wifiAPMenu.parentMenu, true); });
-    for (int i = 0; i < airtags->size(); i++) {
-      String label = String(airtags->get(i).rssi) + " " + airtags->get(i).mac;
-      this->addNodes(&wifiAPMenu, label.c_str(), rssiToMenuColor(airtags->get(i).rssi), 255, [this, i]() {
-        uint8_t mac[6];
-        convertMacStringToUint8(airtags->get(i).mac, mac);
-        wifi_scan_obj.setFoxHuntTarget(mac, airtags->get(i).mac, airtags->get(i).rssi, 0, true, airtags->get(i).mac);
-        display_obj.clearScreen();
-        this->drawStatusBar();
-        wifi_scan_obj.StartScan(BT_SCAN_FOX_HUNT, TFT_CYAN);
-      });
-    }
-    this->changeMenu(&wifiAPMenu, true);
-  });
-
-  this->addNodes(&foxHuntMenu, "Flipper Zero", TFTORANGE, FLIPPER, [this]() {
-    wifiAPMenu.list->clear();
-    wifiAPMenu.parentMenu = &foxHuntMenu;
-    this->addNodes(&wifiAPMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(wifiAPMenu.parentMenu, true); });
-    for (int i = 0; i < flippers->size(); i++) {
-      String label = flippers->get(i).name.length() ? flippers->get(i).name : flippers->get(i).mac;
-      this->addNodes(&wifiAPMenu, label.c_str(), TFTORANGE, 255, [this, i]() {
-        uint8_t mac[6];
-        convertMacStringToUint8(flippers->get(i).mac, mac);
-        String name = flippers->get(i).name.length() ? flippers->get(i).name : flippers->get(i).mac;
-        wifi_scan_obj.setFoxHuntTarget(mac, name, -128, 0, true, flippers->get(i).mac);
-        display_obj.clearScreen();
-        this->drawStatusBar();
-        wifi_scan_obj.StartScan(BT_SCAN_FOX_HUNT, TFT_CYAN);
-      });
-    }
-    this->changeMenu(&wifiAPMenu, true);
-  });
-
+  this->addNodes(&foxHuntMenu, text09, TFTLIGHTGREY, 0, [this]() { this->changeMenu(foxHuntMenu.parentMenu, true); });
+  this->addNodes(&foxHuntMenu, "BLE Devices", TFTCYAN, BLUETOOTH, [this]() { buildFoxTargetList(FoxTargetList::BLE_DEVICE); });
+  this->addNodes(&foxHuntMenu, "FindMy", TFTWHITE, BLUETOOTH, [this]() { buildFoxTargetList(FoxTargetList::FINDMY); });
+  this->addNodes(&foxHuntMenu, "Flipper Zero", TFTORANGE, FLIPPER, [this]() { buildFoxTargetList(FoxTargetList::FLIPPER); });
   this->changeMenu(&foxHuntMenu, true);
 }
 
@@ -1757,6 +1838,8 @@ void MenuFunctions::RunSetup()
   setMacMenu.list = new LinkedList<MenuNode>();
   genAPMacMenu.list = new LinkedList<MenuNode>();
   wifiStationMenu.list = new LinkedList<MenuNode>();
+  foxSortMenu.list = new LinkedList<MenuNode>();
+  foxFilterMenu.list = new LinkedList<MenuNode>();
   selectProbeSSIDsMenu.list = new LinkedList<MenuNode>();
 
   // WiFi HTML menu stuff

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -130,15 +130,15 @@ class MenuFunctions
 {
   private:
 
-    enum class FoxTargetList : uint8_t {
-      WIFI_AP,
-      STATION_AP,
-      STATION,
-      PINEAPPLE,
-      MULTISSID,
-      BLE_DEVICE,
-      FINDMY,
-      FLIPPER,
+    enum class FoxHuntListKind : uint8_t {
+      AP_TARGETS,
+      APS_WITH_STATIONS,
+      STATION_TARGETS,
+      PINEAPPLE_TARGETS,
+      MULTISSID_TARGETS,
+      BLE_TARGETS,
+      FINDMY_TARGETS,
+      FLIPPER_TARGETS,
     };
 
     String u_result = "";
@@ -153,7 +153,7 @@ class MenuFunctions
 
     void buildWiFiFoxHuntMenu();
     void buildBluetoothFoxHuntMenu();
-    void buildFoxTargetList(FoxTargetList type, int context_ap = -1);
+    void buildFoxTargetList(FoxHuntListKind type, int context_ap = -1);
     void buildFoxSortMenu();
     void buildFoxFilterMenu();
     const char* foxSortLabel() const;
@@ -161,7 +161,7 @@ class MenuFunctions
     bool foxListSupportsRecent() const;
     bool foxListSupportsBand() const;
 
-    FoxTargetList fox_target_list = FoxTargetList::WIFI_AP;
+    FoxHuntListKind fox_target_list = FoxHuntListKind::AP_TARGETS;
     int fox_target_context_ap = -1;
     TargetSortMode fox_sort_mode = TargetSortMode::SIGNAL_DESC;
     TargetFilterMode fox_filter_mode = TargetFilterMode::ALL;

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -18,6 +18,7 @@
 #define BATTERY_ANALOG_ON 0
 
 #include "WiFiScan.h"
+#include "TargetListSort.h"
 #include "BatteryInterface.h"
 #include "SDInterface.h"
 #include "settings.h"
@@ -129,6 +130,17 @@ class MenuFunctions
 {
   private:
 
+    enum class FoxTargetList : uint8_t {
+      WIFI_AP,
+      STATION_AP,
+      STATION,
+      PINEAPPLE,
+      MULTISSID,
+      BLE_DEVICE,
+      FINDMY,
+      FLIPPER,
+    };
+
     String u_result = "";
 
 
@@ -141,6 +153,18 @@ class MenuFunctions
 
     void buildWiFiFoxHuntMenu();
     void buildBluetoothFoxHuntMenu();
+    void buildFoxTargetList(FoxTargetList type, int context_ap = -1);
+    void buildFoxSortMenu();
+    void buildFoxFilterMenu();
+    const char* foxSortLabel() const;
+    const char* foxFilterLabel() const;
+    bool foxListSupportsRecent() const;
+    bool foxListSupportsBand() const;
+
+    FoxTargetList fox_target_list = FoxTargetList::WIFI_AP;
+    int fox_target_context_ap = -1;
+    TargetSortMode fox_sort_mode = TargetSortMode::SIGNAL_DESC;
+    TargetFilterMode fox_filter_mode = TargetFilterMode::ALL;
 
     // Main menu stuff
     Menu mainMenu;
@@ -200,6 +224,8 @@ class MenuFunctions
     Menu evilPortalMenu;
 
     Menu foxHuntMenu;
+    Menu foxSortMenu;
+    Menu foxFilterMenu;
 
     #ifdef HAS_DIRECT_UPLOAD
       Menu deleteAllMenu;

--- a/esp32_marauder/TargetListSort.cpp
+++ b/esp32_marauder/TargetListSort.cpp
@@ -1,0 +1,47 @@
+#include "TargetListSort.h"
+
+#include <algorithm>
+#include <ctype.h>
+#include <string.h>
+
+namespace {
+int caseInsensitiveCompare(const char* left, const char* right) {
+  while (*left && *right) {
+    int a = tolower((unsigned char)*left++);
+    int b = tolower((unsigned char)*right++);
+    if (a != b)
+      return a - b;
+  }
+  return (unsigned char)*left - (unsigned char)*right;
+}
+}  // namespace
+
+bool targetListItemMatchesFilter(const TargetListItem& item, TargetFilterMode filter,
+                                 uint32_t now_ms) {
+  switch (filter) {
+    case TargetFilterMode::ALL:
+      return true;
+    case TargetFilterMode::RECENT_30S:
+      return item.last_seen_ms != 0 && (uint32_t)(now_ms - item.last_seen_ms) <= 30000;
+    case TargetFilterMode::BAND_24_GHZ:
+      return item.channel >= 1 && item.channel <= 14;
+    case TargetFilterMode::BAND_5_GHZ:
+      return item.channel > 14;
+  }
+  return true;
+}
+
+void sortTargetList(std::vector<TargetListItem>& items, TargetSortMode mode) {
+  std::stable_sort(items.begin(), items.end(), [mode](const TargetListItem& a, const TargetListItem& b) {
+    switch (mode) {
+      case TargetSortMode::SIGNAL_DESC:
+        return a.rssi != b.rssi ? a.rssi > b.rssi : caseInsensitiveCompare(a.name, b.name) < 0;
+      case TargetSortMode::NAME_ASC:
+        return caseInsensitiveCompare(a.name, b.name) < 0;
+      case TargetSortMode::CHANNEL_ASC:
+        return a.channel != b.channel ? a.channel < b.channel : caseInsensitiveCompare(a.name, b.name) < 0;
+    }
+    return false;
+  });
+}
+

--- a/esp32_marauder/TargetListSort.h
+++ b/esp32_marauder/TargetListSort.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <vector>
+
+enum class TargetSortMode : uint8_t {
+  SIGNAL_DESC,
+  NAME_ASC,
+  CHANNEL_ASC,
+};
+
+enum class TargetFilterMode : uint8_t {
+  ALL,
+  RECENT_30S,
+  BAND_24_GHZ,
+  BAND_5_GHZ,
+};
+
+struct TargetListItem {
+  size_t source_index;
+  int16_t rssi;
+  uint8_t channel;
+  uint32_t last_seen_ms;
+  char name[40];
+};
+
+bool targetListItemMatchesFilter(const TargetListItem& item, TargetFilterMode filter,
+                                 uint32_t now_ms);
+void sortTargetList(std::vector<TargetListItem>& items, TargetSortMode mode);
+

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -11439,6 +11439,14 @@ String WiFiScan::getPineScanLabel(size_t index) const {
   return String(target.rssi) + " " + target.essid;
 }
 
+int8_t WiFiScan::getPineScanRssi(size_t index) const {
+  return index < this->confirmed_pinescan->size() ? this->confirmed_pinescan->get(index).rssi : -128;
+}
+
+uint8_t WiFiScan::getPineScanChannel(size_t index) const {
+  return index < this->confirmed_pinescan->size() ? this->confirmed_pinescan->get(index).channel : 0;
+}
+
 bool WiFiScan::selectPineScanFoxTarget(size_t index) {
   if (index >= this->confirmed_pinescan->size())
     return false;
@@ -11456,6 +11464,14 @@ String WiFiScan::getMultiSSIDLabel(size_t index) const {
     return "";
   const ConfirmedMultiSSID& target = this->confirmed_multissid->get(index);
   return String(target.rssi) + " " + target.essid;
+}
+
+int8_t WiFiScan::getMultiSSIDRssi(size_t index) const {
+  return index < this->confirmed_multissid->size() ? this->confirmed_multissid->get(index).rssi : -128;
+}
+
+uint8_t WiFiScan::getMultiSSIDChannel(size_t index) const {
+  return index < this->confirmed_multissid->size() ? this->confirmed_multissid->get(index).channel : 0;
 }
 
 bool WiFiScan::selectMultiSSIDFoxTarget(size_t index) {

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -997,9 +997,13 @@ class WiFiScan
     bool updateBluetoothFoxHuntRssi(const uint8_t mac[6], const String& advertised_address, int8_t rssi);
     size_t getPineScanCount() const;
     String getPineScanLabel(size_t index) const;
+    int8_t getPineScanRssi(size_t index) const;
+    uint8_t getPineScanChannel(size_t index) const;
     bool selectPineScanFoxTarget(size_t index);
     size_t getMultiSSIDCount() const;
     String getMultiSSIDLabel(size_t index) const;
+    int8_t getMultiSSIDRssi(size_t index) const;
+    uint8_t getMultiSSIDChannel(size_t index) const;
     bool selectMultiSSIDFoxTarget(size_t index);
     uint32_t getCompleteEapol(int check_index = -1);
     void drawChannelLine();

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,7 @@ build_src_filter =
   +<BeaconFrame.cpp>
   +<WdgResponse.cpp>
   +<FoxHuntTarget.cpp>
+  +<TargetListSort.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/test_target_list_sort/test_main.cpp
+++ b/test/test_target_list_sort/test_main.cpp
@@ -1,0 +1,51 @@
+#include <unity.h>
+
+#include <string.h>
+#include <vector>
+
+#include "TargetListSort.h"
+
+static TargetListItem item(size_t index, int rssi, uint8_t channel, uint32_t seen, const char* name) {
+  TargetListItem value = {index, (int16_t)rssi, channel, seen, {}};
+  strncpy(value.name, name, sizeof(value.name) - 1);
+  return value;
+}
+
+void test_signal_sort_is_strongest_first_and_stable() {
+  std::vector<TargetListItem> values = {item(0, -70, 6, 1, "Zulu"), item(1, -40, 1, 1, "Beta"), item(2, -40, 11, 1, "Alpha")};
+  sortTargetList(values, TargetSortMode::SIGNAL_DESC);
+  TEST_ASSERT_EQUAL_UINT16(2, values[0].source_index);
+  TEST_ASSERT_EQUAL_UINT16(1, values[1].source_index);
+  TEST_ASSERT_EQUAL_UINT16(0, values[2].source_index);
+}
+
+void test_name_sort_is_case_insensitive() {
+  std::vector<TargetListItem> values = {item(0, -1, 1, 1, "zulu"), item(1, -1, 1, 1, "Alpha")};
+  sortTargetList(values, TargetSortMode::NAME_ASC);
+  TEST_ASSERT_EQUAL_UINT16(1, values[0].source_index);
+}
+
+void test_channel_sort_groups_low_to_high() {
+  std::vector<TargetListItem> values = {item(0, -1, 149, 1, "A"), item(1, -1, 6, 1, "B")};
+  sortTargetList(values, TargetSortMode::CHANNEL_ASC);
+  TEST_ASSERT_EQUAL_UINT16(1, values[0].source_index);
+}
+
+void test_filters_handle_recency_rollover_and_bands() {
+  TargetListItem recent = item(0, -1, 6, 0xfffffff0u, "A");
+  TEST_ASSERT_TRUE(targetListItemMatchesFilter(recent, TargetFilterMode::RECENT_30S, 0x20u));
+  TEST_ASSERT_TRUE(targetListItemMatchesFilter(recent, TargetFilterMode::BAND_24_GHZ, 0));
+  TEST_ASSERT_FALSE(targetListItemMatchesFilter(recent, TargetFilterMode::BAND_5_GHZ, 0));
+  TargetListItem five = item(1, -1, 149, 1, "B");
+  TEST_ASSERT_TRUE(targetListItemMatchesFilter(five, TargetFilterMode::BAND_5_GHZ, 0));
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_signal_sort_is_strongest_first_and_stable);
+  RUN_TEST(test_name_sort_is_case_insensitive);
+  RUN_TEST(test_channel_sort_groups_low_to_high);
+  RUN_TEST(test_filters_handle_recency_rollover_and_bands);
+  return UNITY_END();
+}
+


### PR DESCRIPTION
## Summary
- add Sort, Filter, and Refresh controls to every fox-hunt target list
- support strongest-signal, name/MAC, and channel ordering where applicable
- support recent-30-second and 2.4/5 GHz filters where the target data supports them
- preserve a stable snapshot while navigating so live RSSI changes do not move the selected row
- retain the existing AP-filtered station selection and fox-hunt launch behavior

## Lists covered
- WiFi APs
- APs containing stations and their station lists
- WiFi Pineapples
- MultiSSID targets
- BLE devices
- FindMy devices
- Flipper Zero devices

## Validation
- native Unity: 43/43 passed
- target-list tests cover signal/name/channel ordering, recency rollover, and band filters
- `git diff --check`: passed

This PR is intentionally left open and unmerged for hardware testing.