### PR TITLE
Fix IP scanner subnet range iteration

### DIFF
--- a/.github/workflows/build_installer_manifests.yml
+++ b/.github/workflows/build_installer_manifests.yml
@@ -235,6 +235,10 @@ jobs:
             done
           fi
 
+      - name: Configure LilyGo T-Dongle C5 partition table
+        if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'
+        run: cp installer/partitions/t_dongle_c5.csv esp32_marauder/partitions.csv
+
       - name: Build Marauder for ${{ matrix.board.name }}
         uses: ArminJo/arduino-test-compile@v3.3.0
         with:

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -244,6 +244,10 @@ jobs:
             sed -i 's/^\/\/#include <${{ matrix.board.tft_file }}>/#include <${{ matrix.board.tft_file }}>/' /home/runner/work/ESP32Marauder/ESP32Marauder/CustomTFT_eSPI/User_Setup_Select.h
           fi
 
+      - name: Configure LilyGo T-Dongle C5 partition table
+        if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'
+        run: cp installer/partitions/t_dongle_c5.csv esp32_marauder/partitions.csv
+
       - name: Build Marauder for ${{ matrix.board.name }}
         uses: ArminJo/arduino-test-compile@v3.3.0
         with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -297,6 +297,10 @@ jobs:
             sed -i 's/^\/\/#include <${{ matrix.board.tft_file }}>/#include <${{ matrix.board.tft_file }}>/' /home/runner/work/ESP32Marauder/ESP32Marauder/CustomTFT_eSPI/User_Setup_Select.h
           fi
 
+      - name: Configure LilyGo T-Dongle C5 partition table
+        if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'
+        run: cp installer/partitions/t_dongle_c5.csv esp32_marauder/partitions.csv
+
       - name: Build Marauder for ${{ matrix.board.name }}
         uses: ArminJo/arduino-test-compile@v3.3.0
         with:

--- a/esp32_marauder/IPv4Range.cpp
+++ b/esp32_marauder/IPv4Range.cpp
@@ -1,0 +1,43 @@
+#include "IPv4Range.h"
+
+namespace marauder {
+
+namespace {
+
+bool isContiguousMask(uint32_t mask) {
+  const uint32_t inverted = ~mask;
+  return (inverted & (inverted + 1U)) == 0U;
+}
+
+}  // namespace
+
+IPv4HostRange ipv4HostRange(uint32_t address, uint32_t subnetMask) {
+  const uint32_t network = address & subnetMask;
+  const uint32_t broadcast = network | ~subnetMask;
+  const bool valid = isContiguousMask(subnetMask) &&
+                     (broadcast - network) >= 2U;
+
+  return {network, broadcast, valid ? network + 1U : 0U,
+          valid ? broadcast - 1U : 0U, valid};
+}
+
+uint32_t nextIPv4Host(uint32_t current, const IPv4HostRange& range) {
+  if (!range.valid || current >= range.last) {
+    return 0U;
+  }
+  if (current < range.first) {
+    return range.first;
+  }
+  return current + 1U;
+}
+
+uint32_t previousIPv4Host(uint32_t current, uint32_t steps,
+                          const IPv4HostRange& range) {
+  if (!range.valid || current < range.first || current > range.last ||
+      steps > current - range.first) {
+    return 0U;
+  }
+  return current - steps;
+}
+
+}  // namespace marauder

--- a/esp32_marauder/IPv4Range.h
+++ b/esp32_marauder/IPv4Range.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+
+namespace marauder {
+
+struct IPv4HostRange {
+  uint32_t network;
+  uint32_t broadcast;
+  uint32_t first;
+  uint32_t last;
+  bool valid;
+};
+
+IPv4HostRange ipv4HostRange(uint32_t address, uint32_t subnetMask);
+uint32_t nextIPv4Host(uint32_t current, const IPv4HostRange& range);
+uint32_t previousIPv4Host(uint32_t current, uint32_t steps,
+                          const IPv4HostRange& range);
+
+}  // namespace marauder

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -3363,7 +3363,8 @@ void WiFiScan::RunPingScan(uint8_t scan_mode, uint16_t color) {
     #endif
     this->prepareScanStage(TFT_RED, TFT_BLACK);
   #endif
-  this->current_scan_ip = this->gateway;
+  this->current_scan_ip = getNetworkIP(this->ip_addr, this->subnet);
+  this->last_scan_ip = IPAddress(0, 0, 0, 0);
   //Serial.print(F("Cleared IPs: "));
   this->clearList(CLEAR_IPS);
   if (scan_mode == WIFI_PING_SCAN)
@@ -3442,8 +3443,10 @@ void WiFiScan::RunPortScanAll(uint8_t scan_mode, uint16_t color) {
       (scan_mode == WIFI_SCAN_DNS) ||
       (scan_mode == WIFI_SCAN_HTTP) ||
       (scan_mode == WIFI_SCAN_HTTPS) ||
-      (scan_mode == WIFI_SCAN_RDP))
-    this->current_scan_ip = this->gateway;
+      (scan_mode == WIFI_SCAN_RDP)) {
+    this->current_scan_ip = getNetworkIP(this->ip_addr, this->subnet);
+    this->last_scan_ip = IPAddress(0, 0, 0, 0);
+  }
 
   Serial.println(F("Starting Port Scan with..."));
   this->showNetworkInfo();
@@ -10468,6 +10471,18 @@ bool WiFiScan::checkHostPort(IPAddress ip, uint16_t port, uint16_t timeout) {
   return false;
 }
 
+IPAddress WiFiScan::advanceScanIP() {
+  do {
+    this->current_scan_ip = getNextIP(this->current_scan_ip, this->subnet);
+  } while ((this->current_scan_ip != IPAddress(0, 0, 0, 0)) &&
+           (this->current_scan_ip == this->ip_addr));
+
+  if (this->current_scan_ip != IPAddress(0, 0, 0, 0)) {
+    this->last_scan_ip = this->current_scan_ip;
+  }
+  return this->current_scan_ip;
+}
+
 #ifndef HAS_IDF_3
   bool WiFiScan::readARP(IPAddress targ_ip) {
     // Convert IPAddress to ip4_addr_t using IP4_ADDR
@@ -10537,7 +10552,8 @@ bool WiFiScan::checkHostPort(IPAddress ip, uint16_t port, uint16_t timeout) {
 
     //this->arp_count = 0;
 
-    if (this->current_scan_ip != IPAddress(0, 0, 0, 0)) {
+    if (this->current_scan_ip != IPAddress(0, 0, 0, 0) &&
+        this->advanceScanIP() != IPAddress(0, 0, 0, 0)) {
       ip4_addr_t lwip_ip;
       IP4_ADDR(&lwip_ip,
               this->current_scan_ip[0],
@@ -10549,8 +10565,6 @@ bool WiFiScan::checkHostPort(IPAddress ip, uint16_t port, uint16_t timeout) {
 
       delay(100);
 
-      this->current_scan_ip = getNextIP(this->current_scan_ip, this->subnet);
-
       this->arp_count++;
 
       if (this->arp_count >= 10) {
@@ -10558,7 +10572,7 @@ bool WiFiScan::checkHostPort(IPAddress ip, uint16_t port, uint16_t timeout) {
 
         this->arp_count = 0;
 
-        for (int i = 10; i > 0; i--) {
+        for (int i = 9; i >= 0; i--) {
           IPAddress check_ip = getPrevIP(this->current_scan_ip, this->subnet, i);
           display_string = "";
           output_line = "";
@@ -10586,7 +10600,7 @@ bool WiFiScan::checkHostPort(IPAddress ip, uint16_t port, uint16_t timeout) {
       for (int i = this->arp_count; i > 0; i--) {
         delay(250);
 
-        IPAddress check_ip = getPrevIP(this->current_scan_ip, this->subnet, i);
+        IPAddress check_ip = getPrevIP(this->last_scan_ip, this->subnet, i - 1);
         display_string = "";
         output_line = "";
         if (this->readARP(check_ip)) {
@@ -10622,10 +10636,11 @@ void WiFiScan::pingScan(uint8_t scan_mode) {
 
   if (scan_mode == WIFI_PING_SCAN) {
     if (this->current_scan_ip != IPAddress(0, 0, 0, 0)) {
-      this->current_scan_ip = getNextIP(this->current_scan_ip, this->subnet);
+      this->advanceScanIP();
       
       // Check if IP is alive
-      if (this->isHostAlive(this->current_scan_ip)) {
+      if ((this->current_scan_ip != IPAddress(0, 0, 0, 0)) &&
+          this->isHostAlive(this->current_scan_ip)) {
         output_line = this->current_scan_ip.toString();
         display_string.concat(output_line);
         uint8_t temp_len = display_string.length();
@@ -10668,7 +10683,10 @@ void WiFiScan::pingScan(uint8_t scan_mode) {
       targ_port = 3389;
 
     if (this->current_scan_ip != IPAddress(0, 0, 0, 0)) {
-      this->current_scan_ip = getNextIP(this->current_scan_ip, this->subnet);
+      this->advanceScanIP();
+      if (this->current_scan_ip == IPAddress(0, 0, 0, 0)) {
+        return;
+      }
       #ifndef HAS_IDF_3
         if (this->singleARP(this->current_scan_ip)) {
       #else

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -716,6 +716,7 @@ class WiFiScan
     bool singleARP(IPAddress ip_addr);
     void pingScan(uint8_t scan_mode = WIFI_PING_SCAN);
     void portScan(uint8_t scan_mode = WIFI_PORT_SCAN_ALL, uint16_t targ_port = 22);
+    IPAddress advanceScanIP();
     bool isHostAlive(IPAddress ip);
     bool checkHostPort(IPAddress ip, uint16_t port, uint16_t timeout = 100);
     String extractManufacturer(const uint8_t* payload);
@@ -930,6 +931,7 @@ class WiFiScan
     IPAddress subnet;
 
     IPAddress current_scan_ip;
+    IPAddress last_scan_ip;
 
     uint16_t current_scan_port = 1;
 

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -42,7 +42,7 @@
 
   #define JSON_SETTING_SIZE 2048
 
-#define MARAUDER_VERSION "v1.15.0"
+#define MARAUDER_VERSION "v1.15.1"
 
   #define GRAPH_REFRESH   100
 

--- a/esp32_marauder/utils.h
+++ b/esp32_marauder/utils.h
@@ -7,6 +7,7 @@
 #include <WiFi.h>
 
 #include "configs.h"
+#include "IPv4Range.h"
 #include "MarauderMacAddress.h"
 
 #include "esp_heap_caps.h"
@@ -193,52 +194,45 @@ inline void convertMacStringToUint8(const String& macStr, uint8_t macAddr[6]) {
 }
 
 
-inline IPAddress getNextIP(IPAddress currentIP, IPAddress subnetMask) {
-  // Convert IPAddress to uint32_t
-  uint32_t ipInt = (currentIP[0] << 24) | (currentIP[1] << 16) | (currentIP[2] << 8) | currentIP[3];
-  uint32_t maskInt = (subnetMask[0] << 24) | (subnetMask[1] << 16) | (subnetMask[2] << 8) | subnetMask[3];
+inline uint32_t ipAddressToUint32(const IPAddress& address) {
+  return (static_cast<uint32_t>(address[0]) << 24) |
+         (static_cast<uint32_t>(address[1]) << 16) |
+         (static_cast<uint32_t>(address[2]) << 8) |
+         static_cast<uint32_t>(address[3]);
+}
 
-  uint32_t networkBase = ipInt & maskInt;
-  uint32_t broadcast = networkBase | ~maskInt;
-
-  uint32_t nextIP = ipInt + 1;
-
-  if (nextIP <= networkBase) {
-    nextIP = networkBase + 1;
-  }
-  if (nextIP >= broadcast) {
-    return IPAddress(0, 0, 0, 0); // no more IPs
-  }
-
+inline IPAddress uint32ToIPAddress(uint32_t address) {
   return IPAddress(
-    (nextIP >> 24) & 0xFF,
-    (nextIP >> 16) & 0xFF,
-    (nextIP >> 8) & 0xFF,
-    nextIP & 0xFF
+    (address >> 24) & 0xFF,
+    (address >> 16) & 0xFF,
+    (address >> 8) & 0xFF,
+    address & 0xFF
   );
 }
 
-inline IPAddress getPrevIP(IPAddress currentIP, IPAddress subnetMask, uint16_t stepsBack) {
-  // Convert IPAddress to uint32_t
-  uint32_t ipInt = (currentIP[0] << 24) | (currentIP[1] << 16) | (currentIP[2] << 8) | currentIP[3];
-  uint32_t maskInt = (subnetMask[0] << 24) | (subnetMask[1] << 16) | (subnetMask[2] << 8) | subnetMask[3];
+inline marauder::IPv4HostRange getIPHostRange(const IPAddress& address,
+                                               const IPAddress& subnetMask) {
+  return marauder::ipv4HostRange(ipAddressToUint32(address),
+                                 ipAddressToUint32(subnetMask));
+}
 
-  uint32_t networkBase = ipInt & maskInt;
-  uint32_t broadcast = networkBase | ~maskInt;
+inline IPAddress getNetworkIP(const IPAddress& address,
+                              const IPAddress& subnetMask) {
+  return uint32ToIPAddress(getIPHostRange(address, subnetMask).network);
+}
 
-  uint32_t prevIP = ipInt - stepsBack;
+inline IPAddress getNextIP(const IPAddress& currentIP,
+                           const IPAddress& subnetMask) {
+  const marauder::IPv4HostRange range = getIPHostRange(currentIP, subnetMask);
+  return uint32ToIPAddress(
+      marauder::nextIPv4Host(ipAddressToUint32(currentIP), range));
+}
 
-  // Ensure prevIP is not below the usable range
-  if (prevIP <= networkBase) {
-    return IPAddress(0, 0, 0, 0);  // No more IPs
-  }
-
-  return IPAddress(
-    (prevIP >> 24) & 0xFF,
-    (prevIP >> 16) & 0xFF,
-    (prevIP >> 8) & 0xFF,
-    prevIP & 0xFF
-  );
+inline IPAddress getPrevIP(const IPAddress& currentIP,
+                           const IPAddress& subnetMask, uint16_t stepsBack) {
+  const marauder::IPv4HostRange range = getIPHostRange(currentIP, subnetMask);
+  return uint32ToIPAddress(marauder::previousIPv4Host(
+      ipAddressToUint32(currentIP), stepsBack, range));
 }
 
 inline uint16_t getNextPort(uint16_t port) {

--- a/installer/partitions/t_dongle_c5.csv
+++ b/installer/partitions/t_dongle_c5.csv
@@ -1,4 +1,4 @@
-# LilyGo T-Dongle C5 16 MB layout (selected only with PartitionScheme=custom)
+# LilyGo T-Dongle C5 16 MB layout
 # Name,   Type, SubType, Offset,   Size,     Flags
 nvs,      data, nvs,     0x9000,   0x5000,
 otadata,  data, ota,     0xe000,   0x2000,

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,7 @@ build_src_filter =
   +<FoxHuntTarget.cpp>
   +<TargetListSort.cpp>
   +<TDongleStats.cpp>
+  +<IPv4Range.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/test_ipv4_range/test_main.cpp
+++ b/test/test_ipv4_range/test_main.cpp
@@ -1,0 +1,86 @@
+#include <unity.h>
+
+#include "IPv4Range.h"
+
+namespace {
+
+constexpr uint32_t ip(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  return (static_cast<uint32_t>(a) << 24) |
+         (static_cast<uint32_t>(b) << 16) |
+         (static_cast<uint32_t>(c) << 8) | static_cast<uint32_t>(d);
+}
+
+}  // namespace
+
+void setUp() {}
+void tearDown() {}
+
+void test_slash_24_range_uses_network_and_broadcast_boundaries() {
+  const auto range = marauder::ipv4HostRange(ip(192, 168, 1, 77),
+                                              ip(255, 255, 255, 0));
+  TEST_ASSERT_TRUE(range.valid);
+  TEST_ASSERT_EQUAL_HEX32(ip(192, 168, 1, 0), range.network);
+  TEST_ASSERT_EQUAL_HEX32(ip(192, 168, 1, 255), range.broadcast);
+  TEST_ASSERT_EQUAL_HEX32(ip(192, 168, 1, 1), range.first);
+  TEST_ASSERT_EQUAL_HEX32(ip(192, 168, 1, 254), range.last);
+}
+
+void test_slash_23_range_includes_hosts_below_gateway_octet() {
+  const auto range = marauder::ipv4HostRange(ip(10, 0, 5, 1),
+                                              ip(255, 255, 254, 0));
+  TEST_ASSERT_EQUAL_HEX32(ip(10, 0, 4, 1), range.first);
+  TEST_ASSERT_EQUAL_HEX32(ip(10, 0, 5, 254), range.last);
+  TEST_ASSERT_EQUAL_HEX32(range.first,
+                          marauder::nextIPv4Host(range.network, range));
+}
+
+void test_gateway_near_broadcast_does_not_shorten_range() {
+  const auto range = marauder::ipv4HostRange(ip(172, 16, 35, 126),
+                                              ip(255, 255, 255, 192));
+  TEST_ASSERT_EQUAL_HEX32(ip(172, 16, 35, 65), range.first);
+  TEST_ASSERT_EQUAL_HEX32(ip(172, 16, 35, 126), range.last);
+}
+
+void test_iteration_stops_after_last_host() {
+  const auto range = marauder::ipv4HostRange(ip(192, 168, 1, 10),
+                                              ip(255, 255, 255, 252));
+  TEST_ASSERT_EQUAL_HEX32(ip(192, 168, 1, 9),
+                          marauder::nextIPv4Host(range.network, range));
+  TEST_ASSERT_EQUAL_HEX32(ip(192, 168, 1, 10),
+                          marauder::nextIPv4Host(range.first, range));
+  TEST_ASSERT_EQUAL_HEX32(0, marauder::nextIPv4Host(range.last, range));
+}
+
+void test_previous_host_rejects_underflow_and_accepts_current_host() {
+  const auto range = marauder::ipv4HostRange(ip(192, 168, 1, 10),
+                                              ip(255, 255, 255, 0));
+  TEST_ASSERT_EQUAL_HEX32(ip(192, 168, 1, 10),
+                          marauder::previousIPv4Host(ip(192, 168, 1, 10), 0,
+                                                    range));
+  TEST_ASSERT_EQUAL_HEX32(ip(192, 168, 1, 1),
+                          marauder::previousIPv4Host(ip(192, 168, 1, 10), 9,
+                                                    range));
+  TEST_ASSERT_EQUAL_HEX32(0,
+                          marauder::previousIPv4Host(ip(192, 168, 1, 10), 10,
+                                                    range));
+}
+
+void test_noncontiguous_and_hostless_masks_are_rejected() {
+  TEST_ASSERT_FALSE(
+      marauder::ipv4HostRange(ip(10, 0, 0, 1), ip(255, 0, 255, 0)).valid);
+  TEST_ASSERT_FALSE(
+      marauder::ipv4HostRange(ip(10, 0, 0, 1), ip(255, 255, 255, 254)).valid);
+  TEST_ASSERT_FALSE(
+      marauder::ipv4HostRange(ip(10, 0, 0, 1), ip(255, 255, 255, 255)).valid);
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_slash_24_range_uses_network_and_broadcast_boundaries);
+  RUN_TEST(test_slash_23_range_includes_hosts_below_gateway_octet);
+  RUN_TEST(test_gateway_near_broadcast_does_not_shorten_range);
+  RUN_TEST(test_iteration_stops_after_last_host);
+  RUN_TEST(test_previous_host_rejects_underflow_and_accepts_current_host);
+  RUN_TEST(test_noncontiguous_and_hostless_masks_are_rejected);
+  return UNITY_END();
+}

--- a/tools/test_t_dongle_hardware.py
+++ b/tools/test_t_dongle_hardware.py
@@ -84,6 +84,20 @@ class TDongleHardwareTests(unittest.TestCase):
             ).group("body")
             self.assertIn("if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'", install_step)
             self.assertIn("repository: pololu/apa102-arduino", install_step)
+            partition_step = re.search(
+                r"- name: Configure LilyGo T-Dongle C5 partition table"
+                r"(?P<body>.*?)(?=\n\s+- name:)",
+                workflow,
+                re.S,
+            ).group("body")
+            self.assertIn("if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'", partition_step)
+            self.assertIn(
+                "cp installer/partitions/t_dongle_c5.csv esp32_marauder/partitions.csv",
+                partition_step,
+            )
+
+        self.assertFalse((ROOT / "esp32_marauder" / "partitions.csv").exists())
+        self.assertTrue((ROOT / "installer" / "partitions" / "t_dongle_c5.csv").is_file())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- scan the complete usable IPv4 subnet instead of starting after the gateway
- skip Marauder’s own address and preserve final ARP results without wraparound
- bump firmware version to v1.15.1 and add subnet boundary tests