### PR TITLE
Bump firmware version to v1.15.0

### DIFF
--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -41,7 +41,7 @@
 
   #define JSON_SETTING_SIZE 2048
 
-#define MARAUDER_VERSION "v1.14.3"
+#define MARAUDER_VERSION "v1.15.0"
 
   #define GRAPH_REFRESH   100
 


### PR DESCRIPTION
- Update `MARAUDER_VERSION` to `v1.15.0`.
- No functional firmware changes.