### PR TITLE
fix: colorama Fore/Style NameError in c5_flasher.py

### DIFF
--- a/C5_Py_Flasher_for_adapter/c5_flasher.py
+++ b/C5_Py_Flasher_for_adapter/c5_flasher.py
@@ -28,6 +28,7 @@ try:
     from colorama import Fore, Style
 except ImportError:
     ensure_package('colorama')
+    from colorama import Fore, Style
 
 # Dependency check and install if needed
 REQUIRED_PACKAGES = [


### PR DESCRIPTION
## Summary
- `c5_flasher.py` imports `Fore`/`Style` from `colorama` inside a try/except that auto-installs the package on `ImportError`, but the except block never re-imports the names afterward
- On a fresh environment without colorama pre-installed, this causes `NameError: name 'Fore' is not defined` on the first colored print in `main()`

## Test plan
- [x] Ran `c5_flasher.py` in a fresh virtualenv without colorama installed; script now installs colorama and proceeds past the logo/splash print without error