### PR TITLE
Fix PMKID, Evil Portal, and SD update handling

### DIFF
--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -21,7 +21,9 @@ void EvilPortal::setup() {
     if (sd_obj.supported) {
       sd_obj.listDirToLinkedList(html_files, "/", "html");
 
-      Serial.println("Evil Portal Found " + (String)html_files->size() + " HTML files");
+      #ifndef MARAUDER_V8
+        Serial.println("Evil Portal Found " + (String)html_files->size() + " HTML files");
+      #endif
     }
   #endif
 }
@@ -68,7 +70,9 @@ void EvilPortal::setupServer() {
   #ifndef HAS_PSRAM
     server.on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {
       request->send_P(200, "text/html", index_html);
-      Serial.println(F("client connected"));
+      #ifndef MARAUDER_V8
+        Serial.println(F("client connected"));
+      #endif
       #ifdef HAS_SCREEN
         this->sendToDisplay(F("Client connected to server"));
       #endif
@@ -76,7 +80,9 @@ void EvilPortal::setupServer() {
   #else
     server.on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {
       request->send(200, "text/html", index_html);
-      Serial.println("client connected");
+      #ifndef MARAUDER_V8
+        Serial.println("client connected");
+      #endif
       #ifdef HAS_SCREEN
         this->sendToDisplay(F("Client connected to server"));
       #endif
@@ -135,7 +141,9 @@ void EvilPortal::setupServer() {
 }
 
 void EvilPortal::setHtmlFromSerial() {
-  Serial.println(F("Setting HTML from serial..."));
+  #ifndef MARAUDER_V8
+    Serial.println(F("Setting HTML from serial..."));
+  #endif
   const char *htmlStr = Serial.readString().c_str();
   #ifdef HAS_PSRAM
     index_html = (char*) ps_malloc(MAX_HTML_SIZE);
@@ -146,15 +154,21 @@ void EvilPortal::setHtmlFromSerial() {
   #endif
   this->has_html = true;
   this->using_serial_html = true;
-  Serial.println("html set");
+  #ifndef MARAUDER_V8
+    Serial.println("html set");
+  #endif
 }
 
 bool EvilPortal::setHtml() {
   if (this->using_serial_html) {
-    Serial.println(F("html previously set"));
+    #ifndef MARAUDER_V8
+      Serial.println(F("html previously set"));
+    #endif
     return true;
   }
-  Serial.println(F("Setting HTML..."));
+  #ifndef MARAUDER_V8
+    Serial.println(F("Setting HTML..."));
+  #endif
   #ifdef HAS_SD
     File html_file = sd_obj.getFile("/" + this->target_html_name);
   #else
@@ -165,7 +179,9 @@ bool EvilPortal::setHtml() {
       this->sendToDisplay("Could not find /" + this->target_html_name);
       this->sendToDisplay(F("Touch to exit..."));
     #endif
-    Serial.println("Could not find /" + this->target_html_name + ". Use stopscan...");
+    #ifndef MARAUDER_V8
+      Serial.println("Could not find /" + this->target_html_name + ". Use stopscan...");
+    #endif
     return false;
   }
   else {
@@ -173,7 +189,9 @@ bool EvilPortal::setHtml() {
       #ifdef HAS_SCREEN
         this->sendToDisplay(F("The given HTML is too large. Touch to exit..."));
       #endif
-      Serial.println("The provided HTML is too large.\nUse stopscan...");
+      #ifndef MARAUDER_V8
+        Serial.println("The provided HTML is too large.\nUse stopscan...");
+      #endif
       return false;
     }
     String html = "";
@@ -190,7 +208,9 @@ bool EvilPortal::setHtml() {
       index_html[MAX_HTML_SIZE - 1] = '\0';
     #endif
     this->has_html = true;
-    Serial.println("html set");
+    #ifndef MARAUDER_V8
+      Serial.println("html set");
+    #endif
     html_file.close();
     return true;
   }
@@ -326,8 +346,10 @@ void EvilPortal::startAP() {
   WiFi.softAPConfig(AP_IP, AP_IP, IPAddress(255, 255, 255, 0));
   WiFi.softAP(apName);
 
-  Serial.print(F("ap ip address: "));
-  Serial.println(WiFi.softAPIP());
+  #ifndef MARAUDER_V8
+    Serial.print(F("ap ip address: "));
+    Serial.println(WiFi.softAPIP());
+  #endif
 
   // Register the web-server endpoints + captive handler ONCE for the app lifetime.
   // setupServer() appends ~12 handlers and addHandler() allocates a
@@ -344,7 +366,9 @@ void EvilPortal::startAP() {
   }
 
   this->dnsServer.start(53, "*", WiFi.softAPIP());
-  Serial.println(F("Evil Portal READY"));
+  #ifndef MARAUDER_V8
+    Serial.println(F("Evil Portal READY"));
+  #endif
   #ifdef HAS_SCREEN
     this->sendToDisplay(F("Evil Portal READY"));
   #endif

--- a/esp32_marauder/EvilPortal.cpp
+++ b/esp32_marauder/EvilPortal.cpp
@@ -212,82 +212,54 @@ bool EvilPortal::setAP(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_
   // If there are no SSIDs and there are no APs selected, pull from file
   // This means the file is last resort
   if ((ssids->size() <= 0) && (temp_ap_name == "")) {
-    #ifdef HAS_SD
-      File ap_config_file = sd_obj.getFile("/ap.config.txt");
-    #else
-      File ap_config_file;
-    #endif
-    // Could not open config file. return false
-    if (!ap_config_file) {
-      #ifdef HAS_SCREEN
-        this->sendToDisplay(F("Could not find /ap.config.txt."));
-        this->sendToDisplay(F("Touch to exit..."));
-      #endif
-      Serial.println(F("Could not find /ap.config.txt. Use stopscan..."));
-      return false;
-    }
-    // Config file good. Proceed
-    else {
-      // ap name too long. return false        
-      if (ap_config_file.size() > MAX_AP_NAME_SIZE) {
-        #ifdef HAS_SCREEN
-          this->sendToDisplay(F("The given AP name is too large. Touch to exit..."));
-        #endif
-        Serial.println("The provided AP name is too large.\nUse stopscan...");
-        return false;
-      }
-      // AP name length good. Read from file into var
-      while (ap_config_file.available()) {
-        char c = ap_config_file.read();
-        Serial.print(c);
-        if (isPrintable(c)) {
-          ap_config.concat(c);
-        }
-      }
-      #ifdef HAS_SCREEN
-        this->sendToDisplay(F("AP name from config file"));
-        this->sendToDisplay("AP name: " + ap_config);
-      #endif
-      Serial.println("AP name from config file: " + ap_config);
-      ap_config_file.close();
-    }
+    return this->setAPFromConfig();
   }
   // There are SSIDs in the list but there could also be an AP selected
   // Priority is SSID list before AP selected and config file
   else if (ssids->size() > 0) {
     ap_config = ssids->get(0).essid;
     if (ap_config.length() > MAX_AP_NAME_SIZE) {
-      #ifdef HAS_SCREEN
+      #if defined(HAS_SCREEN) && !defined(MARAUDER_V8)
         this->sendToDisplay(F("The given AP name is too large. Touch to exit..."));
       #endif
-      Serial.println("The provided AP name is too large.\nUse stopscan...");
+      #ifndef MARAUDER_V8
+        Serial.println("The provided AP name is too large.\nUse stopscan...");
+      #endif
       return false;
     }
-    #ifdef HAS_SCREEN
+    #if defined(HAS_SCREEN) && !defined(MARAUDER_V8)
       this->sendToDisplay(F("AP name from SSID list"));
       this->sendToDisplay("AP name: " + ap_config);
     #endif
-    Serial.println("AP name from SSID list: " + ap_config);
+    #ifndef MARAUDER_V8
+      Serial.println("AP name from SSID list: " + ap_config);
+    #endif
   }
   else if (temp_ap_name != "") {
     if (temp_ap_name.length() > MAX_AP_NAME_SIZE) {
-      #ifdef HAS_SCREEN
+      #if defined(HAS_SCREEN) && !defined(MARAUDER_V8)
         this->sendToDisplay(F("The given AP name is too large. Touch to exit..."));
       #endif
-      Serial.println("The given AP name is too large.\nUse stopscan...");
+      #ifndef MARAUDER_V8
+        Serial.println("The given AP name is too large.\nUse stopscan...");
+      #endif
     }
     else {
       ap_config = temp_ap_name;
-      #ifdef HAS_SCREEN
+      #if defined(HAS_SCREEN) && !defined(MARAUDER_V8)
         this->sendToDisplay(F("AP name from AP list"));
         this->sendToDisplay("AP name: " + ap_config);
       #endif
-      Serial.println("AP name from AP list: " + ap_config);
+      #ifndef MARAUDER_V8
+        Serial.println("AP name from AP list: " + ap_config);
+      #endif
     }
   }
   else {
-    Serial.println(F("Could not configure Access Point. Use stopscan..."));
-    #ifdef HAS_SCREEN
+    #ifndef MARAUDER_V8
+      Serial.println(F("Could not configure Access Point. Use stopscan..."));
+    #endif
+    #if defined(HAS_SCREEN) && !defined(MARAUDER_V8)
       this->sendToDisplay(F("Could not configure Access Point.\nTouch to exit..."));
     #endif
   }
@@ -295,13 +267,39 @@ bool EvilPortal::setAP(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_
   if (ap_config != "") {
     strncpy(apName, ap_config.c_str(), MAX_AP_NAME_SIZE);
     this->has_ap = true;
-    Serial.println(F("ap config set"));
+    #ifndef MARAUDER_V8
+      Serial.println(F("ap config set"));
+    #endif
     this->ap_index = targ_ap_index;
     return true;
   }
   else
     return false;
 
+}
+
+bool EvilPortal::setAPFromConfig() {
+  #ifdef HAS_SD
+    File ap_config_file = sd_obj.getFile("/ap.config.txt");
+  #else
+    File ap_config_file;
+  #endif
+
+  if (!ap_config_file || ap_config_file.size() > MAX_AP_NAME_SIZE) {
+    if (ap_config_file)
+      ap_config_file.close();
+    return false;
+  }
+
+  String ap_config = ap_config_file.readString();
+  ap_config_file.close();
+
+  if (this->setAP(ap_config)) {
+    this->ap_index = -1;
+    return true;
+  }
+
+  return false;
 }
 
 bool EvilPortal::setAP(String essid) {
@@ -312,9 +310,12 @@ bool EvilPortal::setAP(String essid) {
     return false;
   }
 
-  strncpy(apName, essid.c_str(), MAX_AP_NAME_SIZE);
+  strncpy(apName, essid.c_str(), MAX_AP_NAME_SIZE - 1);
+  apName[MAX_AP_NAME_SIZE - 1] = '\0';
   this->has_ap = true;
-  Serial.println(F("ap config set"));
+  #ifndef MARAUDER_V8
+    Serial.println(F("ap config set"));
+  #endif
   return true;
 }
 

--- a/esp32_marauder/EvilPortal.h
+++ b/esp32_marauder/EvilPortal.h
@@ -122,6 +122,7 @@ class EvilPortal {
     String get_user_name();
     String get_password();
     bool setAP(String essid);
+    bool setAPFromConfig();
     void setup();
     bool begin(LinkedList<ssid>* ssids, LinkedList<AccessPoint>* access_points);
     void main(uint8_t scan_mode);

--- a/esp32_marauder/FirmwareMetadata.cpp
+++ b/esp32_marauder/FirmwareMetadata.cpp
@@ -1,0 +1,114 @@
+#include "FirmwareMetadata.h"
+
+#ifdef PIO_UNIT_TESTING
+  #define HARDWARE_NAME "Native test target"
+#else
+  #include "configs.h"
+#endif
+
+namespace MarauderFirmware {
+namespace {
+
+constexpr uint8_t METADATA_MAGIC[METADATA_MAGIC_SIZE] = {
+  'M', 'R', 'D', 'R', 'F', 'W', 'I', 'D'
+};
+
+constexpr uint8_t METADATA_END_MAGIC[METADATA_MAGIC_SIZE] = {
+  'D', 'I', 'W', 'F', 'R', 'D', 'R', 'M'
+};
+
+#if defined(CONFIG_IDF_TARGET_ESP32C5)
+  #define MARAUDER_CHIP_ID "esp32c5"
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+  #define MARAUDER_CHIP_ID "esp32c6"
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+  #define MARAUDER_CHIP_ID "esp32s3"
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+  #define MARAUDER_CHIP_ID "esp32s2"
+#elif defined(CONFIG_IDF_TARGET_ESP32)
+  #define MARAUDER_CHIP_ID "esp32"
+#else
+  #define MARAUDER_CHIP_ID "native"
+#endif
+
+const Metadata CURRENT_METADATA = {
+  {'M', 'R', 'D', 'R', 'F', 'W', 'I', 'D'},
+  METADATA_SCHEMA_VERSION,
+  {0, 0, 0},
+  HARDWARE_NAME,
+  MARAUDER_CHIP_ID,
+  {'D', 'I', 'W', 'F', 'R', 'D', 'R', 'M'}
+};
+
+}  // namespace
+
+MetadataScanner::MetadataScanner()
+  : candidate{}, magic_index(0), capture_index(0), capturing(false), valid(false) {}
+
+bool MetadataScanner::push(uint8_t byte) {
+  if (valid)
+    return true;
+
+  if (!capturing) {
+    if (byte == METADATA_MAGIC[magic_index]) {
+      candidate.magic[magic_index++] = byte;
+      if (magic_index == METADATA_MAGIC_SIZE) {
+        capturing = true;
+        capture_index = METADATA_MAGIC_SIZE;
+      }
+    }
+    else {
+      magic_index = byte == METADATA_MAGIC[0] ? 1 : 0;
+      if (magic_index == 1)
+        candidate.magic[0] = byte;
+    }
+    return false;
+  }
+
+  reinterpret_cast<uint8_t*>(&candidate)[capture_index++] = byte;
+  if (capture_index < sizeof(Metadata))
+    return false;
+
+  valid = validMetadata(candidate);
+  if (!valid) {
+    uint8_t replay[sizeof(Metadata) - 1];
+    memcpy(replay, reinterpret_cast<const uint8_t*>(&candidate) + 1, sizeof(replay));
+    candidate = {};
+    magic_index = 0;
+    capture_index = 0;
+    capturing = false;
+    for (size_t i = 0; i < sizeof(replay) && !valid; i++)
+      push(replay[i]);
+  }
+  return valid;
+}
+
+bool MetadataScanner::found() const {
+  return valid;
+}
+
+const Metadata& MetadataScanner::metadata() const {
+  return candidate;
+}
+
+bool validMetadata(const Metadata& metadata) {
+  return memcmp(metadata.magic, METADATA_MAGIC, METADATA_MAGIC_SIZE) == 0 &&
+         metadata.schema_version == METADATA_SCHEMA_VERSION &&
+         metadata.hardware[0] != '\0' &&
+         metadata.chip[0] != '\0' &&
+         memchr(metadata.hardware, '\0', sizeof(metadata.hardware)) != nullptr &&
+         memchr(metadata.chip, '\0', sizeof(metadata.chip)) != nullptr &&
+         memcmp(metadata.end_magic, METADATA_END_MAGIC, METADATA_MAGIC_SIZE) == 0;
+}
+
+bool metadataMatches(const Metadata& candidate, const Metadata& current) {
+  return validMetadata(candidate) && validMetadata(current) &&
+         strncmp(candidate.hardware, current.hardware, sizeof(current.hardware)) == 0 &&
+         strncmp(candidate.chip, current.chip, sizeof(current.chip)) == 0;
+}
+
+const Metadata& currentMetadata() {
+  return CURRENT_METADATA;
+}
+
+}  // namespace MarauderFirmware

--- a/esp32_marauder/FirmwareMetadata.h
+++ b/esp32_marauder/FirmwareMetadata.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace MarauderFirmware {
+
+constexpr size_t METADATA_MAGIC_SIZE = 8;
+constexpr size_t METADATA_HARDWARE_SIZE = 48;
+constexpr size_t METADATA_CHIP_SIZE = 12;
+constexpr uint8_t METADATA_SCHEMA_VERSION = 1;
+
+struct __attribute__((packed)) Metadata {
+  uint8_t magic[METADATA_MAGIC_SIZE];
+  uint8_t schema_version;
+  uint8_t reserved[3];
+  char hardware[METADATA_HARDWARE_SIZE];
+  char chip[METADATA_CHIP_SIZE];
+  uint8_t end_magic[METADATA_MAGIC_SIZE];
+};
+
+class MetadataScanner {
+ public:
+  MetadataScanner();
+
+  bool push(uint8_t byte);
+  bool found() const;
+  const Metadata& metadata() const;
+
+ private:
+  Metadata candidate;
+  size_t magic_index;
+  size_t capture_index;
+  bool capturing;
+  bool valid;
+};
+
+bool validMetadata(const Metadata& metadata);
+bool metadataMatches(const Metadata& candidate, const Metadata& current);
+const Metadata& currentMetadata();
+
+}  // namespace MarauderFirmware

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -2359,6 +2359,16 @@ void MenuFunctions::RunSetup()
   this->addNodes(&evilPortalMenu, text09, TFTLIGHTGREY, 0, [this]() {
     this->changeMenu(evilPortalMenu.parentMenu, true);
   });
+  this->addNodes(&evilPortalMenu, "AP Config", TFTMAGENTA, SD_UPDATE, [this]() {
+    if (evil_portal_obj.setAPFromConfig()) {
+      display_obj.clearScreen();
+      this->drawStatusBar();
+      wifi_scan_obj.StartScan(WIFI_SCAN_EVIL_PORTAL, TFT_MAGENTA);
+      wifi_scan_obj.setMac();
+    }
+    else
+      this->changeMenu(&evilPortalMenu, true);
+  });
   this->addNodes(&evilPortalMenu, "Access Points", TFTGREEN, BEACON_SNIFF, [this]() {
     this->changeMenu(&wifiAPMenu, true);
   });

--- a/esp32_marauder/SDInterface.cpp
+++ b/esp32_marauder/SDInterface.cpp
@@ -391,11 +391,18 @@ void SDInterface::runUpdate(String file_name) {
     size_t updateSize = updateBin.size();
 
     if (updateSize > 0) {
+      if (!this->validateUpdate(updateBin)) {
+        updateBin.close();
+        return;
+      }
       #ifdef HAS_SCREEN
         display_obj.tft.println(F(text_table2[1]));
       #endif
       Serial.println(F("Starting update over SD. Please wait..."));
-      this->performUpdate(updateBin, updateSize);
+      if (!this->performUpdate(updateBin, updateSize)) {
+        updateBin.close();
+        return;
+      }
     }
     else {
       #ifdef HAS_SCREEN
@@ -406,6 +413,7 @@ void SDInterface::runUpdate(String file_name) {
       #ifdef HAS_SCREEN
         display_obj.tft.setTextColor(TFT_WHITE);
       #endif
+      updateBin.close();
       return;
     }
 
@@ -415,11 +423,16 @@ void SDInterface::runUpdate(String file_name) {
     #ifdef HAS_SCREEN
       display_obj.tft.println(F(text_table2[3]));
     #endif
-    const esp_partition_t *running = esp_ota_get_running_partition();
-
     const esp_partition_t *next = esp_ota_get_next_update_partition(NULL);
-
-    esp_err_t result = esp_ota_set_boot_partition(next);
+    if (next == nullptr || esp_ota_set_boot_partition(next) != ESP_OK) {
+      #ifdef HAS_SCREEN
+        display_obj.tft.setTextColor(TFT_RED);
+        display_obj.tft.println(F("Could not select updated firmware"));
+        display_obj.tft.setTextColor(TFT_WHITE);
+      #endif
+      Serial.println(F("Update verified but boot partition selection failed"));
+      return;
+    }
      
     ESP.restart();
   }
@@ -435,7 +448,68 @@ void SDInterface::runUpdate(String file_name) {
   }
 }
 
-void SDInterface::performUpdate(Stream &updateSource, size_t updateSize) {
+bool SDInterface::validateUpdate(File &updateBin) {
+  MarauderFirmware::MetadataScanner scanner;
+  uint8_t buffer[512];
+  updateBin.seek(0);
+
+  while (updateBin.available() && !scanner.found()) {
+    size_t bytes_read = updateBin.read(buffer, sizeof(buffer));
+    for (size_t i = 0; i < bytes_read && !scanner.found(); i++)
+      scanner.push(buffer[i]);
+  }
+
+  updateBin.seek(0);
+
+  #ifdef ALLOW_UNVERIFIED_SD_UPDATE
+    if (!scanner.found()) {
+      Serial.println(F("WARNING: firmware identity missing; developer override accepted update"));
+      return true;
+    }
+  #endif
+
+  if (!scanner.found()) {
+    #ifdef HAS_SCREEN
+      display_obj.tft.setTextColor(TFT_RED);
+      display_obj.tft.println(F("Rejected: not a validated Marauder image"));
+      display_obj.tft.setTextColor(TFT_WHITE);
+    #endif
+    Serial.println(F("Rejected SD update: Marauder firmware identity not found"));
+    return false;
+  }
+
+  const MarauderFirmware::Metadata &candidate = scanner.metadata();
+  const MarauderFirmware::Metadata &current = MarauderFirmware::currentMetadata();
+  if (!MarauderFirmware::metadataMatches(candidate, current)) {
+    #ifdef ALLOW_UNVERIFIED_SD_UPDATE
+      Serial.println(F("WARNING: firmware identity mismatch; developer override accepted update"));
+      return true;
+    #else
+      #ifdef HAS_SCREEN
+        display_obj.tft.setTextColor(TFT_RED);
+        display_obj.tft.println(F("Rejected: firmware is for another device"));
+        display_obj.tft.setTextColor(TFT_WHITE);
+      #endif
+      Serial.print(F("Rejected SD update: expected "));
+      Serial.print(current.hardware);
+      Serial.print(F("/"));
+      Serial.print(current.chip);
+      Serial.print(F(", got "));
+      Serial.print(candidate.hardware);
+      Serial.print(F("/"));
+      Serial.println(candidate.chip);
+      return false;
+    #endif
+  }
+
+  Serial.print(F("Validated SD update for "));
+  Serial.print(candidate.hardware);
+  Serial.print(F("/"));
+  Serial.println(candidate.chip);
+  return true;
+}
+
+bool SDInterface::performUpdate(Stream &updateSource, size_t updateSize) {
   if (Update.begin(updateSize)) {   
     #ifdef HAS_SCREEN
       display_obj.tft.println(text_table2[5] + String(updateSize));
@@ -459,10 +533,12 @@ void SDInterface::performUpdate(Stream &updateSource, size_t updateSize) {
       Serial.print(F("/"));
       Serial.print(updateSize);
       Serial.println(F(". Retry?"));
+      Update.abort();
+      return false;
     }
     if (Update.end()) {
       if (Update.isFinished()) {
-
+        return true;
       }
       else {
         #ifdef HAS_SCREEN
@@ -473,6 +549,7 @@ void SDInterface::performUpdate(Stream &updateSource, size_t updateSize) {
         #ifdef HAS_SCREEN
           display_obj.tft.setTextColor(TFT_WHITE);
         #endif
+        return false;
       }
     }
     else {
@@ -481,6 +558,7 @@ void SDInterface::performUpdate(Stream &updateSource, size_t updateSize) {
       #endif
       Serial.print(F("Error Occurred. Error #: "));
       Serial.println(Update.getError());
+      return false;
     }
 
   }
@@ -490,5 +568,6 @@ void SDInterface::performUpdate(Stream &updateSource, size_t updateSize) {
       display_obj.tft.println(text_table2[14]);
     #endif
     Serial.println(F("Not enough space to begin OTA"));
+    return false;
   }
 }

--- a/esp32_marauder/SDInterface.h
+++ b/esp32_marauder/SDInterface.h
@@ -15,6 +15,7 @@
   #include "SPI.h"
 #endif
 #include "Buffer.h"
+#include "FirmwareMetadata.h"
 #ifdef HAS_SCREEN
   #include "Display.h"
 #endif
@@ -44,6 +45,8 @@ class SDInterface {
     int _cs;
   #endif
 
+    bool validateUpdate(File &updateBin);
+
   public:
     #ifdef HAS_C5_SD
       SDInterface(SPIClass* spi, int cs);
@@ -67,7 +70,7 @@ class SDInterface {
     void listDirToLinkedList(LinkedList<String>* file_names, String str_dir = "/", String ext = "");
     File getFile(String path);
     void runUpdate(String file_name = "");
-    void performUpdate(Stream &updateSource, size_t updateSize);
+    bool performUpdate(Stream &updateSource, size_t updateSize);
     bool removeFile(String file_path);
     bool migrateSPIFFS(uint8_t operation, size_t& files, size_t& bytes, uint8_t& error);
 };

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -4585,7 +4585,12 @@ void WiFiScan::RunEapolScan(uint8_t scan_mode, uint16_t color) {
     led_obj.setMode(MODE_SNIFF);
   #endif*/
 
-  this->send_deauth = settings_obj.loadSetting<bool>(text_table4[5]);
+  // Explicit active PMKID scan modes must win over the persistent ForcePMKID
+  // preference. Previously sniffpmkid -d selected an active mode here, but this
+  // assignment discarded that request whenever ForcePMKID was disabled.
+  this->send_deauth = (scan_mode == WIFI_SCAN_ACTIVE_EAPOL) ||
+                      (scan_mode == WIFI_SCAN_ACTIVE_LIST_EAPOL) ||
+                      settings_obj.loadSetting<bool>(text_table4[5]);
   
   num_eapol = 0;
 

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -8,6 +8,10 @@
 
   //#define DEVELOPER
 
+  // Developer-only escape hatch for unsigned or mismatched SD update images.
+  // Production builds must remain fail-closed.
+  //#define ALLOW_UNVERIFIED_SD_UPDATE
+
   //// BOARD TARGETS
   //#define MARAUDER_M5STICKC
   //#define MARAUDER_M5STICKCP2

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,7 @@ build_src_filter =
   +<TargetListSort.cpp>
   +<TDongleStats.cpp>
   +<IPv4Range.cpp>
+  +<FirmwareMetadata.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/test_firmware_metadata/test_main.cpp
+++ b/test/test_firmware_metadata/test_main.cpp
@@ -1,0 +1,102 @@
+#include <unity.h>
+
+#include <cstring>
+#include <vector>
+
+#include "FirmwareMetadata.h"
+
+using MarauderFirmware::Metadata;
+using MarauderFirmware::MetadataScanner;
+
+namespace {
+
+Metadata makeMetadata(const char* hardware, const char* chip) {
+  Metadata metadata = {
+    {'M', 'R', 'D', 'R', 'F', 'W', 'I', 'D'},
+    MarauderFirmware::METADATA_SCHEMA_VERSION,
+    {0, 0, 0},
+    {},
+    {},
+    {'D', 'I', 'W', 'F', 'R', 'D', 'R', 'M'}
+  };
+  strncpy(metadata.hardware, hardware, sizeof(metadata.hardware) - 1);
+  strncpy(metadata.chip, chip, sizeof(metadata.chip) - 1);
+  return metadata;
+}
+
+Metadata scan(const std::vector<uint8_t>& bytes, bool& found) {
+  MetadataScanner scanner;
+  for (uint8_t byte : bytes)
+    scanner.push(byte);
+  found = scanner.found();
+  return scanner.metadata();
+}
+
+std::vector<uint8_t> imageWith(const Metadata& metadata) {
+  std::vector<uint8_t> image(37, 0xA5);
+  const uint8_t* bytes = reinterpret_cast<const uint8_t*>(&metadata);
+  image.insert(image.end(), bytes, bytes + sizeof(metadata));
+  image.insert(image.end(), 19, 0x5A);
+  return image;
+}
+
+void test_scanner_finds_valid_metadata_inside_image() {
+  Metadata expected = makeMetadata("Marauder v8", "esp32c5");
+  bool found = false;
+  Metadata actual = scan(imageWith(expected), found);
+  TEST_ASSERT_TRUE(found);
+  TEST_ASSERT_EQUAL_STRING(expected.hardware, actual.hardware);
+  TEST_ASSERT_EQUAL_STRING(expected.chip, actual.chip);
+}
+
+void test_scanner_rejects_invalid_trailer() {
+  Metadata metadata = makeMetadata("Marauder v8", "esp32c5");
+  metadata.end_magic[0] = 'X';
+  bool found = true;
+  scan(imageWith(metadata), found);
+  TEST_ASSERT_FALSE(found);
+}
+
+void test_scanner_recovers_when_false_magic_precedes_metadata() {
+  Metadata invalid = makeMetadata("Wrong", "esp32");
+  invalid.end_magic[0] = 'X';
+  Metadata expected = makeMetadata("Marauder v8", "esp32c5");
+  std::vector<uint8_t> image = imageWith(invalid);
+  std::vector<uint8_t> valid_image = imageWith(expected);
+  image.insert(image.end(), valid_image.begin(), valid_image.end());
+  bool found = false;
+  Metadata actual = scan(image, found);
+  TEST_ASSERT_TRUE(found);
+  TEST_ASSERT_EQUAL_STRING(expected.hardware, actual.hardware);
+}
+
+void test_metadata_match_requires_hardware_and_chip() {
+  Metadata current = makeMetadata("Marauder v8", "esp32c5");
+  TEST_ASSERT_TRUE(MarauderFirmware::metadataMatches(
+    makeMetadata("Marauder v8", "esp32c5"), current));
+  TEST_ASSERT_FALSE(MarauderFirmware::metadataMatches(
+    makeMetadata("Marauder Mini v3", "esp32c5"), current));
+  TEST_ASSERT_FALSE(MarauderFirmware::metadataMatches(
+    makeMetadata("Marauder v8", "esp32s3"), current));
+}
+
+void test_metadata_requires_terminated_identity_fields() {
+  Metadata metadata = makeMetadata("Marauder v8", "esp32c5");
+  memset(metadata.hardware, 'A', sizeof(metadata.hardware));
+  TEST_ASSERT_FALSE(MarauderFirmware::validMetadata(metadata));
+}
+
+}  // namespace
+
+void setUp() {}
+void tearDown() {}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_scanner_finds_valid_metadata_inside_image);
+  RUN_TEST(test_scanner_rejects_invalid_trailer);
+  RUN_TEST(test_scanner_recovers_when_false_magic_precedes_metadata);
+  RUN_TEST(test_metadata_match_requires_hardware_and_chip);
+  RUN_TEST(test_metadata_requires_terminated_identity_fields);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- honor active PMKID deauthentication and launch Evil Portal AP configuration correctly
- prevent repeated Evil Portal handler registration
- validate SD firmware identity and reboot only after a verified update