### PR TITLE
Fix ARP scanning on ESP32-C5 targets

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -1289,9 +1289,11 @@ void CommandLine::runCommand(String input) {
       this->startScanFromCLI(WIFI_PING_SCAN, TFT_GREEN, "Ping Scan");
     }
 
+    // GCOVR_EXCL_START -- command dispatch requires the firmware CLI runtime.
     if (cmd_args.get(0) == ARP_SCAN_CMD) {
       this->startScanFromCLI(WIFI_ARP_SCAN, TFT_CYAN, "ARP Scan");
     }
+    // GCOVR_EXCL_STOP
 
     // GPS POI
     if (cmd_args.get(0) == GPS_POI_CMD) {

--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -1289,11 +1289,9 @@ void CommandLine::runCommand(String input) {
       this->startScanFromCLI(WIFI_PING_SCAN, TFT_GREEN, "Ping Scan");
     }
 
-    #ifndef HAS_DUAL_BAND
-      if (cmd_args.get(0) == ARP_SCAN_CMD) {
-        this->startScanFromCLI(WIFI_ARP_SCAN, TFT_CYAN, "ARP Scan");
-      }
-    #endif
+    if (cmd_args.get(0) == ARP_SCAN_CMD) {
+      this->startScanFromCLI(WIFI_ARP_SCAN, TFT_CYAN, "ARP Scan");
+    }
 
     // GPS POI
     if (cmd_args.get(0) == GPS_POI_CMD) {

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -2002,11 +2002,13 @@ void MenuFunctions::RunSetup()
     this->drawStatusBar();
     wifi_scan_obj.StartScan(WIFI_PING_SCAN, TFT_CYAN);
   });
+  // GCOVR_EXCL_START -- scanner menu wiring requires the hardware UI.
   this->addNodes(&wifiScannerMenu, "ARP Scan", TFTCYAN, SCANNERS, [this]() {
     display_obj.clearScreen();
     this->drawStatusBar();
     wifi_scan_obj.StartScan(WIFI_ARP_SCAN, TFT_CYAN);
   });
+  // GCOVR_EXCL_STOP
   this->addNodes(&wifiScannerMenu, "Port Scan All", TFTMAGENTA, BEACON_LIST, [this](){
     // Add the back button
     wifiIPMenu.list->clear();

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -2002,13 +2002,11 @@ void MenuFunctions::RunSetup()
     this->drawStatusBar();
     wifi_scan_obj.StartScan(WIFI_PING_SCAN, TFT_CYAN);
   });
-  #ifndef HAS_DUAL_BAND
-    this->addNodes(&wifiScannerMenu, "ARP Scan", TFTCYAN, SCANNERS, [this]() {
-      display_obj.clearScreen();
-      this->drawStatusBar();
-      wifi_scan_obj.StartScan(WIFI_ARP_SCAN, TFT_CYAN);
-    });
-  #endif
+  this->addNodes(&wifiScannerMenu, "ARP Scan", TFTCYAN, SCANNERS, [this]() {
+    display_obj.clearScreen();
+    this->drawStatusBar();
+    wifi_scan_obj.StartScan(WIFI_ARP_SCAN, TFT_CYAN);
+  });
   this->addNodes(&wifiScannerMenu, "Port Scan All", TFTMAGENTA, BEACON_LIST, [this](){
     // Add the back button
     wifiIPMenu.list->clear();

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10724,6 +10724,7 @@ void WiFiScan::pingScan(uint8_t scan_mode) {
     else if (scan_mode == WIFI_SCAN_RDP)
       targ_port = 3389;
 
+    // GCOVR_EXCL_START -- service discovery requires a live lwIP station interface.
     if (this->current_scan_ip != IPAddress(0, 0, 0, 0)) {
       if ((this->advanceScanIP() != IPAddress(0, 0, 0, 0)) &&
           this->singleARP(this->current_scan_ip)) {
@@ -10736,6 +10737,7 @@ void WiFiScan::pingScan(uint8_t scan_mode) {
         this->finishNetworkScanDisplay("hosts open"); // GCOVR_EXCL_LINE
       }
     }
+    // GCOVR_EXCL_STOP
   }
 }
 

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10587,6 +10587,12 @@ static bool findStationARP(struct netif* station, const ip4_addr_t* ip) {
   return found;
 }
 
+static bool findStationARP(struct netif* station, IPAddress ip) {
+  ip4_addr_t lwip_ip;
+  IP4_ADDR(&lwip_ip, ip[0], ip[1], ip[2], ip[3]);
+  return findStationARP(station, &lwip_ip);
+}
+
 static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
   #ifdef HAS_IDF_3
     LOCK_TCPIP_CORE();
@@ -10596,18 +10602,6 @@ static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
     UNLOCK_TCPIP_CORE();
   #endif
 }
-
-  bool WiFiScan::readARP(IPAddress targ_ip) {
-    // Convert IPAddress to ip4_addr_t using IP4_ADDR
-    ip4_addr_t test_ip;
-    IP4_ADDR(&test_ip, targ_ip[0], targ_ip[1], targ_ip[2], targ_ip[3]);
-
-    struct netif* netif_interface = getStationLwipNetif();
-    if (netif_interface == nullptr)
-      return false;
-
-    return findStationARP(netif_interface, &test_ip);
-  }
 
   inline __attribute__((always_inline)) bool WiFiScan::singleARP(IPAddress ip_addr) {
     struct netif* netif_interface = getStationLwipNetif();
@@ -10661,7 +10655,7 @@ static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
           IPAddress check_ip = getPrevIP(this->current_scan_ip, this->subnet, i);
           display_string = "";
           output_line = "";
-          if (this->readARP(check_ip)) {
+          if (findStationARP(netif_interface, check_ip)) {
             ipList->add(check_ip);
             output_line = check_ip.toString();
             display_string.concat(output_line);
@@ -10688,7 +10682,7 @@ static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
         IPAddress check_ip = getPrevIP(this->last_scan_ip, this->subnet, i - 1);
         display_string = "";
         output_line = "";
-        if (this->readARP(check_ip)) {
+        if (findStationARP(netif_interface, check_ip)) {
           ipList->add(check_ip);
           output_line = check_ip.toString();
           display_string.concat(output_line);

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10558,8 +10558,11 @@ IPAddress WiFiScan::advanceScanIP() {
 // GCOVR_EXCL_START -- ARP discovery requires a live lwIP station interface.
 static struct netif* getStationLwipNetif() {
   #ifdef HAS_IDF_3
-    return static_cast<struct netif*>(
-      esp_netif_get_netif_impl(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF")));
+    esp_netif_t* station = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    if (station == nullptr)
+      return nullptr;
+
+    return static_cast<struct netif*>(esp_netif_get_netif_impl(station));
   #else
     void* station = nullptr;
     if (tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, &station) != ESP_OK)
@@ -10584,23 +10587,30 @@ static bool findStationARP(struct netif* station, const ip4_addr_t* ip) {
   return found;
 }
 
-static bool findStationARP(struct netif* station, IPAddress ip) {
-  ip4_addr_t lwip_ip;
-  IP4_ADDR(&lwip_ip, ip[0], ip[1], ip[2], ip[3]);
-  return findStationARP(station, &lwip_ip);
-}
-
-static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
+static err_t requestStationARP(struct netif* station, const ip4_addr_t* ip) {
   #ifdef HAS_IDF_3
     LOCK_TCPIP_CORE();
   #endif
-  etharp_request(station, ip);
+  const err_t result = etharp_request(station, ip);
   #ifdef HAS_IDF_3
     UNLOCK_TCPIP_CORE();
   #endif
+
+  return result;
 }
 
-  inline __attribute__((always_inline)) bool WiFiScan::singleARP(IPAddress ip_addr) {
+  bool WiFiScan::readARP(IPAddress targ_ip) {
+    ip4_addr_t test_ip;
+    IP4_ADDR(&test_ip, targ_ip[0], targ_ip[1], targ_ip[2], targ_ip[3]);
+
+    struct netif* netif_interface = getStationLwipNetif();
+    if (netif_interface == nullptr)
+      return false;
+
+    return findStationARP(netif_interface, &test_ip);
+  }
+
+  bool WiFiScan::singleARP(IPAddress ip_addr) {
     struct netif* netif_interface = getStationLwipNetif();
     if (netif_interface == nullptr)
       return false;
@@ -10615,18 +10625,17 @@ static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
     requestStationARP(netif_interface, &lwip_ip);
 
     delay(250);
-    return findStationARP(netif_interface, &lwip_ip);
-  }
 
-  void WiFiScan::recordARPResult(IPAddress ip_addr) {
-    ipList->add(ip_addr);
-    String output_line = ip_addr.toString();
-    this->addNetworkScanDisplayResult(String("UP ") + output_line);
-    buffer_obj.append(output_line + "\n");
-    Serial.println(output_line);
+    if (this->readARP(ip_addr))
+      return true;
+
+    return false;
   }
 
   void WiFiScan::fullARP() {
+    String display_string = "";
+    String output_line = "";
+
     struct netif* netif_interface = getStationLwipNetif();
     if (netif_interface == nullptr)
       return;
@@ -10655,8 +10664,22 @@ static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
 
         for (int i = 9; i >= 0; i--) {
           IPAddress check_ip = getPrevIP(this->current_scan_ip, this->subnet, i);
-          if (findStationARP(netif_interface, check_ip)) {
-            this->recordARPResult(check_ip);
+          display_string = "";
+          output_line = "";
+          if (this->readARP(check_ip)) {
+            ipList->add(check_ip);
+            output_line = check_ip.toString();
+            display_string.concat(output_line);
+            uint8_t temp_len = display_string.length();
+            for (uint8_t i = 0; i < 40 - temp_len; i++)
+            {
+              display_string.concat(" ");
+            }
+            #ifdef HAS_SCREEN
+              display_obj.display_buffer->add(display_string);
+            #endif
+            buffer_obj.append(output_line + "\n");
+            Serial.println(output_line);
           }
         }
       }
@@ -10668,8 +10691,22 @@ static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
         delay(250);
 
         IPAddress check_ip = getPrevIP(this->last_scan_ip, this->subnet, i - 1);
-        if (findStationARP(netif_interface, check_ip)) {
-          this->recordARPResult(check_ip);
+        display_string = "";
+        output_line = "";
+        if (this->readARP(check_ip)) {
+          ipList->add(check_ip);
+          output_line = check_ip.toString();
+          display_string.concat(output_line);
+          uint8_t temp_len = display_string.length();
+          for (uint8_t i = 0; i < 40 - temp_len; i++)
+          {
+            display_string.concat(" ");
+          }
+          #ifdef HAS_SCREEN
+            display_obj.display_buffer->add(display_string);
+          #endif
+          buffer_obj.append(output_line + "\n");
+          Serial.println(output_line);
         }
       }
       this->arp_count = 0;
@@ -10726,8 +10763,12 @@ void WiFiScan::pingScan(uint8_t scan_mode) {
 
     // GCOVR_EXCL_START -- service discovery requires a live lwIP station interface.
     if (this->current_scan_ip != IPAddress(0, 0, 0, 0)) {
-      if ((this->advanceScanIP() != IPAddress(0, 0, 0, 0)) &&
-          this->singleARP(this->current_scan_ip)) {
+      this->advanceScanIP();
+      if (this->current_scan_ip == IPAddress(0, 0, 0, 0)) {
+        return;
+      }
+      if (this->singleARP(this->current_scan_ip)) {
+        Serial.println(this->current_scan_ip);
         this->portScan(scan_mode, targ_port);
       }
     }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10555,21 +10555,22 @@ IPAddress WiFiScan::advanceScanIP() {
   return this->current_scan_ip;
 }
 
-  static struct netif* getStationLwipNetif() {
-    #ifdef HAS_IDF_3
-      esp_netif_t* station = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-      if (station == nullptr)
-        return nullptr;
+// GCOVR_EXCL_START -- ARP discovery requires a live lwIP station interface.
+static struct netif* getStationLwipNetif() {
+  #ifdef HAS_IDF_3
+    esp_netif_t* station = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    if (station == nullptr)
+      return nullptr;
 
-      return static_cast<struct netif*>(esp_netif_get_netif_impl(station));
-    #else
-      void* station = nullptr;
-      if (tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, &station) != ESP_OK)
-        return nullptr;
+    return static_cast<struct netif*>(esp_netif_get_netif_impl(station));
+  #else
+    void* station = nullptr;
+    if (tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, &station) != ESP_OK)
+      return nullptr;
 
-      return static_cast<struct netif*>(station);
-    #endif
-  }
+    return static_cast<struct netif*>(station);
+  #endif
+}
 
   bool WiFiScan::readARP(IPAddress targ_ip) {
     // Convert IPAddress to ip4_addr_t using IP4_ADDR
@@ -10698,6 +10699,8 @@ IPAddress WiFiScan::advanceScanIP() {
       }
     }
   }
+// GCOVR_EXCL_STOP
+
 void WiFiScan::pingScan(uint8_t scan_mode) {
   String output_line = "";
 
@@ -11713,7 +11716,7 @@ void WiFiScan::main(uint32_t currentTime)
     this->pingScan();
   }
   else if (currentScanMode == WIFI_ARP_SCAN) {
-    this->fullARP();
+    this->fullARP(); // GCOVR_EXCL_LINE -- requires a live lwIP station interface.
   }
   else if (currentScanMode == WIFI_PORT_SCAN_ALL) {
     this->portScan(WIFI_PORT_SCAN_ALL);

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10558,11 +10558,8 @@ IPAddress WiFiScan::advanceScanIP() {
 // GCOVR_EXCL_START -- ARP discovery requires a live lwIP station interface.
 static struct netif* getStationLwipNetif() {
   #ifdef HAS_IDF_3
-    esp_netif_t* station = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-    if (station == nullptr)
-      return nullptr;
-
-    return static_cast<struct netif*>(esp_netif_get_netif_impl(station));
+    return static_cast<struct netif*>(
+      esp_netif_get_netif_impl(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF")));
   #else
     void* station = nullptr;
     if (tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, &station) != ESP_OK)
@@ -10756,7 +10753,6 @@ void WiFiScan::pingScan(uint8_t scan_mode) {
         return;
       }
       if (this->singleARP(this->current_scan_ip)) {
-        Serial.println(this->current_scan_ip);
         this->portScan(scan_mode, targ_port);
       }
     }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10767,11 +10767,7 @@ void WiFiScan::pingScan(uint8_t scan_mode) {
       if (this->current_scan_ip == IPAddress(0, 0, 0, 0)) {
         return;
       }
-      #ifndef HAS_IDF_3
-        if (this->singleARP(this->current_scan_ip)) {
-      #else
-        if (this->isHostAlive(this->current_scan_ip)) {
-      #endif
+      if (this->singleARP(this->current_scan_ip)) {
         Serial.println(this->current_scan_ip);
         this->portScan(scan_mode, targ_port);
       }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10748,11 +10748,8 @@ void WiFiScan::pingScan(uint8_t scan_mode) {
       targ_port = 3389;
 
     if (this->current_scan_ip != IPAddress(0, 0, 0, 0)) {
-      this->advanceScanIP();
-      if (this->current_scan_ip == IPAddress(0, 0, 0, 0)) {
-        return;
-      }
-      if (this->singleARP(this->current_scan_ip)) {
+      if ((this->advanceScanIP() != IPAddress(0, 0, 0, 0)) &&
+          this->singleARP(this->current_scan_ip)) {
         this->portScan(scan_mode, targ_port);
       }
     }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10555,22 +10555,35 @@ IPAddress WiFiScan::advanceScanIP() {
   return this->current_scan_ip;
 }
 
-#ifndef HAS_IDF_3
+  static struct netif* getStationLwipNetif() {
+    #ifdef HAS_IDF_3
+      esp_netif_t* station = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+      if (station == nullptr)
+        return nullptr;
+
+      return static_cast<struct netif*>(esp_netif_get_netif_impl(station));
+    #else
+      void* station = nullptr;
+      if (tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, &station) != ESP_OK)
+        return nullptr;
+
+      return static_cast<struct netif*>(station);
+    #endif
+  }
+
   bool WiFiScan::readARP(IPAddress targ_ip) {
     // Convert IPAddress to ip4_addr_t using IP4_ADDR
     ip4_addr_t test_ip;
     IP4_ADDR(&test_ip, targ_ip[0], targ_ip[1], targ_ip[2], targ_ip[3]);
 
-    // Get the netif interface for STA mode
-    //void* netif = NULL;
-    //tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, &netif);
-    //struct netif* netif_interface = (struct netif*)netif;
+    struct netif* netif_interface = getStationLwipNetif();
+    if (netif_interface == nullptr)
+      return false;
 
     const ip4_addr_t* ipaddr_ret = NULL;
     struct eth_addr* eth_ret = NULL;
 
-    // Use actual interface instead of NULL
-    if (etharp_find_addr(NULL, &test_ip, &eth_ret, &ipaddr_ret) >= 0) {
+    if (etharp_find_addr(netif_interface, &test_ip, &eth_ret, &ipaddr_ret) >= 0) {
       return true;
     }
 
@@ -10578,17 +10591,9 @@ IPAddress WiFiScan::advanceScanIP() {
   }
 
   bool WiFiScan::singleARP(IPAddress ip_addr) {
-
-    #ifndef HAS_IDF_3
-      void* netif = NULL;
-      tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, &netif);
-      struct netif* netif_interface = (struct netif*)netif;
-    #else
-      struct netif* netif_interface = (struct netif*)esp_netif_get_netif_impl(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"));
-      //esp_netif_t* netif_interface = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-      //struct netif* netif_interface = (struct netif*)netif;
-      //struct netif* netif_interface = esp_netif_get_netif_impl(*netif);
-    #endif
+    struct netif* netif_interface = getStationLwipNetif();
+    if (netif_interface == nullptr)
+      return false;
 
     ip4_addr_t lwip_ip;
     IP4_ADDR(&lwip_ip,
@@ -10611,16 +10616,9 @@ IPAddress WiFiScan::advanceScanIP() {
     String display_string = "";
     String output_line = "";
 
-    #ifndef HAS_IDF_3
-      void* netif = NULL;
-      tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, &netif);
-      struct netif* netif_interface = (struct netif*)netif;
-    #else
-      struct netif* netif_interface = (struct netif*)esp_netif_get_netif_impl(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"));
-      //esp_netif_t* netif_interface = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-      //struct netif* netif_interface = (struct netif*)netif;
-      //struct netif* netif_interface = esp_netif_get_netif_impl(*netif);
-    #endif
+    struct netif* netif_interface = getStationLwipNetif();
+    if (netif_interface == nullptr)
+      return;
 
     //this->arp_count = 0;
 
@@ -10700,8 +10698,6 @@ IPAddress WiFiScan::advanceScanIP() {
       }
     }
   }
-#endif
-
 void WiFiScan::pingScan(uint8_t scan_mode) {
   String output_line = "";
 
@@ -11717,9 +11713,7 @@ void WiFiScan::main(uint32_t currentTime)
     this->pingScan();
   }
   else if (currentScanMode == WIFI_ARP_SCAN) {
-    #ifndef HAS_IDF_3
-      this->fullARP();
-    #endif
+    this->fullARP();
   }
   else if (currentScanMode == WIFI_PORT_SCAN_ALL) {
     this->portScan(WIFI_PORT_SCAN_ALL);

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10626,11 +10626,7 @@ static err_t requestStationARP(struct netif* station, const ip4_addr_t* ip) {
     requestStationARP(netif_interface, &lwip_ip);
 
     delay(250);
-
-    if (this->readARP(ip_addr))
-      return true;
-
-    return false;
+    return findStationARP(netif_interface, &lwip_ip);
   }
 
   void WiFiScan::fullARP() {

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10618,10 +10618,15 @@ static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
     return findStationARP(netif_interface, &lwip_ip);
   }
 
-  void WiFiScan::fullARP() {
-    String display_string = "";
-    String output_line = "";
+  void WiFiScan::recordARPResult(IPAddress ip_addr) {
+    ipList->add(ip_addr);
+    String output_line = ip_addr.toString();
+    this->addNetworkScanDisplayResult(String("UP ") + output_line);
+    buffer_obj.append(output_line + "\n");
+    Serial.println(output_line);
+  }
 
+  void WiFiScan::fullARP() {
     struct netif* netif_interface = getStationLwipNetif();
     if (netif_interface == nullptr)
       return;
@@ -10650,22 +10655,8 @@ static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
 
         for (int i = 9; i >= 0; i--) {
           IPAddress check_ip = getPrevIP(this->current_scan_ip, this->subnet, i);
-          display_string = "";
-          output_line = "";
           if (findStationARP(netif_interface, check_ip)) {
-            ipList->add(check_ip);
-            output_line = check_ip.toString();
-            display_string.concat(output_line);
-            uint8_t temp_len = display_string.length();
-            for (uint8_t i = 0; i < 40 - temp_len; i++)
-            {
-              display_string.concat(" ");
-            }
-            #ifdef HAS_SCREEN
-              display_obj.display_buffer->add(display_string);
-            #endif
-            buffer_obj.append(output_line + "\n");
-            Serial.println(output_line);
+            this->recordARPResult(check_ip);
           }
         }
       }
@@ -10677,22 +10668,8 @@ static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
         delay(250);
 
         IPAddress check_ip = getPrevIP(this->last_scan_ip, this->subnet, i - 1);
-        display_string = "";
-        output_line = "";
         if (findStationARP(netif_interface, check_ip)) {
-          ipList->add(check_ip);
-          output_line = check_ip.toString();
-          display_string.concat(output_line);
-          uint8_t temp_len = display_string.length();
-          for (uint8_t i = 0; i < 40 - temp_len; i++)
-          {
-            display_string.concat(" ");
-          }
-          #ifdef HAS_SCREEN
-            display_obj.display_buffer->add(display_string);
-          #endif
-          buffer_obj.append(output_line + "\n");
-          Serial.println(output_line);
+          this->recordARPResult(check_ip);
         }
       }
       this->arp_count = 0;

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10572,6 +10572,33 @@ static struct netif* getStationLwipNetif() {
   #endif
 }
 
+static bool findStationARP(struct netif* station, const ip4_addr_t* ip) {
+  const ip4_addr_t* resolved_ip = nullptr;
+  struct eth_addr* resolved_mac = nullptr;
+
+  #ifdef HAS_IDF_3
+    LOCK_TCPIP_CORE();
+  #endif
+  const bool found = etharp_find_addr(station, ip, &resolved_mac, &resolved_ip) >= 0;
+  #ifdef HAS_IDF_3
+    UNLOCK_TCPIP_CORE();
+  #endif
+
+  return found;
+}
+
+static err_t requestStationARP(struct netif* station, const ip4_addr_t* ip) {
+  #ifdef HAS_IDF_3
+    LOCK_TCPIP_CORE();
+  #endif
+  const err_t result = etharp_request(station, ip);
+  #ifdef HAS_IDF_3
+    UNLOCK_TCPIP_CORE();
+  #endif
+
+  return result;
+}
+
   bool WiFiScan::readARP(IPAddress targ_ip) {
     // Convert IPAddress to ip4_addr_t using IP4_ADDR
     ip4_addr_t test_ip;
@@ -10581,14 +10608,7 @@ static struct netif* getStationLwipNetif() {
     if (netif_interface == nullptr)
       return false;
 
-    const ip4_addr_t* ipaddr_ret = NULL;
-    struct eth_addr* eth_ret = NULL;
-
-    if (etharp_find_addr(netif_interface, &test_ip, &eth_ret, &ipaddr_ret) >= 0) {
-      return true;
-    }
-
-    return false;
+    return findStationARP(netif_interface, &test_ip);
   }
 
   bool WiFiScan::singleARP(IPAddress ip_addr) {
@@ -10603,7 +10623,7 @@ static struct netif* getStationLwipNetif() {
               ip_addr[2],
               ip_addr[3]);
 
-    etharp_request(netif_interface, &lwip_ip);
+    requestStationARP(netif_interface, &lwip_ip);
 
     delay(250);
 
@@ -10632,7 +10652,7 @@ static struct netif* getStationLwipNetif() {
               this->current_scan_ip[2],
               this->current_scan_ip[3]);
 
-      etharp_request(netif_interface, &lwip_ip);
+      requestStationARP(netif_interface, &lwip_ip);
 
       delay(100);
 

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -10587,16 +10587,14 @@ static bool findStationARP(struct netif* station, const ip4_addr_t* ip) {
   return found;
 }
 
-static err_t requestStationARP(struct netif* station, const ip4_addr_t* ip) {
+static void requestStationARP(struct netif* station, const ip4_addr_t* ip) {
   #ifdef HAS_IDF_3
     LOCK_TCPIP_CORE();
   #endif
-  const err_t result = etharp_request(station, ip);
+  etharp_request(station, ip);
   #ifdef HAS_IDF_3
     UNLOCK_TCPIP_CORE();
   #endif
-
-  return result;
 }
 
   bool WiFiScan::readARP(IPAddress targ_ip) {
@@ -10611,7 +10609,7 @@ static err_t requestStationARP(struct netif* station, const ip4_addr_t* ip) {
     return findStationARP(netif_interface, &test_ip);
   }
 
-  bool WiFiScan::singleARP(IPAddress ip_addr) {
+  inline __attribute__((always_inline)) bool WiFiScan::singleARP(IPAddress ip_addr) {
     struct netif* netif_interface = getStationLwipNetif();
     if (netif_interface == nullptr)
       return false;

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -32,11 +32,12 @@
 #include "mbedtls/bignum.h"
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/ecp.h"
-#ifndef HAS_IDF_3
-  #include <lwip/etharp.h>
-  #include <lwip/ip_addr.h>
-#endif
+#include <lwip/etharp.h>
+#include <lwip/ip_addr.h>
+#include <lwip/netif.h>
 #ifdef HAS_IDF_3
+  #include "esp_netif.h"
+  #include "esp_netif_net_stack.h"
   #include "esp_system.h"
   #include "esp_mac.h"
 #endif

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -717,6 +717,7 @@ class WiFiScan
     void finishNetworkScanDisplay(const String& result_label);
     void setNetworkInfo();
     void fullARP();
+    void recordARPResult(IPAddress ip_addr);
     inline __attribute__((always_inline)) bool singleARP(IPAddress ip_addr);
     void pingScan(uint8_t scan_mode = WIFI_PING_SCAN);
     void portScan(uint8_t scan_mode = WIFI_PORT_SCAN_ALL, uint16_t targ_port = 22);

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -35,6 +35,7 @@
 #include <lwip/etharp.h>
 #include <lwip/ip_addr.h>
 #include <lwip/netif.h>
+#include <lwip/tcpip.h>
 #ifdef HAS_IDF_3
   #include "esp_netif.h"
   #include "esp_netif_net_stack.h"

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -718,7 +718,7 @@ class WiFiScan
     void setNetworkInfo();
     void fullARP();
     bool readARP(IPAddress targ_ip);
-    bool singleARP(IPAddress ip_addr);
+    inline __attribute__((always_inline)) bool singleARP(IPAddress ip_addr);
     void pingScan(uint8_t scan_mode = WIFI_PING_SCAN);
     void portScan(uint8_t scan_mode = WIFI_PORT_SCAN_ALL, uint16_t targ_port = 22);
     IPAddress advanceScanIP();

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -717,7 +717,6 @@ class WiFiScan
     void finishNetworkScanDisplay(const String& result_label);
     void setNetworkInfo();
     void fullARP();
-    bool readARP(IPAddress targ_ip);
     inline __attribute__((always_inline)) bool singleARP(IPAddress ip_addr);
     void pingScan(uint8_t scan_mode = WIFI_PING_SCAN);
     void portScan(uint8_t scan_mode = WIFI_PORT_SCAN_ALL, uint16_t targ_port = 22);

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -717,8 +717,8 @@ class WiFiScan
     void finishNetworkScanDisplay(const String& result_label);
     void setNetworkInfo();
     void fullARP();
-    void recordARPResult(IPAddress ip_addr);
-    inline __attribute__((always_inline)) bool singleARP(IPAddress ip_addr);
+    bool readARP(IPAddress targ_ip);
+    bool singleARP(IPAddress ip_addr);
     void pingScan(uint8_t scan_mode = WIFI_PING_SCAN);
     void portScan(uint8_t scan_mode = WIFI_PORT_SCAN_ALL, uint16_t targ_port = 22);
     IPAddress advanceScanIP();


### PR DESCRIPTION
## Summary
- enable ARP discovery on ESP32-C5 and other ESP-NETIF targets
- resolve the station lwIP interface through the appropriate legacy or modern network stack API
- scope ARP cache lookups and requests to the active station interface