### PR TITLE
Repair v1.15.0 partition layouts

### DIFF
--- a/.github/workflows/build_installer_manifests.yml
+++ b/.github/workflows/build_installer_manifests.yml
@@ -235,6 +235,10 @@ jobs:
             done
           fi
 
+      - name: Configure LilyGo T-Dongle C5 partition table
+        if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'
+        run: cp installer/partitions/t_dongle_c5.csv esp32_marauder/partitions.csv
+
       - name: Build Marauder for ${{ matrix.board.name }}
         uses: ArminJo/arduino-test-compile@v3.3.0
         with:

--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -244,6 +244,10 @@ jobs:
             sed -i 's/^\/\/#include <${{ matrix.board.tft_file }}>/#include <${{ matrix.board.tft_file }}>/' /home/runner/work/ESP32Marauder/ESP32Marauder/CustomTFT_eSPI/User_Setup_Select.h
           fi
 
+      - name: Configure LilyGo T-Dongle C5 partition table
+        if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'
+        run: cp installer/partitions/t_dongle_c5.csv esp32_marauder/partitions.csv
+
       - name: Build Marauder for ${{ matrix.board.name }}
         uses: ArminJo/arduino-test-compile@v3.3.0
         with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -297,6 +297,10 @@ jobs:
             sed -i 's/^\/\/#include <${{ matrix.board.tft_file }}>/#include <${{ matrix.board.tft_file }}>/' /home/runner/work/ESP32Marauder/ESP32Marauder/CustomTFT_eSPI/User_Setup_Select.h
           fi
 
+      - name: Configure LilyGo T-Dongle C5 partition table
+        if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'
+        run: cp installer/partitions/t_dongle_c5.csv esp32_marauder/partitions.csv
+
       - name: Build Marauder for ${{ matrix.board.name }}
         uses: ArminJo/arduino-test-compile@v3.3.0
         with:

--- a/installer/partitions/t_dongle_c5.csv
+++ b/installer/partitions/t_dongle_c5.csv
@@ -1,4 +1,4 @@
-# LilyGo T-Dongle C5 16 MB layout (selected only with PartitionScheme=custom)
+# LilyGo T-Dongle C5 16 MB layout
 # Name,   Type, SubType, Offset,   Size,     Flags
 nvs,      data, nvs,     0x9000,   0x5000,
 otadata,  data, ota,     0xe000,   0x2000,

--- a/tools/test_t_dongle_hardware.py
+++ b/tools/test_t_dongle_hardware.py
@@ -84,6 +84,20 @@ class TDongleHardwareTests(unittest.TestCase):
             ).group("body")
             self.assertIn("if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'", install_step)
             self.assertIn("repository: pololu/apa102-arduino", install_step)
+            partition_step = re.search(
+                r"- name: Configure LilyGo T-Dongle C5 partition table"
+                r"(?P<body>.*?)(?=\n\s+- name:)",
+                workflow,
+                re.S,
+            ).group("body")
+            self.assertIn("if: matrix.board.flag == 'MARAUDER_T_DONGLE_C5'", partition_step)
+            self.assertIn(
+                "cp installer/partitions/t_dongle_c5.csv esp32_marauder/partitions.csv",
+                partition_step,
+            )
+
+        self.assertFalse((ROOT / "esp32_marauder" / "partitions.csv").exists())
+        self.assertTrue((ROOT / "installer" / "partitions" / "t_dongle_c5.csv").is_file())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- scope the 16 MB partition table exclusively to LilyGo T-Dongle C5 builds
- restore each other target’s configured partition scheme for corrected v1.15.0 artifacts
- add regression coverage across release, nightly, and installer workflows