### PR TITLE
Reduce automatic firmware matrix runs

### DIFF
--- a/.github/workflows/build_parallel.yml
+++ b/.github/workflows/build_parallel.yml
@@ -2,16 +2,23 @@ name: Build and Push Parallel
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-    tags:
-      - "*"
+    inputs:
+      create_release:
+        description: "Create the draft release after the full matrix passes"
+        required: true
+        type: boolean
+        default: true
   pull_request:
+    types: [labeled]
+
+concurrency:
+  group: full-hardware-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   compile_sketch:
     name: build ${{ matrix.board.name }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'full-hardware-ci' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -44,6 +51,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           
       - name: Install Arduino CLI
         run: |
@@ -286,7 +295,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [compile_sketch]
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.create_release }}
     permissions:
       contents: write
     steps: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Development workflow
+
+ESP32 Marauder supports many hardware targets, so the full firmware matrix is
+reserved for final validation and releases. It is not an iteration loop.
+
+## Iteration
+
+1. Work on a local branch without opening a pull request.
+2. Run native unit tests and static checks locally.
+3. Compile only the hardware targets requested for physical testing.
+4. Clearly identify locally compiled test binaries by target and exact commit.
+5. Revise locally until the requested hardware behavior is accepted.
+
+## Pull request gate
+
+Push the branch and open a pull request only when the change is ready for
+review. Pull requests run the comparatively inexpensive native unit-test
+workflow. Additional commits should be batched instead of pushed after every
+small edit.
+
+## Full-matrix gate
+
+When a pull request is merge-ready, a maintainer applies the
+`full-hardware-ci` label. That label runs **Build and Push Parallel** against the
+pull request's exact current head. Any later source push invalidates that
+evidence, so the label must be removed and applied again to validate the new
+head before merge.
+
+The workflow can also be dispatched manually against a final candidate branch
+with `create_release` disabled. Do not use the full matrix for ordinary
+iteration or to obtain one or two test binaries.
+
+Untrusted fork code must not receive protected-build credentials. Private V8,
+Mini V3, and Dual Mini C5 validation is performed only after review, from an
+exact-head branch controlled by the maintainers.
+
+For a firmware release, dispatch the same workflow against the exact release
+source commit with `create_release` enabled. The workflow remains the
+authoritative producer of the draft release and its public binaries.


### PR DESCRIPTION
## Summary
- replace automatic full-matrix PR and push builds with maintainer-gated exact-head validation
- preserve manual release drafting with an explicit release switch
- document the local iteration, PR, protected-build, and full-matrix gates