### PR TITLE
Add cross-hardware Recon mission mode

### DIFF
--- a/.github/workflows/recon_converter.yml
+++ b/.github/workflows/recon_converter.yml
@@ -1,0 +1,42 @@
+name: Recon desktop converter
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tools/recon_*.py"
+      - "tools/RECON_CONVERTER_README.md"
+      - ".github/workflows/recon_converter.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: package ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows
+          - os: macos-latest
+            name: macos
+          - os: ubuntu-latest
+            name: linux
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --disable-pip-version-check pyinstaller==6.15.0
+      - run: python -m unittest tools.test_recon_report
+      - run: python -m PyInstaller --onefile --windowed --name Marauder-Recon-Converter tools/recon_converter.py
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: Marauder-Recon-Converter-${{ matrix.name }}
+          path: |
+            dist/Marauder-Recon-Converter*
+            tools/RECON_CONVERTER_README.md
+          if-no-files-found: error

--- a/esp32_marauder/Buffer.cpp
+++ b/esp32_marauder/Buffer.cpp
@@ -9,21 +9,22 @@ Buffer::Buffer(){
 
 void Buffer::createFile(const char* name, bool is_pcap, bool is_gpx){
   int i=0;
+  String prefix = directory ? String(directory) + "/" : "/";
   if (is_pcap) {
     do{
-      fileName = "/"+String(name)+"_"+(String)i+".pcap";
+      fileName = prefix+String(name)+"_"+(String)i+".pcap";
       i++;
     } while(fs->exists(fileName));
   }
   else if ((!is_pcap) && (!is_gpx)) {
     do{
-      fileName = "/"+String(name)+"_"+(String)i+".log";
+      fileName = prefix+String(name)+"_"+(String)i+".log";
       i++;
     } while(fs->exists(fileName));
   }
   else {
     do{
-      fileName = "/"+String(name)+"_"+(String)i+".gpx";
+      fileName = prefix+String(name)+"_"+(String)i+".gpx";
       i++;
     } while(fs->exists(fileName));
   }
@@ -51,6 +52,10 @@ void Buffer::open(bool is_pcap){
 
 String Buffer::getFileName() {
   return this->fileName;
+}
+
+void Buffer::setDirectory(const char* path) {
+  directory = path;
 }
 
 void Buffer::openFile(const char* file_name, fs::FS* fs, bool serial, bool is_pcap, bool is_gpx) {

--- a/esp32_marauder/Buffer.h
+++ b/esp32_marauder/Buffer.h
@@ -38,7 +38,7 @@ class Buffer {
     void write(const uint8_t* buf, uint32_t len);
     void saveFs();
     void saveSerial();
-    
+
     uint8_t* bufA;
     uint8_t* bufB;
 

--- a/esp32_marauder/Buffer.h
+++ b/esp32_marauder/Buffer.h
@@ -26,6 +26,7 @@ class Buffer {
     void append(String log);
     void save();
     String getFileName();
+    void setDirectory(const char* path);
   private:
     void createFile(const char* name, bool is_pcap, bool is_gpx = false);
     void open(bool is_pcap);
@@ -49,6 +50,7 @@ class Buffer {
     bool saving = false; // currently saving onto the SD card
 
     String fileName = "/0.pcap";
+    const char* directory = NULL;
     File file;
     fs::FS* fs;
     bool serial;

--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -290,6 +290,7 @@ void CommandLine::runCommand(String input) {
     Serial.println(HELP_NMEA_CMD);
     Serial.println(HELP_GPS_POI_CMD);
     Serial.println(HELP_GPS_TRACKER_CMD);
+    Serial.println(HELP_RECON_CMD);
     
     // WiFi sniff/scan
     Serial.println(HELP_EVIL_PORTAL_CMD);
@@ -371,6 +372,7 @@ void CommandLine::runCommand(String input) {
     }
 
     wifi_scan_obj.StartScan(WIFI_SCAN_OFF);
+    recon_obj.stop();
 
     if(old_scan_mode == WIFI_SCAN_GPS_NMEA)
       Serial.println(F("END OF NMEA STREAM"));
@@ -384,6 +386,30 @@ void CommandLine::runCommand(String input) {
       display_obj.init();
       menu_function_obj.changeMenu(menu_function_obj.current_menu);
     #endif
+  }
+  else if (cmd_args.get(0) == RECON_CMD) {
+    if (cmd_args.size() < 2 || cmd_args.get(1) == "status") {
+      Serial.println(recon_obj.active() ? F("active") : F("stopped"));
+    }
+    else if (cmd_args.get(1) == "stop") {
+      recon_obj.stop();
+      wifi_scan_obj.StartScan(WIFI_SCAN_OFF);
+      Serial.println(F("stopped"));
+    }
+    else {
+      if (wifi_scan_obj.scanning()) {
+        Serial.println(F("Stop the current scan before starting Recon"));
+      }
+      else if (cmd_args.get(1) == "wifi") {
+        if (recon_obj.start(ReconMode::WIFI_RECON)) Serial.println(F("active"));
+      }
+      #ifdef HAS_BT
+        else if (cmd_args.get(1) == "ble") {
+          if (recon_obj.start(ReconMode::BLE_RECON)) Serial.println(F("active"));
+        }
+      #endif
+      else Serial.println(HELP_RECON_CMD);
+    }
   }
   else if (cmd_args.get(0) == GPS_DATA_CMD) {
     #ifdef HAS_GPS

--- a/esp32_marauder/CommandLine.h
+++ b/esp32_marauder/CommandLine.h
@@ -16,6 +16,7 @@
   #include "SDInterface.h"
 #endif
 #include "settings.h"
+#include "ReconMission.h"
 #if defined(HAS_NEOPIXEL_LED)
   #include "LedInterface.h"
 #endif
@@ -31,6 +32,7 @@ extern WiFiScan wifi_scan_obj;
   extern SDInterface sd_obj;
 #endif
 extern Settings settings_obj;
+extern ReconMission recon_obj;
 #if defined(HAS_NEOPIXEL_LED)
   extern LedInterface led_obj;
 #endif
@@ -65,6 +67,7 @@ const char PROGMEM GPS_CMD[] = "gps";
 const char PROGMEM NMEA_CMD[] = "nmea";
 const char PROGMEM GPS_POI_CMD[] = "gpspoi";
 const char PROGMEM GPS_TRACKER_CMD[] = "gpstracker";
+const char PROGMEM RECON_CMD[] = "recon";
 
 // WiFi sniff/scan
 const char PROGMEM EVIL_PORTAL_CMD[] = "evilportal";
@@ -146,6 +149,7 @@ const char PROGMEM HELP_GPS_DATA_CMD[] = "gpsdata";
 const char PROGMEM HELP_GPS_CMD[] = "gps [-t] [-g] <fix/sat/lon/lat/alt/date/accuracy/text/nmea>\r\n    [-n] <native/all/gps/glonass/galileo/navic/qzss/beidou>\r\n         [-b = use BD vs GB for beidou]";
 const char PROGMEM HELP_GPS_POI_CMD[] = "gpspoi -s/-m/-e";
 const char PROGMEM HELP_GPS_TRACKER_CMD[] = "gpstracker -c <start/stop>";
+const char PROGMEM HELP_RECON_CMD[] = "recon wifi|ble|status|stop";
 const char PROGMEM HELP_NMEA_CMD[] = "nmea";
 
 // WiFi sniff/scan

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1883,9 +1883,11 @@ void MenuFunctions::RunSetup()
   #endif
 
   foxHuntMenu.list = new LinkedList<MenuNode>();
+  reconMenu.list = new LinkedList<MenuNode>();
 
   // Work menu names
   mainMenu.name = text_table1[6];
+  reconMenu.name = "Recon";
   wifiMenu.name = text_table1[7];
   deviceMenu.name = text_table1[9];
   failedUpdateMenu.name = text_table1[11];
@@ -1949,6 +1951,25 @@ void MenuFunctions::RunSetup()
 
   // Build Main Menu
   mainMenu.parentMenu = NULL;
+  reconMenu.parentMenu = &mainMenu;
+  this->addNodes(&reconMenu, text09, TFTLIGHTGREY, 0, [this]() {
+    this->changeMenu(&mainMenu, true);
+  });
+  this->addNodes(&reconMenu, "Start WiFi", TFTGREEN, WIFI, [this]() {
+    display_obj.clearScreen();
+    this->drawStatusBar();
+    recon_obj.start(ReconMode::WIFI_RECON);
+  });
+  #ifdef HAS_BT
+    this->addNodes(&reconMenu, "Start BLE", TFTCYAN, BLUETOOTH, [this]() {
+      display_obj.clearScreen();
+      this->drawStatusBar();
+      recon_obj.start(ReconMode::BLE_RECON);
+    });
+  #endif
+  this->addNodes(&mainMenu, "Recon", TFTMAGENTA, GENERAL_APPS, [this]() {
+    this->changeMenu(&reconMenu, true);
+  });
   this->addNodes(&mainMenu, text_table1[7], TFTGREEN, WIFI, [this]() {
     this->changeMenu(&wifiMenu, true);
   });

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -18,6 +18,7 @@
 #define BATTERY_ANALOG_ON 0
 
 #include "WiFiScan.h"
+#include "ReconMission.h"
 #include "TargetListSort.h"
 #include "BatteryInterface.h"
 #include "SDInterface.h"
@@ -43,6 +44,7 @@
 #endif
 
 extern WiFiScan wifi_scan_obj;
+extern ReconMission recon_obj;
 extern SDInterface sd_obj;
 // #ifdef HAS_BATTERY
 extern BatteryInterface battery_obj;
@@ -168,6 +170,7 @@ class MenuFunctions
 
     // Main menu stuff
     Menu mainMenu;
+    Menu reconMenu;
 
     Menu wifiMenu;
     Menu bluetoothMenu;

--- a/esp32_marauder/ReconMission.cpp
+++ b/esp32_marauder/ReconMission.cpp
@@ -95,6 +95,7 @@ bool ReconMission::start(ReconMode mode) {
   ui_relationship_head = 0;
   memset(signal_history, 0, sizeof(signal_history));
   signal_history_count = 0;
+  pending_signal_peak = -128;
   memset(channel_activity, 0, sizeof(channel_activity));
   suppress_scan_ui = true;
 
@@ -341,14 +342,7 @@ void ReconMission::writeProbe(const ReconProbeEvent& event) {
 }
 
 void ReconMission::recordSignal(int8_t rssi, uint8_t channel) {
-  if (rssi > -127) {
-    if (signal_history_count < sizeof(signal_history)) {
-      signal_history[signal_history_count++] = rssi;
-    } else {
-      memmove(signal_history, signal_history + 1, sizeof(signal_history) - 1);
-      signal_history[sizeof(signal_history) - 1] = rssi;
-    }
-  }
+  if (rssi > pending_signal_peak) pending_signal_peak = rssi;
   if (!channel) return;
   uint8_t channel_index = UINT8_MAX;
   #ifdef HAS_DUAL_BAND
@@ -484,6 +478,13 @@ void ReconMission::drawDashboard(uint32_t current_time) {
   #ifdef HAS_SCREEN
     if (last_dashboard && current_time - last_dashboard < 1000) return;
     last_dashboard = current_time;
+    if (signal_history_count < sizeof(signal_history)) {
+      signal_history[signal_history_count++] = pending_signal_peak;
+    } else {
+      memmove(signal_history, signal_history + 1, sizeof(signal_history) - 1);
+      signal_history[sizeof(signal_history) - 1] = pending_signal_peak;
+    }
+    pending_signal_peak = -128;
     const uint32_t seconds = (current_time - started_at) / 1000;
     bool gps_fix = false;
     #ifdef HAS_GPS
@@ -528,46 +529,69 @@ void ReconMission::drawDashboard(uint32_t current_time) {
     const int16_t body_top = 48;
     display_obj.tft.fillRect(0, body_top, TFT_WIDTH, TFT_HEIGHT - body_top, TFT_BLACK);
     #if TFT_HEIGHT < 160
-      const int16_t beacon_x = 7;
-      const int16_t beacon_y = body_top + 7;
-      const int16_t beacon_width = 50;
-      const int16_t beacon_height = 62;
+      const int16_t graph_x = 7;
+      const int16_t graph_y = body_top + 7;
+      const int16_t graph_width = 50;
+      const int16_t graph_height = 62;
     #elif TFT_WIDTH < 200
-      const int16_t beacon_x = (TFT_WIDTH - 84) / 2;
-      const int16_t beacon_y = body_top + 7;
-      const int16_t beacon_width = 84;
-      const int16_t beacon_height = 82;
+      const int16_t graph_x = (TFT_WIDTH - 84) / 2;
+      const int16_t graph_y = body_top + 7;
+      const int16_t graph_width = 84;
+      const int16_t graph_height = 82;
     #else
-      const int16_t beacon_x = 8;
-      const int16_t beacon_y = body_top + 7;
-      const int16_t beacon_width = 92;
-      const int16_t beacon_height = 88;
+      const int16_t graph_x = 8;
+      const int16_t graph_y = body_top + 7;
+      const int16_t graph_width = 92;
+      const int16_t graph_height = 88;
     #endif
     const int8_t latest_rssi = signal_history_count
                                  ? signal_history[signal_history_count - 1] : -128;
     const uint8_t lit_segments = reconSignalSegments(latest_rssi);
     const ReconSignalTrend trend = reconSignalTrend(signal_history, signal_history_count);
-    const uint16_t signal_color = lit_segments >= 4 ? TFT_GREEN :
+    const uint16_t signal_color = !lit_segments ? TFT_DARKGREY :
+                                  lit_segments >= 4 ? TFT_GREEN :
                                   lit_segments >= 2 ? TFT_YELLOW : TFT_ORANGE;
-    display_obj.tft.drawRect(beacon_x, beacon_y, beacon_width, beacon_height, TFT_DARKGREY);
-    display_obj.tft.fillCircle(beacon_x + beacon_width / 2, beacon_y + 10, 3,
-                              lit_segments ? signal_color : TFT_DARKGREY);
-    for (uint8_t segment = 0; segment < 5; segment++) {
-      const int16_t width = 12 + segment * 11;
-      const int16_t x = beacon_x + (beacon_width - width) / 2;
-      const int16_t y = beacon_y + 18 + segment * 8;
-      const uint16_t segment_color = segment < lit_segments ? signal_color : TFT_DARKGREY;
-      display_obj.tft.fillRect(x, y, width, 4, segment_color);
-    }
+    display_obj.tft.drawRect(graph_x, graph_y, graph_width, graph_height, TFT_DARKGREY);
+    display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+    display_obj.tft.drawString("RSSI", graph_x + 3, graph_y + 3, 1);
+    char rssi_label[6];
+    if (latest_rssi > -127) snprintf(rssi_label, sizeof(rssi_label), "%d", latest_rssi);
+    else snprintf(rssi_label, sizeof(rssi_label), "--");
     display_obj.tft.setTextColor(signal_color, TFT_BLACK);
-    display_obj.tft.drawCentreString(reconProximityLabel(latest_rssi),
-                                     beacon_x + beacon_width / 2,
-                                     beacon_y + beacon_height - 15, 1);
+    display_obj.tft.drawRightString(rssi_label, graph_x + graph_width - 3, graph_y + 3, 1);
+    const int16_t plot_left = graph_x + 3;
+    const int16_t plot_top = graph_y + 15;
+    const int16_t plot_width = graph_width - 6;
+    const int16_t plot_height = graph_height - 30;
+    for (uint8_t grid = 1; grid < 3; grid++)
+      display_obj.tft.drawFastHLine(plot_left, plot_top + (plot_height * grid) / 3,
+                                   plot_width, TFT_DARKGREY);
+    const uint8_t visible_samples = signal_history_count < plot_width
+                                      ? signal_history_count : plot_width;
+    const uint8_t first_sample = signal_history_count - visible_samples;
+    const int16_t first_x = plot_left + plot_width - visible_samples;
+    bool have_previous = false;
+    int16_t previous_x = 0;
+    int16_t previous_y = 0;
+    for (uint8_t sample = 0; sample < visible_samples; sample++) {
+      const uint8_t level = reconRssiPlotLevel(signal_history[first_sample + sample]);
+      if (!level) {
+        have_previous = false;
+        continue;
+      }
+      const int16_t x = first_x + sample;
+      const int16_t y = plot_top + plot_height - 1 - ((level - 1) * (plot_height - 1)) / 99;
+      if (have_previous) display_obj.tft.drawLine(previous_x, previous_y, x, y, signal_color);
+      else display_obj.tft.drawPixel(x, y, signal_color);
+      previous_x = x;
+      previous_y = y;
+      have_previous = true;
+    }
     const char* trend_label = trend == ReconSignalTrend::APPROACHING ? "CLOSING +" :
                               trend == ReconSignalTrend::DEPARTING ? "LEAVING -" : "STEADY";
     display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-    display_obj.tft.drawCentreString(trend_label, beacon_x + beacon_width / 2,
-                                     beacon_y + beacon_height + 2, 1);
+    display_obj.tft.drawCentreString(trend_label, graph_x + graph_width / 2,
+                                     graph_y + graph_height - 12, 1);
 
     display_obj.tft.setTextSize(1);
     display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);

--- a/esp32_marauder/ReconMission.cpp
+++ b/esp32_marauder/ReconMission.cpp
@@ -96,6 +96,7 @@ bool ReconMission::start(ReconMode mode) {
   memset(signal_history, 0, sizeof(signal_history));
   signal_history_count = 0;
   memset(channel_activity, 0, sizeof(channel_activity));
+  suppress_scan_ui = true;
 
   buffer_obj.setDirectory(NULL);
   #ifdef HAS_SD
@@ -174,6 +175,7 @@ void ReconMission::stop() {
   writeManifest(true);
   buffer_obj.setDirectory(NULL);
   running = false;
+  suppress_scan_ui = false;
 }
 
 void ReconMission::writeRelationship(const uint8_t station[6],
@@ -347,8 +349,20 @@ void ReconMission::recordSignal(int8_t rssi, uint8_t channel) {
       signal_history[sizeof(signal_history) - 1] = rssi;
     }
   }
-  if (channel > 0 && channel < 15 && channel_activity[channel - 1] < UINT16_MAX)
-    channel_activity[channel - 1]++;
+  if (!channel) return;
+  uint8_t channel_index = UINT8_MAX;
+  #ifdef HAS_DUAL_BAND
+    for (uint8_t index = 0; index < DUAL_BAND_CHANNELS; index++) {
+      if (wifi_scan_obj.dual_band_channels[index] == channel) {
+        channel_index = index;
+        break;
+      }
+    }
+  #else
+    if (channel <= MAX_CHANNEL) channel_index = channel - 1;
+  #endif
+  if (channel_index != UINT8_MAX && channel_activity[channel_index] < UINT16_MAX)
+    channel_activity[channel_index]++;
 }
 
 void ReconMission::queueDeauth(const uint8_t transmitter[6], const uint8_t bssid[6],
@@ -485,13 +499,12 @@ void ReconMission::drawDashboard(uint32_t current_time) {
                  static_cast<unsigned long>(station_count),
                  static_cast<unsigned long>(probe_count));
       #else
-        snprintf(status, sizeof(status), "REC W %lu:%02lu A%lu S%lu P%lu D%lu G%c",
+        snprintf(status, sizeof(status), "REC W %lu:%02lu A%lu S%lu P%lu G%c",
                  static_cast<unsigned long>(seconds / 60),
                  static_cast<unsigned long>(seconds % 60),
                  static_cast<unsigned long>(ap_count),
                  static_cast<unsigned long>(station_count),
-                 static_cast<unsigned long>(probe_count),
-                 static_cast<unsigned long>(deauth_count), gps_fix ? '+' : '-');
+                 static_cast<unsigned long>(probe_count), gps_fix ? '+' : '-');
       #endif
     } else {
       snprintf(status, sizeof(status), "REC B %lu:%02lu D%lu U%lu G%c",
@@ -507,15 +520,6 @@ void ReconMission::drawDashboard(uint32_t current_time) {
     display_obj.tft.setTextSize(1);
     display_obj.tft.setTextColor(TFT_BLACK, color);
     display_obj.tft.drawCentreString(status, (TFT_WIDTH / 2) + 4, 20, 1);
-    if (active_mode == ReconMode::WIFI_RECON) {
-      const bool deauth_active = last_deauth && current_time - last_deauth < RECON_DEAUTH_ALERT_MS;
-      display_obj.tft.fillRect(TFT_WIDTH - 34, 34, 32, 12, TFT_BLACK);
-      display_obj.tft.setTextColor(deauth_active ? TFT_RED : TFT_DARKGREY, TFT_BLACK);
-      char deauth_badge[7];
-      snprintf(deauth_badge, sizeof(deauth_badge), "D!%lu",
-               static_cast<unsigned long>(deauth_count % 1000));
-      display_obj.tft.drawRightString(deauth_badge, TFT_WIDTH - 3, 35, 1);
-    }
     while (display_obj.display_buffer->size()) display_obj.display_buffer->shift();
     #ifdef SCREEN_BUFFER
       while (display_obj.screen_buffer->size()) display_obj.screen_buffer->shift();
@@ -582,6 +586,12 @@ void ReconMission::drawDashboard(uint32_t current_time) {
       else
         snprintf(line, sizeof(line), "UPDATE %-3lu", (unsigned long)repeat_count);
       display_obj.tft.drawString(line, stats_x, body_top + 22, 1);
+      if (active_mode == ReconMode::WIFI_RECON) {
+        const bool deauth_active = last_deauth && current_time - last_deauth < RECON_DEAUTH_ALERT_MS;
+        snprintf(line, sizeof(line), "D! %-4lu", (unsigned long)deauth_count);
+        display_obj.tft.setTextColor(deauth_active ? TFT_RED : TFT_DARKGREY, TFT_BLACK);
+        display_obj.tft.drawString(line, stats_x, body_top + 36, 1);
+      }
     #elif TFT_WIDTH < 200
       if (active_mode == ReconMode::WIFI_RECON)
         snprintf(line, sizeof(line), "AP %lu  STA %lu", (unsigned long)ap_count,
@@ -595,6 +605,12 @@ void ReconMission::drawDashboard(uint32_t current_time) {
       else
         snprintf(line, sizeof(line), "UPDATE %lu", (unsigned long)repeat_count);
       display_obj.tft.drawCentreString(line, TFT_WIDTH / 2, body_top + 110, 1);
+      if (active_mode == ReconMode::WIFI_RECON) {
+        const bool deauth_active = last_deauth && current_time - last_deauth < RECON_DEAUTH_ALERT_MS;
+        snprintf(line, sizeof(line), "DEAUTH %lu", (unsigned long)deauth_count);
+        display_obj.tft.setTextColor(deauth_active ? TFT_RED : TFT_DARKGREY, TFT_BLACK);
+        display_obj.tft.drawCentreString(line, TFT_WIDTH / 2, body_top + 124, 1);
+      }
     #else
       const int16_t stats_x = 108;
       display_obj.tft.setTextColor(TFT_MAGENTA, TFT_BLACK);
@@ -609,6 +625,10 @@ void ReconMission::drawDashboard(uint32_t current_time) {
         display_obj.tft.drawString(line, stats_x, body_top + 56, 1);
         snprintf(line, sizeof(line), "UPDATE   %lu", (unsigned long)repeat_count);
         display_obj.tft.drawString(line, stats_x, body_top + 70, 1);
+        const bool deauth_active = last_deauth && current_time - last_deauth < RECON_DEAUTH_ALERT_MS;
+        snprintf(line, sizeof(line), "DEAUTH   %lu", (unsigned long)deauth_count);
+        display_obj.tft.setTextColor(deauth_active ? TFT_RED : TFT_DARKGREY, TFT_BLACK);
+        display_obj.tft.drawString(line, stats_x, body_top + 84, 1);
       } else {
         snprintf(line, sizeof(line), "BLE DEVICE  %lu", (unsigned long)ble_count);
         display_obj.tft.drawString(line, stats_x, body_top + 35, 1);
@@ -637,18 +657,39 @@ void ReconMission::drawDashboard(uint32_t current_time) {
         }
 
         if (active_mode == ReconMode::WIFI_RECON) {
+          #ifdef HAS_DUAL_BAND
+            const uint8_t channel_count = DUAL_BAND_CHANNELS;
+          #else
+            const uint8_t channel_count = MAX_CHANNEL;
+          #endif
+          const uint8_t page = reconChannelPage(current_time - started_at, channel_count);
+          const uint8_t first_channel = page * RECON_CHANNELS_PER_PAGE;
+          const uint8_t visible_channels = reconChannelsOnPage(page, channel_count);
           uint16_t peak = 1;
-          for (uint8_t channel = 0; channel < 14; channel++)
-            if (channel_activity[channel] > peak) peak = channel_activity[channel];
+          for (uint8_t offset = 0; offset < visible_channels; offset++)
+            if (channel_activity[first_channel + offset] > peak)
+              peak = channel_activity[first_channel + offset];
           const int16_t strip_y = TFT_HEIGHT - 31;
           display_obj.tft.setTextColor(TFT_DARKGREY, TFT_BLACK);
-          display_obj.tft.drawString("CH", 5, strip_y + 8, 1);
-          const int16_t slot = (TFT_WIDTH - 26) / 14;
-          for (uint8_t channel = 0; channel < 14; channel++) {
-            const int16_t height = 2 + (channel_activity[channel] * 14UL) / peak;
-            const int16_t x = 24 + channel * slot;
-            display_obj.tft.fillRect(x, strip_y + 17 - height, slot > 2 ? slot - 2 : 1,
-                                     height, channel_activity[channel] ? TFT_BLUE : TFT_DARKGREY);
+          display_obj.tft.drawString("CH", 3, strip_y + 7, 1);
+          const int16_t chart_left = 22;
+          const int16_t slot = (TFT_WIDTH - chart_left - 2) / visible_channels;
+          for (uint8_t offset = 0; offset < visible_channels; offset++) {
+            const uint8_t index = first_channel + offset;
+            const int16_t height = 2 + (channel_activity[index] * 12UL) / peak;
+            const int16_t x = chart_left + offset * slot;
+            display_obj.tft.fillRect(x + 1, strip_y + 16 - height,
+                                     slot > 3 ? slot - 3 : 1, height,
+                                     channel_activity[index] ? TFT_BLUE : TFT_DARKGREY);
+            #ifdef HAS_DUAL_BAND
+              const uint8_t channel = wifi_scan_obj.dual_band_channels[index];
+            #else
+              const uint8_t channel = index + 1;
+            #endif
+            char channel_label[4];
+            snprintf(channel_label, sizeof(channel_label), "%u", channel);
+            display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+            display_obj.tft.drawCentreString(channel_label, x + slot / 2, strip_y + 19, 1);
           }
         }
       #else

--- a/esp32_marauder/ReconMission.cpp
+++ b/esp32_marauder/ReconMission.cpp
@@ -577,9 +577,14 @@ void ReconMission::drawDashboard(uint32_t current_time) {
     #endif
     display_obj.tft.setTextColor(churn_in ? TFT_CYAN : TFT_DARKGREY, TFT_BLACK);
     display_obj.tft.drawRightString(churn_label, graph_x + graph_width - 3, graph_y + 3, 1);
-    const int16_t plot_left = graph_x + 3;
+    #if TFT_WIDTH >= 200 && TFT_HEIGHT >= 160
+      const int16_t plot_left = graph_x + 20;
+      const int16_t plot_width = graph_width - 23;
+    #else
+      const int16_t plot_left = graph_x + 3;
+      const int16_t plot_width = graph_width - 6;
+    #endif
     const int16_t plot_top = graph_y + 15;
-    const int16_t plot_width = graph_width - 6;
     const int16_t plot_height = graph_height - 29;
     for (uint8_t grid = 1; grid < 3; grid++)
       display_obj.tft.drawFastHLine(plot_left, plot_top + (plot_height * grid) / 3,
@@ -595,6 +600,17 @@ void ReconMission::drawDashboard(uint32_t current_time) {
       if (churn_in_history[index] > peak) peak = churn_in_history[index];
       if (churn_out_history[index] > peak) peak = churn_out_history[index];
     }
+    #if TFT_WIDTH >= 200 && TFT_HEIGHT >= 160
+      char scale_label[4];
+      display_obj.tft.setTextColor(TFT_DARKGREY, TFT_BLACK);
+      snprintf(scale_label, sizeof(scale_label), "%u", peak);
+      display_obj.tft.drawRightString(scale_label, plot_left - 3, plot_top - 3, 1);
+      snprintf(scale_label, sizeof(scale_label), "%u", (peak + 1) / 2);
+      display_obj.tft.drawRightString(scale_label, plot_left - 3,
+                                      plot_top + plot_height / 2 - 3, 1);
+      display_obj.tft.drawRightString("0", plot_left - 3,
+                                      plot_top + plot_height - 7, 1);
+    #endif
     for (uint8_t sample = 0; sample < visible_samples; sample++) {
       const uint8_t index = first_sample + sample;
       const int16_t x = first_x + sample * 3;

--- a/esp32_marauder/ReconMission.cpp
+++ b/esp32_marauder/ReconMission.cpp
@@ -93,9 +93,13 @@ bool ReconMission::start(ReconMode mode) {
   ui_event_head = 0;
   memset(ui_relationships, 0, sizeof(ui_relationships));
   ui_relationship_head = 0;
-  memset(signal_history, 0, sizeof(signal_history));
-  signal_history_count = 0;
-  pending_signal_peak = -128;
+  memset(churn_in_history, 0, sizeof(churn_in_history));
+  memset(churn_out_history, 0, sizeof(churn_out_history));
+  churn_history_count = 0;
+  pending_churn_in = 0;
+  pending_churn_out = 0;
+  band_24_observations = 0;
+  band_5_observations = 0;
   memset(channel_activity, 0, sizeof(channel_activity));
   suppress_scan_ui = true;
 
@@ -228,8 +232,10 @@ void ReconMission::pruneStaleDevices(uint32_t current_time) {
 
   if (stations) {
     for (int index = stations->size() - 1; index >= 0; index--) {
-      if (reconDeviceExpired(current_time, stations->get(index).last_seen_ms))
+      if (reconDeviceExpired(current_time, stations->get(index).last_seen_ms)) {
         stations->remove(index);
+        pending_churn_out++;
+      }
     }
   }
 
@@ -239,7 +245,10 @@ void ReconMission::pruneStaleDevices(uint32_t current_time) {
       if (stations) {
         for (int station_index = stations->size() - 1; station_index >= 0; station_index--) {
           Station station = stations->get(station_index);
-          if (station.ap == ap_index) stations->remove(station_index);
+          if (station.ap == ap_index) {
+            stations->remove(station_index);
+            pending_churn_out++;
+          }
           else if (station.ap > ap_index) {
             station.ap--;
             stations->set(station_index, station);
@@ -249,14 +258,17 @@ void ReconMission::pruneStaleDevices(uint32_t current_time) {
       LinkedList<uint16_t>* links = access_points->get(ap_index).stations;
       if (links) delete links;
       access_points->remove(ap_index);
+      pending_churn_out++;
     }
   }
 
   #ifdef HAS_BT
     if (ble_devices) {
       for (int index = ble_devices->size() - 1; index >= 0; index--) {
-        if (reconDeviceExpired(current_time, ble_devices->get(index).last_seen_ms))
+        if (reconDeviceExpired(current_time, ble_devices->get(index).last_seen_ms)) {
           ble_devices->remove(index);
+          pending_churn_out++;
+        }
       }
     }
   #endif
@@ -266,9 +278,9 @@ void ReconMission::pruneStaleDevices(uint32_t current_time) {
 
 void ReconMission::writeObservation(char type, const uint8_t mac[6], int rssi,
                                     uint8_t channel) {
-  if (type == 'a') ap_count++;
-  else if (type == 's') station_count++;
-  else if (type == 'b') ble_count++;
+  if (type == 'a') { ap_count++; pending_churn_in++; }
+  else if (type == 's') { station_count++; pending_churn_in++; }
+  else if (type == 'b') { ble_count++; pending_churn_in++; }
   else if (type != 'd') repeat_count++;
   recordUiEvent(type, mac, static_cast<int8_t>(rssi));
   recordSignal(static_cast<int8_t>(rssi), channel);
@@ -342,7 +354,7 @@ void ReconMission::writeProbe(const ReconProbeEvent& event) {
 }
 
 void ReconMission::recordSignal(int8_t rssi, uint8_t channel) {
-  if (rssi > pending_signal_peak) pending_signal_peak = rssi;
+  (void)rssi;
   if (!channel) return;
   uint8_t channel_index = UINT8_MAX;
   #ifdef HAS_DUAL_BAND
@@ -355,8 +367,11 @@ void ReconMission::recordSignal(int8_t rssi, uint8_t channel) {
   #else
     if (channel <= MAX_CHANNEL) channel_index = channel - 1;
   #endif
-  if (channel_index != UINT8_MAX && channel_activity[channel_index] < UINT16_MAX)
-    channel_activity[channel_index]++;
+  if (channel_index != UINT8_MAX) {
+    if (channel_activity[channel_index] < UINT16_MAX) channel_activity[channel_index]++;
+    if (channel <= 14) band_24_observations++;
+    else band_5_observations++;
+  }
 }
 
 void ReconMission::queueDeauth(const uint8_t transmitter[6], const uint8_t bssid[6],
@@ -478,13 +493,19 @@ void ReconMission::drawDashboard(uint32_t current_time) {
   #ifdef HAS_SCREEN
     if (last_dashboard && current_time - last_dashboard < 1000) return;
     last_dashboard = current_time;
-    if (signal_history_count < sizeof(signal_history)) {
-      signal_history[signal_history_count++] = pending_signal_peak;
+    const uint8_t churn_in = pending_churn_in > UINT8_MAX ? UINT8_MAX : pending_churn_in;
+    const uint8_t churn_out = pending_churn_out > UINT8_MAX ? UINT8_MAX : pending_churn_out;
+    if (churn_history_count < sizeof(churn_in_history)) {
+      churn_in_history[churn_history_count] = churn_in;
+      churn_out_history[churn_history_count++] = churn_out;
     } else {
-      memmove(signal_history, signal_history + 1, sizeof(signal_history) - 1);
-      signal_history[sizeof(signal_history) - 1] = pending_signal_peak;
+      memmove(churn_in_history, churn_in_history + 1, sizeof(churn_in_history) - 1);
+      memmove(churn_out_history, churn_out_history + 1, sizeof(churn_out_history) - 1);
+      churn_in_history[sizeof(churn_in_history) - 1] = churn_in;
+      churn_out_history[sizeof(churn_out_history) - 1] = churn_out;
     }
-    pending_signal_peak = -128;
+    pending_churn_in = 0;
+    pending_churn_out = 0;
     const uint32_t seconds = (current_time - started_at) / 1000;
     bool gps_fix = false;
     #ifdef HAS_GPS
@@ -544,54 +565,58 @@ void ReconMission::drawDashboard(uint32_t current_time) {
       const int16_t graph_width = 92;
       const int16_t graph_height = 88;
     #endif
-    const int8_t latest_rssi = signal_history_count
-                                 ? signal_history[signal_history_count - 1] : -128;
-    const uint8_t lit_segments = reconSignalSegments(latest_rssi);
-    const ReconSignalTrend trend = reconSignalTrend(signal_history, signal_history_count);
-    const uint16_t signal_color = !lit_segments ? TFT_DARKGREY :
-                                  lit_segments >= 4 ? TFT_GREEN :
-                                  lit_segments >= 2 ? TFT_YELLOW : TFT_ORANGE;
     display_obj.tft.drawRect(graph_x, graph_y, graph_width, graph_height, TFT_DARKGREY);
     display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-    display_obj.tft.drawString("RSSI", graph_x + 3, graph_y + 3, 1);
-    char rssi_label[6];
-    if (latest_rssi > -127) snprintf(rssi_label, sizeof(rssi_label), "%d", latest_rssi);
-    else snprintf(rssi_label, sizeof(rssi_label), "--");
-    display_obj.tft.setTextColor(signal_color, TFT_BLACK);
-    display_obj.tft.drawRightString(rssi_label, graph_x + graph_width - 3, graph_y + 3, 1);
+    char churn_label[10];
+    #if TFT_HEIGHT < 160
+      display_obj.tft.drawString("C", graph_x + 3, graph_y + 3, 1);
+      snprintf(churn_label, sizeof(churn_label), "+%u-%u", churn_in, churn_out);
+    #else
+      display_obj.tft.drawString("CHURN", graph_x + 3, graph_y + 3, 1);
+      snprintf(churn_label, sizeof(churn_label), "+%u -%u", churn_in, churn_out);
+    #endif
+    display_obj.tft.setTextColor(churn_in ? TFT_CYAN : TFT_DARKGREY, TFT_BLACK);
+    display_obj.tft.drawRightString(churn_label, graph_x + graph_width - 3, graph_y + 3, 1);
     const int16_t plot_left = graph_x + 3;
     const int16_t plot_top = graph_y + 15;
     const int16_t plot_width = graph_width - 6;
-    const int16_t plot_height = graph_height - 30;
+    const int16_t plot_height = graph_height - 29;
     for (uint8_t grid = 1; grid < 3; grid++)
       display_obj.tft.drawFastHLine(plot_left, plot_top + (plot_height * grid) / 3,
                                    plot_width, TFT_DARKGREY);
-    const uint8_t visible_samples = signal_history_count < plot_width
-                                      ? signal_history_count : plot_width;
-    const uint8_t first_sample = signal_history_count - visible_samples;
-    const int16_t first_x = plot_left + plot_width - visible_samples;
-    bool have_previous = false;
-    int16_t previous_x = 0;
-    int16_t previous_y = 0;
+    const uint8_t sample_slots = plot_width / 3;
+    const uint8_t visible_samples = churn_history_count < sample_slots
+                                      ? churn_history_count : sample_slots;
+    const uint8_t first_sample = churn_history_count - visible_samples;
+    const int16_t first_x = plot_left + plot_width - visible_samples * 3;
+    uint8_t peak = 1;
     for (uint8_t sample = 0; sample < visible_samples; sample++) {
-      const uint8_t level = reconRssiPlotLevel(signal_history[first_sample + sample]);
-      if (!level) {
-        have_previous = false;
-        continue;
-      }
-      const int16_t x = first_x + sample;
-      const int16_t y = plot_top + plot_height - 1 - ((level - 1) * (plot_height - 1)) / 99;
-      if (have_previous) display_obj.tft.drawLine(previous_x, previous_y, x, y, signal_color);
-      else display_obj.tft.drawPixel(x, y, signal_color);
-      previous_x = x;
-      previous_y = y;
-      have_previous = true;
+      const uint8_t index = first_sample + sample;
+      if (churn_in_history[index] > peak) peak = churn_in_history[index];
+      if (churn_out_history[index] > peak) peak = churn_out_history[index];
     }
-    const char* trend_label = trend == ReconSignalTrend::APPROACHING ? "CLOSING +" :
-                              trend == ReconSignalTrend::DEPARTING ? "LEAVING -" : "STEADY";
-    display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-    display_obj.tft.drawCentreString(trend_label, graph_x + graph_width / 2,
-                                     graph_y + graph_height - 12, 1);
+    for (uint8_t sample = 0; sample < visible_samples; sample++) {
+      const uint8_t index = first_sample + sample;
+      const int16_t x = first_x + sample * 3;
+      const uint8_t in_height = reconChurnHeight(churn_in_history[index], peak, plot_height);
+      const uint8_t out_height = reconChurnHeight(churn_out_history[index], peak, plot_height);
+      if (in_height)
+        display_obj.tft.drawFastHLine(x, plot_top + plot_height - in_height, 2, TFT_CYAN);
+      if (out_height)
+        display_obj.tft.drawFastHLine(x, plot_top + plot_height - out_height, 2, TFT_ORANGE);
+    }
+    const uint32_t band_total = band_24_observations + band_5_observations;
+    const uint8_t band_24_percent = band_total
+                                      ? (static_cast<uint64_t>(band_24_observations) * 100ULL) /
+                                          band_total : 0;
+    const uint8_t band_5_percent = band_total ? 100 - band_24_percent : 0;
+    char band_label[20];
+    snprintf(band_label, sizeof(band_label), "2G%u 5G%u", band_24_percent, band_5_percent);
+    #if TFT_HEIGHT >= 160
+      display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+      display_obj.tft.drawCentreString(band_label, graph_x + graph_width / 2,
+                                       graph_y + graph_height - 12, 1);
+    #endif
 
     display_obj.tft.setTextSize(1);
     display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
@@ -615,6 +640,8 @@ void ReconMission::drawDashboard(uint32_t current_time) {
         snprintf(line, sizeof(line), "D! %-4lu", (unsigned long)deauth_count);
         display_obj.tft.setTextColor(deauth_active ? TFT_RED : TFT_DARKGREY, TFT_BLACK);
         display_obj.tft.drawString(line, stats_x, body_top + 36, 1);
+        display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+        display_obj.tft.drawString(band_label, stats_x, body_top + 50, 1);
       }
     #elif TFT_WIDTH < 200
       if (active_mode == ReconMode::WIFI_RECON)

--- a/esp32_marauder/ReconMission.cpp
+++ b/esp32_marauder/ReconMission.cpp
@@ -1,0 +1,560 @@
+#include "ReconMission.h"
+
+#include "Buffer.h"
+#include "WiFiScan.h"
+#ifdef HAS_SCREEN
+  #include "Display.h"
+#endif
+#ifdef HAS_GPS
+  #include "GpsInterface.h"
+#endif
+#ifdef HAS_SD
+  #include "SDInterface.h"
+#endif
+
+extern LinkedList<AccessPoint>* access_points;
+extern LinkedList<Station>* stations;
+extern LinkedList<BleDevice>* ble_devices;
+extern WiFiScan wifi_scan_obj;
+extern Buffer buffer_obj;
+#ifdef HAS_SCREEN
+  extern Display display_obj;
+#endif
+#ifdef HAS_GPS
+  extern GpsInterface gps_obj;
+#endif
+#ifdef HAS_SD
+  extern SDInterface sd_obj;
+#endif
+
+namespace {
+struct __attribute__((packed)) ReconLogHeader {
+  char magic[4] = {'R', 'C', 'N', '1'};
+};
+
+struct __attribute__((packed)) ReconLogRecord {
+  uint32_t elapsed_ms;
+  int32_t latitude;
+  int32_t longitude;
+  uint8_t mac[6];
+  int8_t rssi;
+  uint8_t channel;
+  char type;
+};
+
+struct __attribute__((packed)) ReconProbeHeader {
+  char magic[4] = {'P', 'R', 'B', '1'};
+};
+
+struct __attribute__((packed)) ReconProbeRecord {
+  uint32_t elapsed_ms;
+  int32_t latitude;
+  int32_t longitude;
+  uint8_t mac[6];
+  int8_t rssi;
+  uint8_t channel;
+  uint8_t name_length;
+  char name[RECON_PROBE_NAME_MAX];
+};
+
+struct __attribute__((packed)) ReconRelationshipHeader {
+  char magic[4] = {'R', 'E', 'L', '1'};
+};
+
+struct __attribute__((packed)) ReconRelationshipRecord {
+  uint8_t station[6];
+  uint8_t access_point[6];
+};
+
+portMUX_TYPE probe_queue_mux = portMUX_INITIALIZER_UNLOCKED;
+}  // namespace
+
+bool ReconMission::start(ReconMode mode) {
+  if (running || wifi_scan_obj.scanning()) return false;
+  active_mode = mode;
+  started_at = millis();
+  last_sample = 0;
+  last_dashboard = 0;
+  pending_flush = 0;
+  probe_pending_flush = 0;
+  ap_count = 0;
+  station_count = 0;
+  ble_count = 0;
+  probe_count = 0;
+  repeat_count = 0;
+  probe_queue.reset();
+  repeat_queue.reset();
+  repeat_gate.reset();
+  memset(ui_events, 0, sizeof(ui_events));
+  ui_event_head = 0;
+
+  buffer_obj.setDirectory(NULL);
+  #ifdef HAS_SD
+    session_dir[0] = '\0';
+    if (sd_obj.supported) {
+      SD.mkdir("/recon");
+      for (uint16_t index = 0; index < 10000; index++) {
+        snprintf(session_dir, sizeof(session_dir), "/recon/m%04u", index);
+        if (!SD.exists(session_dir) && SD.mkdir(session_dir)) break;
+        session_dir[0] = '\0';
+      }
+      if (session_dir[0]) buffer_obj.setDirectory(session_dir);
+    }
+  #endif
+
+  wifi_scan_obj.StartScan(active_mode == ReconMode::WIFI_RECON ? WIFI_SCAN_AP_STA : BT_SCAN_ALL,
+                          active_mode == ReconMode::WIFI_RECON ? TFT_MAGENTA : TFT_CYAN);
+  state.reset();
+  if (active_mode == ReconMode::WIFI_RECON) {
+    state.consume(ReconSource::AP_LIST, access_points ? access_points->size() : 0);
+    state.consume(ReconSource::STATION_LIST, stations ? stations->size() : 0);
+  } else {
+    state.consume(ReconSource::BLE_LIST, ble_devices ? ble_devices->size() : 0);
+  }
+
+  #ifdef HAS_SD
+    if (session_dir[0]) {
+      char file_name[36];
+      snprintf(file_name, sizeof(file_name), "%s/obs.rlog", session_dir);
+      log_file = SD.open(file_name, FILE_WRITE);
+      if (log_file) {
+        const ReconLogHeader header;
+        log_file.write(reinterpret_cast<const uint8_t*>(&header), sizeof(header));
+      }
+      snprintf(file_name, sizeof(file_name), "%s/probes.rlog", session_dir);
+      probe_file = SD.open(file_name, FILE_WRITE);
+      if (probe_file) {
+        const ReconProbeHeader header;
+        probe_file.write(reinterpret_cast<const uint8_t*>(&header), sizeof(header));
+      }
+      snprintf(file_name, sizeof(file_name), "%s/relations.rlog", session_dir);
+      relationship_file = SD.open(file_name, FILE_WRITE);
+      if (relationship_file) {
+        const ReconRelationshipHeader header;
+        relationship_file.write(reinterpret_cast<const uint8_t*>(&header), sizeof(header));
+      }
+    }
+  #endif
+
+  running = true;
+  writeManifest(false);
+  drawDashboard(started_at);
+  return true;
+}
+
+void ReconMission::stop() {
+  if (!running) return;
+  observeLists();
+  drainProbeQueue();
+  drainRepeatQueue();
+  #ifdef HAS_SD
+    if (log_file) {
+      log_file.flush();
+      log_file.close();
+    }
+    if (probe_file) {
+      probe_file.flush();
+      probe_file.close();
+    }
+    if (relationship_file) {
+      relationship_file.flush();
+      relationship_file.close();
+    }
+  #endif
+  writeManifest(true);
+  buffer_obj.setDirectory(NULL);
+  running = false;
+}
+
+void ReconMission::writeRelationship(const uint8_t station[6],
+                                      const uint8_t access_point[6]) {
+  #ifdef HAS_SD
+    if (!relationship_file) return;
+    ReconRelationshipRecord record;
+    memcpy(record.station, station, sizeof(record.station));
+    memcpy(record.access_point, access_point, sizeof(record.access_point));
+    relationship_file.write(reinterpret_cast<const uint8_t*>(&record), sizeof(record));
+  #else
+    (void)station;
+    (void)access_point;
+  #endif
+}
+
+void ReconMission::writeObservation(char type, const uint8_t mac[6], int rssi,
+                                    uint8_t channel) {
+  if (type == 'a') ap_count++;
+  else if (type == 's') station_count++;
+  else if (type == 'b') ble_count++;
+  else repeat_count++;
+  recordUiEvent(type, mac, static_cast<int8_t>(rssi));
+
+  ReconLogRecord record = {};
+  record.elapsed_ms = millis() - started_at;
+  record.rssi = static_cast<int8_t>(rssi);
+  record.channel = channel;
+  record.type = type;
+  memcpy(record.mac, mac, sizeof(record.mac));
+  #ifdef HAS_GPS
+    if (gps_obj.getFixStatus()) {
+      record.latitude = gps_obj.getLatInt();
+      record.longitude = gps_obj.getLonInt();
+    }
+  #endif
+
+  #ifdef HAS_SD
+    if (log_file) {
+      log_file.write(reinterpret_cast<const uint8_t*>(&record), sizeof(record));
+      if (++pending_flush >= 16) {
+        log_file.flush();
+        pending_flush = 0;
+      }
+    }
+  #endif
+}
+
+void ReconMission::queueProbe(const uint8_t mac[6], int8_t rssi, uint8_t channel,
+                              const uint8_t* name, uint8_t name_length) {
+  if (!running || active_mode != ReconMode::WIFI_RECON || !name || !name_length) return;
+  ReconProbeEvent event = {};
+  event.elapsed_ms = millis() - started_at;
+  memcpy(event.mac, mac, sizeof(event.mac));
+  event.rssi = rssi;
+  event.channel = channel;
+  event.name_length = min(name_length, static_cast<uint8_t>(RECON_PROBE_NAME_MAX));
+  memcpy(event.name, name, event.name_length);
+  portENTER_CRITICAL(&probe_queue_mux);
+  probe_queue.push(event);
+  portEXIT_CRITICAL(&probe_queue_mux);
+}
+
+void ReconMission::writeProbe(const ReconProbeEvent& event) {
+  probe_count++;
+  char label[13] = {};
+  memcpy(label, event.name, min(event.name_length, static_cast<uint8_t>(sizeof(label) - 1)));
+  recordUiEvent('p', event.mac, event.rssi, label);
+  #ifdef HAS_SD
+    if (!probe_file) return;
+    ReconProbeRecord record = {};
+    record.elapsed_ms = event.elapsed_ms;
+    memcpy(record.mac, event.mac, sizeof(record.mac));
+    record.rssi = event.rssi;
+    record.channel = event.channel;
+    record.name_length = event.name_length;
+    memcpy(record.name, event.name, event.name_length);
+    #ifdef HAS_GPS
+      if (gps_obj.getFixStatus()) {
+        record.latitude = gps_obj.getLatInt();
+        record.longitude = gps_obj.getLonInt();
+      }
+    #endif
+    probe_file.write(reinterpret_cast<const uint8_t*>(&record), sizeof(record));
+    if (++probe_pending_flush >= 16) {
+      probe_file.flush();
+      probe_pending_flush = 0;
+    }
+  #endif
+}
+
+void ReconMission::recordUiEvent(char type, const uint8_t mac[6], int8_t rssi,
+                                 const char* label) {
+  UiEvent& event = ui_events[ui_event_head++ % 4];
+  memcpy(event.mac, mac, sizeof(event.mac));
+  event.type = type;
+  event.rssi = rssi;
+  event.label[0] = '\0';
+  if (label) {
+    strncpy(event.label, label, sizeof(event.label) - 1);
+    event.label[sizeof(event.label) - 1] = '\0';
+  }
+}
+
+void ReconMission::queueRepeat(char type, const uint8_t mac[6], int8_t rssi,
+                               uint8_t channel) {
+  if (!running || (type == 'B') != (active_mode == ReconMode::BLE_RECON)) return;
+  portENTER_CRITICAL(&probe_queue_mux);
+  if (repeat_gate.accept(mac, rssi, millis())) {
+    ReconRepeatEvent event = {};
+    memcpy(event.mac, mac, sizeof(event.mac));
+    event.rssi = rssi;
+    event.channel = channel;
+    event.type = type;
+    repeat_queue.push(event);
+  }
+  portEXIT_CRITICAL(&probe_queue_mux);
+}
+
+void ReconMission::drainProbeQueue() {
+  ReconProbeEvent event;
+  while (true) {
+    portENTER_CRITICAL(&probe_queue_mux);
+    const bool available = probe_queue.pop(event);
+    portEXIT_CRITICAL(&probe_queue_mux);
+    if (!available) break;
+    writeProbe(event);
+  }
+}
+
+void ReconMission::drainRepeatQueue() {
+  ReconRepeatEvent event;
+  while (true) {
+    portENTER_CRITICAL(&probe_queue_mux);
+    const bool available = repeat_queue.pop(event);
+    portEXIT_CRITICAL(&probe_queue_mux);
+    if (!available) break;
+    writeObservation(event.type, event.mac, event.rssi, event.channel);
+  }
+}
+
+void ReconMission::writeManifest(bool complete) {
+  #ifdef HAS_SD
+    if (!session_dir[0]) return;
+    char path[40];
+    snprintf(path, sizeof(path), "%s/session.json", session_dir);
+    SD.remove(path);
+    File manifest = SD.open(path, FILE_WRITE);
+    if (!manifest) return;
+    bool gps_fix = false;
+    #ifdef HAS_GPS
+      gps_fix = gps_obj.getFixStatus();
+    #endif
+    const String capture = active_mode == ReconMode::WIFI_RECON
+                             ? buffer_obj.getFileName() : "";
+    manifest.printf(
+      "{\"schema\":1,\"state\":\"%s\",\"mode\":\"%s\",\"start_ms\":%lu,"
+      "\"duration_ms\":%lu,\"ap\":%lu,\"station\":%lu,\"ble\":%lu,"
+      "\"probe\":%lu,\"repeat\":%lu,\"dropped\":%u,\"gps_fix\":%s,"
+      "\"observations\":\"obs.rlog\",\"probes\":\"probes.rlog\","
+      "\"relationships\":\"relations.rlog\",\"capture\":\"%s\"}\n",
+      complete ? "complete" : "active",
+      active_mode == ReconMode::WIFI_RECON ? "wifi" : "ble",
+      static_cast<unsigned long>(started_at),
+      static_cast<unsigned long>(complete ? millis() - started_at : 0),
+      static_cast<unsigned long>(ap_count),
+      static_cast<unsigned long>(station_count),
+      static_cast<unsigned long>(ble_count),
+      static_cast<unsigned long>(probe_count),
+      static_cast<unsigned long>(repeat_count),
+      probe_queue.dropped() + repeat_queue.dropped(),
+      gps_fix ? "true" : "false", capture.c_str());
+    manifest.close();
+  #else
+    (void)complete;
+  #endif
+}
+
+void ReconMission::drawDashboard(uint32_t current_time) {
+  #ifdef HAS_SCREEN
+    if (last_dashboard && current_time - last_dashboard < 1000) return;
+    last_dashboard = current_time;
+    const uint32_t seconds = (current_time - started_at) / 1000;
+    bool gps_fix = false;
+    #ifdef HAS_GPS
+      gps_fix = gps_obj.getFixStatus();
+    #endif
+    char status[40];
+    if (active_mode == ReconMode::WIFI_RECON) {
+      #if TFT_WIDTH < 200
+        snprintf(status, sizeof(status), "R W %lu:%02lu A%lu S%lu P%lu",
+                 static_cast<unsigned long>(seconds / 60),
+                 static_cast<unsigned long>(seconds % 60),
+                 static_cast<unsigned long>(ap_count),
+                 static_cast<unsigned long>(station_count),
+                 static_cast<unsigned long>(probe_count));
+      #else
+        snprintf(status, sizeof(status), "REC W %lu:%02lu A%lu S%lu P%lu U%lu G%c",
+                 static_cast<unsigned long>(seconds / 60),
+                 static_cast<unsigned long>(seconds % 60),
+                 static_cast<unsigned long>(ap_count),
+                 static_cast<unsigned long>(station_count),
+                 static_cast<unsigned long>(probe_count),
+                 static_cast<unsigned long>(repeat_count), gps_fix ? '+' : '-');
+      #endif
+    } else {
+      snprintf(status, sizeof(status), "REC B %lu:%02lu D%lu U%lu G%c",
+               static_cast<unsigned long>(seconds / 60),
+               static_cast<unsigned long>(seconds % 60),
+               static_cast<unsigned long>(ble_count),
+               static_cast<unsigned long>(repeat_count), gps_fix ? '+' : '-');
+    }
+    const uint16_t color = active_mode == ReconMode::WIFI_RECON ? TFT_MAGENTA : TFT_CYAN;
+    display_obj.tft.fillRect(0, 16, TFT_WIDTH, 16, color);
+    display_obj.tft.fillCircle(7, 24, 3, TFT_RED);
+    display_obj.tft.setFreeFont(NULL);
+    display_obj.tft.setTextSize(1);
+    display_obj.tft.setTextColor(TFT_BLACK, color);
+    display_obj.tft.drawCentreString(status, (TFT_WIDTH / 2) + 4, 20, 1);
+    while (display_obj.display_buffer->size()) display_obj.display_buffer->shift();
+    #ifdef SCREEN_BUFFER
+      while (display_obj.screen_buffer->size()) display_obj.screen_buffer->shift();
+    #endif
+
+    const int16_t body_top = 48;
+    display_obj.tft.fillRect(0, body_top, TFT_WIDTH, TFT_HEIGHT - body_top, TFT_BLACK);
+    #if TFT_HEIGHT < 160
+      const int16_t meter_x = 7;
+      const int16_t meter_y = body_top + 10;
+      const int16_t meter_width = 50;
+      const int16_t meter_height = 54;
+    #elif TFT_WIDTH < 200
+      const int16_t meter_x = (TFT_WIDTH - 76) / 2;
+      const int16_t meter_y = body_top + 10;
+      const int16_t meter_width = 76;
+      const int16_t meter_height = 76;
+    #else
+      const int16_t meter_x = 10;
+      const int16_t meter_y = body_top + 10;
+      const int16_t meter_width = 84;
+      const int16_t meter_height = 84;
+    #endif
+    display_obj.tft.drawRect(meter_x, meter_y, meter_width, meter_height, TFT_DARKGREY);
+    display_obj.tft.drawFastHLine(meter_x + 1, meter_y + meter_height / 3,
+                                  meter_width - 2, TFT_DARKGREY);
+    display_obj.tft.drawFastHLine(meter_x + 1, meter_y + (meter_height * 2) / 3,
+                                  meter_width - 2, TFT_DARKGREY);
+    const int16_t slot_width = (meter_width - 6) / 4;
+    const int16_t baseline = meter_y + meter_height - 3;
+    for (uint8_t index = 0; index < 4; index++) {
+      const UiEvent& event = ui_events[(ui_event_head + index) % 4];
+      if (!event.type) continue;
+      uint16_t bar_color = TFT_CYAN;
+      if (event.type == 'a') bar_color = TFT_GREEN;
+      else if (event.type == 'p') bar_color = TFT_YELLOW;
+      else if (event.type == 'A' || event.type == 'S' || event.type == 'B')
+        bar_color = TFT_MAGENTA;
+      const uint8_t level = reconRssiLevel(event.rssi);
+      const int16_t x = meter_x + 3 + index * slot_width;
+      const int16_t bar_width = slot_width - 3 > 3 ? slot_width - 3 : 3;
+      if (level) {
+        const int16_t scaled_height = (meter_height - 7) * level / 8;
+        const int16_t bar_height = scaled_height > 2 ? scaled_height : 2;
+        display_obj.tft.fillRect(x, baseline - bar_height, bar_width, bar_height, bar_color);
+      } else {
+        display_obj.tft.drawRect(x, baseline - 3, bar_width, 3, TFT_DARKGREY);
+      }
+    }
+
+    display_obj.tft.setTextSize(1);
+    display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    char line[34];
+    #if TFT_HEIGHT < 160
+      const int16_t stats_x = 64;
+      if (active_mode == ReconMode::WIFI_RECON)
+        snprintf(line, sizeof(line), "AP %-4lu STA %-4lu", (unsigned long)ap_count,
+                 (unsigned long)station_count);
+      else
+        snprintf(line, sizeof(line), "BLE %-5lu", (unsigned long)ble_count);
+      display_obj.tft.drawString(line, stats_x, body_top + 8, 1);
+      if (active_mode == ReconMode::WIFI_RECON)
+        snprintf(line, sizeof(line), "PROBE %-3lu UPD %-3lu", (unsigned long)probe_count,
+                 (unsigned long)repeat_count);
+      else
+        snprintf(line, sizeof(line), "UPDATE %-3lu", (unsigned long)repeat_count);
+      display_obj.tft.drawString(line, stats_x, body_top + 22, 1);
+    #elif TFT_WIDTH < 200
+      if (active_mode == ReconMode::WIFI_RECON)
+        snprintf(line, sizeof(line), "AP %lu  STA %lu", (unsigned long)ap_count,
+                 (unsigned long)station_count);
+      else
+        snprintf(line, sizeof(line), "BLE DEVICES %lu", (unsigned long)ble_count);
+      display_obj.tft.drawCentreString(line, TFT_WIDTH / 2, body_top + 96, 1);
+      if (active_mode == ReconMode::WIFI_RECON)
+        snprintf(line, sizeof(line), "PROBE %lu  UPDATE %lu", (unsigned long)probe_count,
+                 (unsigned long)repeat_count);
+      else
+        snprintf(line, sizeof(line), "UPDATE %lu", (unsigned long)repeat_count);
+      display_obj.tft.drawCentreString(line, TFT_WIDTH / 2, body_top + 110, 1);
+    #else
+      const int16_t stats_x = 108;
+      display_obj.tft.setTextColor(TFT_MAGENTA, TFT_BLACK);
+      display_obj.tft.drawString("LIVE ACTIVITY", stats_x, body_top + 9, 1);
+      display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
+      if (active_mode == ReconMode::WIFI_RECON) {
+        snprintf(line, sizeof(line), "AP       %lu", (unsigned long)ap_count);
+        display_obj.tft.drawString(line, stats_x, body_top + 28, 1);
+        snprintf(line, sizeof(line), "STATION  %lu", (unsigned long)station_count);
+        display_obj.tft.drawString(line, stats_x, body_top + 42, 1);
+        snprintf(line, sizeof(line), "PROBE    %lu", (unsigned long)probe_count);
+        display_obj.tft.drawString(line, stats_x, body_top + 56, 1);
+        snprintf(line, sizeof(line), "UPDATE   %lu", (unsigned long)repeat_count);
+        display_obj.tft.drawString(line, stats_x, body_top + 70, 1);
+      } else {
+        snprintf(line, sizeof(line), "BLE DEVICE  %lu", (unsigned long)ble_count);
+        display_obj.tft.drawString(line, stats_x, body_top + 35, 1);
+        snprintf(line, sizeof(line), "UPDATE      %lu", (unsigned long)repeat_count);
+        display_obj.tft.drawString(line, stats_x, body_top + 55, 1);
+      }
+    #endif
+
+    #if TFT_HEIGHT >= 160
+      const int16_t event_y = TFT_HEIGHT - 34;
+      display_obj.tft.drawFastHLine(6, event_y - 5, TFT_WIDTH - 12, TFT_DARKGREY);
+      const UiEvent& latest = ui_events[(ui_event_head + 3) % 4];
+      if (latest.type) {
+        if (latest.type == 'p') snprintf(line, sizeof(line), "PROBE  %s", latest.label);
+        else snprintf(line, sizeof(line), "%s %02X:%02X:%02X",
+          (latest.type == 'a') ? "NEW AP " : (latest.type == 's') ? "NEW STA" :
+          (latest.type == 'b') ? "NEW BLE" : "UPDATE ",
+          latest.mac[3], latest.mac[4], latest.mac[5]);
+        display_obj.tft.setTextColor(latest.type == 'p' ? TFT_YELLOW : TFT_CYAN, TFT_BLACK);
+        display_obj.tft.drawString(line, 8, event_y, 1);
+      } else {
+        display_obj.tft.setTextColor(TFT_DARKGREY, TFT_BLACK);
+        display_obj.tft.drawString("Waiting for activity...", 8, event_y, 1);
+      }
+    #endif
+    display_obj.tft.setTextColor(active_mode == ReconMode::WIFI_RECON ? TFT_GREEN : TFT_CYAN,
+                                 TFT_BLACK);
+  #else
+    (void)current_time;
+  #endif
+}
+
+void ReconMission::observeLists() {
+  if (!running) return;
+  if (active_mode == ReconMode::WIFI_RECON) {
+    if (access_points) {
+      const ReconRange range = state.consume(ReconSource::AP_LIST, access_points->size());
+      for (size_t index = range.begin; index < range.end; index++) {
+        const AccessPoint& ap = access_points->get(index);
+        writeObservation('a', ap.bssid, ap.rssi, ap.channel);
+      }
+    }
+    if (stations) {
+      const ReconRange range = state.consume(ReconSource::STATION_LIST, stations->size());
+      for (size_t index = range.begin; index < range.end; index++) {
+        const Station& station = stations->get(index);
+        uint8_t channel = 0;
+        if (access_points && station.ap < access_points->size()) {
+          const AccessPoint& ap = access_points->get(station.ap);
+          channel = ap.channel;
+          writeRelationship(station.mac, ap.bssid);
+        }
+        writeObservation('s', station.mac, -128, channel);
+      }
+    }
+  } else {
+    #ifdef HAS_BT
+      if (ble_devices) {
+        const ReconRange range = state.consume(ReconSource::BLE_LIST, ble_devices->size());
+        for (size_t index = range.begin; index < range.end; index++) {
+          const BleDevice& device = ble_devices->get(index);
+          writeObservation('b', device.mac, device.rssi, 0);
+        }
+      }
+    #endif
+  }
+}
+
+void ReconMission::main(uint32_t current_time) {
+  if (!running) return;
+  if (!wifi_scan_obj.scanning()) {
+    stop();
+    return;
+  }
+  if (current_time - last_sample < 500) return;
+  last_sample = current_time;
+  observeLists();
+  drainProbeQueue();
+  drainRepeatQueue();
+  drawDashboard(current_time);
+}

--- a/esp32_marauder/ReconMission.cpp
+++ b/esp32_marauder/ReconMission.cpp
@@ -75,6 +75,8 @@ bool ReconMission::start(ReconMode mode) {
   started_at = millis();
   last_sample = 0;
   last_dashboard = 0;
+  last_prune = started_at;
+  last_deauth = 0;
   pending_flush = 0;
   probe_pending_flush = 0;
   ap_count = 0;
@@ -82,11 +84,18 @@ bool ReconMission::start(ReconMode mode) {
   ble_count = 0;
   probe_count = 0;
   repeat_count = 0;
+  deauth_count = 0;
   probe_queue.reset();
   repeat_queue.reset();
+  deauth_queue.reset();
   repeat_gate.reset();
   memset(ui_events, 0, sizeof(ui_events));
   ui_event_head = 0;
+  memset(ui_relationships, 0, sizeof(ui_relationships));
+  ui_relationship_head = 0;
+  memset(signal_history, 0, sizeof(signal_history));
+  signal_history_count = 0;
+  memset(channel_activity, 0, sizeof(channel_activity));
 
   buffer_obj.setDirectory(NULL);
   #ifdef HAS_SD
@@ -147,6 +156,7 @@ void ReconMission::stop() {
   observeLists();
   drainProbeQueue();
   drainRepeatQueue();
+  drainDeauthQueue();
   #ifdef HAS_SD
     if (log_file) {
       log_file.flush();
@@ -180,13 +190,85 @@ void ReconMission::writeRelationship(const uint8_t station[6],
   #endif
 }
 
+void ReconMission::recordRelationship(const Station& station,
+                                      const AccessPoint& access_point) {
+  UiRelationship& relationship = ui_relationships[ui_relationship_head++ % 3];
+  memcpy(relationship.station, station.mac, sizeof(relationship.station));
+  memcpy(relationship.access_point, access_point.bssid, sizeof(relationship.access_point));
+  const String& name = access_point.essid;
+  if (name.length()) {
+    name.substring(0, sizeof(relationship.ap_name) - 1)
+        .toCharArray(relationship.ap_name, sizeof(relationship.ap_name));
+  } else {
+    snprintf(relationship.ap_name, sizeof(relationship.ap_name), "%02X:%02X:%02X",
+             access_point.bssid[3], access_point.bssid[4], access_point.bssid[5]);
+  }
+}
+
+void ReconMission::rebuildStationLinks() {
+  if (!access_points || !stations) return;
+  for (int ap_index = 0; ap_index < access_points->size(); ap_index++) {
+    LinkedList<uint16_t>* links = access_points->get(ap_index).stations;
+    if (links) links->clear();
+  }
+  for (int station_index = 0; station_index < stations->size(); station_index++) {
+    Station station = stations->get(station_index);
+    if (station.ap >= access_points->size()) continue;
+    LinkedList<uint16_t>* links = access_points->get(station.ap).stations;
+    if (links) links->add(static_cast<uint16_t>(station_index));
+  }
+}
+
+void ReconMission::pruneStaleDevices(uint32_t current_time) {
+  if (current_time - last_prune < 15000) return;
+  last_prune = current_time;
+
+  if (stations) {
+    for (int index = stations->size() - 1; index >= 0; index--) {
+      if (reconDeviceExpired(current_time, stations->get(index).last_seen_ms))
+        stations->remove(index);
+    }
+  }
+
+  if (access_points) {
+    for (int ap_index = access_points->size() - 1; ap_index >= 0; ap_index--) {
+      if (!reconDeviceExpired(current_time, access_points->get(ap_index).last_seen_ms)) continue;
+      if (stations) {
+        for (int station_index = stations->size() - 1; station_index >= 0; station_index--) {
+          Station station = stations->get(station_index);
+          if (station.ap == ap_index) stations->remove(station_index);
+          else if (station.ap > ap_index) {
+            station.ap--;
+            stations->set(station_index, station);
+          }
+        }
+      }
+      LinkedList<uint16_t>* links = access_points->get(ap_index).stations;
+      if (links) delete links;
+      access_points->remove(ap_index);
+    }
+  }
+
+  #ifdef HAS_BT
+    if (ble_devices) {
+      for (int index = ble_devices->size() - 1; index >= 0; index--) {
+        if (reconDeviceExpired(current_time, ble_devices->get(index).last_seen_ms))
+          ble_devices->remove(index);
+      }
+    }
+  #endif
+
+  rebuildStationLinks();
+}
+
 void ReconMission::writeObservation(char type, const uint8_t mac[6], int rssi,
                                     uint8_t channel) {
   if (type == 'a') ap_count++;
   else if (type == 's') station_count++;
   else if (type == 'b') ble_count++;
-  else repeat_count++;
+  else if (type != 'd') repeat_count++;
   recordUiEvent(type, mac, static_cast<int8_t>(rssi));
+  recordSignal(static_cast<int8_t>(rssi), channel);
 
   ReconLogRecord record = {};
   record.elapsed_ms = millis() - started_at;
@@ -232,6 +314,7 @@ void ReconMission::writeProbe(const ReconProbeEvent& event) {
   char label[13] = {};
   memcpy(label, event.name, min(event.name_length, static_cast<uint8_t>(sizeof(label) - 1)));
   recordUiEvent('p', event.mac, event.rssi, label);
+  recordSignal(event.rssi, event.channel);
   #ifdef HAS_SD
     if (!probe_file) return;
     ReconProbeRecord record = {};
@@ -253,6 +336,33 @@ void ReconMission::writeProbe(const ReconProbeEvent& event) {
       probe_pending_flush = 0;
     }
   #endif
+}
+
+void ReconMission::recordSignal(int8_t rssi, uint8_t channel) {
+  if (rssi > -127) {
+    if (signal_history_count < sizeof(signal_history)) {
+      signal_history[signal_history_count++] = rssi;
+    } else {
+      memmove(signal_history, signal_history + 1, sizeof(signal_history) - 1);
+      signal_history[sizeof(signal_history) - 1] = rssi;
+    }
+  }
+  if (channel > 0 && channel < 15 && channel_activity[channel - 1] < UINT16_MAX)
+    channel_activity[channel - 1]++;
+}
+
+void ReconMission::queueDeauth(const uint8_t transmitter[6], const uint8_t bssid[6],
+                               int8_t rssi, uint8_t channel, uint16_t reason) {
+  if (!running || active_mode != ReconMode::WIFI_RECON) return;
+  ReconDeauthEvent event = {};
+  memcpy(event.transmitter, transmitter, sizeof(event.transmitter));
+  memcpy(event.bssid, bssid, sizeof(event.bssid));
+  event.rssi = rssi;
+  event.channel = channel;
+  event.reason = reason;
+  portENTER_CRITICAL(&probe_queue_mux);
+  deauth_queue.push(event);
+  portEXIT_CRITICAL(&probe_queue_mux);
 }
 
 void ReconMission::recordUiEvent(char type, const uint8_t mac[6], int8_t rssi,
@@ -305,6 +415,19 @@ void ReconMission::drainRepeatQueue() {
   }
 }
 
+void ReconMission::drainDeauthQueue() {
+  ReconDeauthEvent event;
+  while (true) {
+    portENTER_CRITICAL(&probe_queue_mux);
+    const bool available = deauth_queue.pop(event);
+    portEXIT_CRITICAL(&probe_queue_mux);
+    if (!available) break;
+    deauth_count++;
+    last_deauth = millis();
+    writeObservation('d', event.transmitter, event.rssi, event.channel);
+  }
+}
+
 void ReconMission::writeManifest(bool complete) {
   #ifdef HAS_SD
     if (!session_dir[0]) return;
@@ -322,7 +445,7 @@ void ReconMission::writeManifest(bool complete) {
     manifest.printf(
       "{\"schema\":1,\"state\":\"%s\",\"mode\":\"%s\",\"start_ms\":%lu,"
       "\"duration_ms\":%lu,\"ap\":%lu,\"station\":%lu,\"ble\":%lu,"
-      "\"probe\":%lu,\"repeat\":%lu,\"dropped\":%u,\"gps_fix\":%s,"
+      "\"probe\":%lu,\"repeat\":%lu,\"deauth\":%lu,\"dropped\":%u,\"gps_fix\":%s,"
       "\"observations\":\"obs.rlog\",\"probes\":\"probes.rlog\","
       "\"relationships\":\"relations.rlog\",\"capture\":\"%s\"}\n",
       complete ? "complete" : "active",
@@ -334,7 +457,8 @@ void ReconMission::writeManifest(bool complete) {
       static_cast<unsigned long>(ble_count),
       static_cast<unsigned long>(probe_count),
       static_cast<unsigned long>(repeat_count),
-      probe_queue.dropped() + repeat_queue.dropped(),
+      static_cast<unsigned long>(deauth_count),
+      probe_queue.dropped() + repeat_queue.dropped() + deauth_queue.dropped(),
       gps_fix ? "true" : "false", capture.c_str());
     manifest.close();
   #else
@@ -361,13 +485,13 @@ void ReconMission::drawDashboard(uint32_t current_time) {
                  static_cast<unsigned long>(station_count),
                  static_cast<unsigned long>(probe_count));
       #else
-        snprintf(status, sizeof(status), "REC W %lu:%02lu A%lu S%lu P%lu U%lu G%c",
+        snprintf(status, sizeof(status), "REC W %lu:%02lu A%lu S%lu P%lu D%lu G%c",
                  static_cast<unsigned long>(seconds / 60),
                  static_cast<unsigned long>(seconds % 60),
                  static_cast<unsigned long>(ap_count),
                  static_cast<unsigned long>(station_count),
                  static_cast<unsigned long>(probe_count),
-                 static_cast<unsigned long>(repeat_count), gps_fix ? '+' : '-');
+                 static_cast<unsigned long>(deauth_count), gps_fix ? '+' : '-');
       #endif
     } else {
       snprintf(status, sizeof(status), "REC B %lu:%02lu D%lu U%lu G%c",
@@ -383,6 +507,15 @@ void ReconMission::drawDashboard(uint32_t current_time) {
     display_obj.tft.setTextSize(1);
     display_obj.tft.setTextColor(TFT_BLACK, color);
     display_obj.tft.drawCentreString(status, (TFT_WIDTH / 2) + 4, 20, 1);
+    if (active_mode == ReconMode::WIFI_RECON) {
+      const bool deauth_active = last_deauth && current_time - last_deauth < RECON_DEAUTH_ALERT_MS;
+      display_obj.tft.fillRect(TFT_WIDTH - 34, 34, 32, 12, TFT_BLACK);
+      display_obj.tft.setTextColor(deauth_active ? TFT_RED : TFT_DARKGREY, TFT_BLACK);
+      char deauth_badge[7];
+      snprintf(deauth_badge, sizeof(deauth_badge), "D!%lu",
+               static_cast<unsigned long>(deauth_count % 1000));
+      display_obj.tft.drawRightString(deauth_badge, TFT_WIDTH - 3, 35, 1);
+    }
     while (display_obj.display_buffer->size()) display_obj.display_buffer->shift();
     #ifdef SCREEN_BUFFER
       while (display_obj.screen_buffer->size()) display_obj.screen_buffer->shift();
@@ -391,47 +524,46 @@ void ReconMission::drawDashboard(uint32_t current_time) {
     const int16_t body_top = 48;
     display_obj.tft.fillRect(0, body_top, TFT_WIDTH, TFT_HEIGHT - body_top, TFT_BLACK);
     #if TFT_HEIGHT < 160
-      const int16_t meter_x = 7;
-      const int16_t meter_y = body_top + 10;
-      const int16_t meter_width = 50;
-      const int16_t meter_height = 54;
+      const int16_t beacon_x = 7;
+      const int16_t beacon_y = body_top + 7;
+      const int16_t beacon_width = 50;
+      const int16_t beacon_height = 62;
     #elif TFT_WIDTH < 200
-      const int16_t meter_x = (TFT_WIDTH - 76) / 2;
-      const int16_t meter_y = body_top + 10;
-      const int16_t meter_width = 76;
-      const int16_t meter_height = 76;
+      const int16_t beacon_x = (TFT_WIDTH - 84) / 2;
+      const int16_t beacon_y = body_top + 7;
+      const int16_t beacon_width = 84;
+      const int16_t beacon_height = 82;
     #else
-      const int16_t meter_x = 10;
-      const int16_t meter_y = body_top + 10;
-      const int16_t meter_width = 84;
-      const int16_t meter_height = 84;
+      const int16_t beacon_x = 8;
+      const int16_t beacon_y = body_top + 7;
+      const int16_t beacon_width = 92;
+      const int16_t beacon_height = 88;
     #endif
-    display_obj.tft.drawRect(meter_x, meter_y, meter_width, meter_height, TFT_DARKGREY);
-    display_obj.tft.drawFastHLine(meter_x + 1, meter_y + meter_height / 3,
-                                  meter_width - 2, TFT_DARKGREY);
-    display_obj.tft.drawFastHLine(meter_x + 1, meter_y + (meter_height * 2) / 3,
-                                  meter_width - 2, TFT_DARKGREY);
-    const int16_t slot_width = (meter_width - 6) / 4;
-    const int16_t baseline = meter_y + meter_height - 3;
-    for (uint8_t index = 0; index < 4; index++) {
-      const UiEvent& event = ui_events[(ui_event_head + index) % 4];
-      if (!event.type) continue;
-      uint16_t bar_color = TFT_CYAN;
-      if (event.type == 'a') bar_color = TFT_GREEN;
-      else if (event.type == 'p') bar_color = TFT_YELLOW;
-      else if (event.type == 'A' || event.type == 'S' || event.type == 'B')
-        bar_color = TFT_MAGENTA;
-      const uint8_t level = reconRssiLevel(event.rssi);
-      const int16_t x = meter_x + 3 + index * slot_width;
-      const int16_t bar_width = slot_width - 3 > 3 ? slot_width - 3 : 3;
-      if (level) {
-        const int16_t scaled_height = (meter_height - 7) * level / 8;
-        const int16_t bar_height = scaled_height > 2 ? scaled_height : 2;
-        display_obj.tft.fillRect(x, baseline - bar_height, bar_width, bar_height, bar_color);
-      } else {
-        display_obj.tft.drawRect(x, baseline - 3, bar_width, 3, TFT_DARKGREY);
-      }
+    const int8_t latest_rssi = signal_history_count
+                                 ? signal_history[signal_history_count - 1] : -128;
+    const uint8_t lit_segments = reconSignalSegments(latest_rssi);
+    const ReconSignalTrend trend = reconSignalTrend(signal_history, signal_history_count);
+    const uint16_t signal_color = lit_segments >= 4 ? TFT_GREEN :
+                                  lit_segments >= 2 ? TFT_YELLOW : TFT_ORANGE;
+    display_obj.tft.drawRect(beacon_x, beacon_y, beacon_width, beacon_height, TFT_DARKGREY);
+    display_obj.tft.fillCircle(beacon_x + beacon_width / 2, beacon_y + 10, 3,
+                              lit_segments ? signal_color : TFT_DARKGREY);
+    for (uint8_t segment = 0; segment < 5; segment++) {
+      const int16_t width = 12 + segment * 11;
+      const int16_t x = beacon_x + (beacon_width - width) / 2;
+      const int16_t y = beacon_y + 18 + segment * 8;
+      const uint16_t segment_color = segment < lit_segments ? signal_color : TFT_DARKGREY;
+      display_obj.tft.fillRect(x, y, width, 4, segment_color);
     }
+    display_obj.tft.setTextColor(signal_color, TFT_BLACK);
+    display_obj.tft.drawCentreString(reconProximityLabel(latest_rssi),
+                                     beacon_x + beacon_width / 2,
+                                     beacon_y + beacon_height - 15, 1);
+    const char* trend_label = trend == ReconSignalTrend::APPROACHING ? "CLOSING +" :
+                              trend == ReconSignalTrend::DEPARTING ? "LEAVING -" : "STEADY";
+    display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+    display_obj.tft.drawCentreString(trend_label, beacon_x + beacon_width / 2,
+                                     beacon_y + beacon_height + 2, 1);
 
     display_obj.tft.setTextSize(1);
     display_obj.tft.setTextColor(TFT_WHITE, TFT_BLACK);
@@ -486,21 +618,61 @@ void ReconMission::drawDashboard(uint32_t current_time) {
     #endif
 
     #if TFT_HEIGHT >= 160
-      const int16_t event_y = TFT_HEIGHT - 34;
-      display_obj.tft.drawFastHLine(6, event_y - 5, TFT_WIDTH - 12, TFT_DARKGREY);
-      const UiEvent& latest = ui_events[(ui_event_head + 3) % 4];
-      if (latest.type) {
-        if (latest.type == 'p') snprintf(line, sizeof(line), "PROBE  %s", latest.label);
-        else snprintf(line, sizeof(line), "%s %02X:%02X:%02X",
-          (latest.type == 'a') ? "NEW AP " : (latest.type == 's') ? "NEW STA" :
-          (latest.type == 'b') ? "NEW BLE" : "UPDATE ",
-          latest.mac[3], latest.mac[4], latest.mac[5]);
-        display_obj.tft.setTextColor(latest.type == 'p' ? TFT_YELLOW : TFT_CYAN, TFT_BLACK);
-        display_obj.tft.drawString(line, 8, event_y, 1);
-      } else {
-        display_obj.tft.setTextColor(TFT_DARKGREY, TFT_BLACK);
-        display_obj.tft.drawString("Waiting for activity...", 8, event_y, 1);
-      }
+      #if TFT_WIDTH >= 200
+        const int16_t relation_y = body_top + 112;
+        display_obj.tft.drawFastHLine(6, relation_y - 6, TFT_WIDTH - 12, TFT_DARKGREY);
+        display_obj.tft.setTextColor(TFT_MAGENTA, TFT_BLACK);
+        display_obj.tft.drawString("NEW ASSOCIATIONS", 8, relation_y, 1);
+        for (uint8_t row = 0; row < 3; row++) {
+          const UiRelationship& relationship =
+              ui_relationships[(ui_relationship_head + row) % 3];
+          if (!relationship.ap_name[0]) continue;
+          char ap_name[13];
+          reconTruncate(relationship.ap_name, ap_name, sizeof(ap_name));
+          snprintf(line, sizeof(line), "%02X:%02X:%02X > %s",
+                   relationship.station[3], relationship.station[4], relationship.station[5],
+                   ap_name);
+          display_obj.tft.setTextColor(row == 2 ? TFT_CYAN : TFT_LIGHTGREY, TFT_BLACK);
+          display_obj.tft.drawString(line, 8, relation_y + 15 + row * 14, 1);
+        }
+
+        if (active_mode == ReconMode::WIFI_RECON) {
+          uint16_t peak = 1;
+          for (uint8_t channel = 0; channel < 14; channel++)
+            if (channel_activity[channel] > peak) peak = channel_activity[channel];
+          const int16_t strip_y = TFT_HEIGHT - 31;
+          display_obj.tft.setTextColor(TFT_DARKGREY, TFT_BLACK);
+          display_obj.tft.drawString("CH", 5, strip_y + 8, 1);
+          const int16_t slot = (TFT_WIDTH - 26) / 14;
+          for (uint8_t channel = 0; channel < 14; channel++) {
+            const int16_t height = 2 + (channel_activity[channel] * 14UL) / peak;
+            const int16_t x = 24 + channel * slot;
+            display_obj.tft.fillRect(x, strip_y + 17 - height, slot > 2 ? slot - 2 : 1,
+                                     height, channel_activity[channel] ? TFT_BLUE : TFT_DARKGREY);
+          }
+        }
+      #else
+        const int16_t event_y = TFT_HEIGHT - 32;
+        display_obj.tft.drawFastHLine(5, event_y - 5, TFT_WIDTH - 10, TFT_DARKGREY);
+        if (active_mode == ReconMode::WIFI_RECON && ui_relationship_head) {
+          const UiRelationship& relationship =
+              ui_relationships[(ui_relationship_head + 2) % 3];
+          char ap_name[9];
+          reconTruncate(relationship.ap_name, ap_name, sizeof(ap_name));
+          snprintf(line, sizeof(line), "%02X:%02X > %s", relationship.station[4],
+                   relationship.station[5], ap_name);
+          display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+          display_obj.tft.drawCentreString(line, TFT_WIDTH / 2, event_y, 1);
+        } else {
+          const UiEvent& latest = ui_events[(ui_event_head + 3) % 4];
+          if (latest.type == 'p') snprintf(line, sizeof(line), "PROBE %.12s", latest.label);
+          else if (latest.type) snprintf(line, sizeof(line), "%c %02X:%02X:%02X",
+                                         latest.type, latest.mac[3], latest.mac[4], latest.mac[5]);
+          else snprintf(line, sizeof(line), "Waiting...");
+          display_obj.tft.setTextColor(latest.type == 'd' ? TFT_RED : TFT_LIGHTGREY, TFT_BLACK);
+          display_obj.tft.drawCentreString(line, TFT_WIDTH / 2, event_y, 1);
+        }
+      #endif
     #endif
     display_obj.tft.setTextColor(active_mode == ReconMode::WIFI_RECON ? TFT_GREEN : TFT_CYAN,
                                  TFT_BLACK);
@@ -528,6 +700,7 @@ void ReconMission::observeLists() {
           const AccessPoint& ap = access_points->get(station.ap);
           channel = ap.channel;
           writeRelationship(station.mac, ap.bssid);
+          recordRelationship(station, ap);
         }
         writeObservation('s', station.mac, -128, channel);
       }
@@ -556,5 +729,7 @@ void ReconMission::main(uint32_t current_time) {
   observeLists();
   drainProbeQueue();
   drainRepeatQueue();
+  drainDeauthQueue();
+  pruneStaleDevices(current_time);
   drawDashboard(current_time);
 }

--- a/esp32_marauder/ReconMission.h
+++ b/esp32_marauder/ReconMission.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#ifndef ReconMission_h
+#define ReconMission_h
+
+#include "configs.h"
+#include "ReconProbeQueue.h"
+#include "ReconMissionState.h"
+
+#include <Arduino.h>
+#ifdef HAS_SD
+  #include <FS.h>
+#endif
+
+enum class ReconMode : uint8_t { WIFI_RECON, BLE_RECON };
+
+class ReconMission {
+ public:
+  bool start(ReconMode mode);
+  void stop();
+  void main(uint32_t current_time);
+  void queueProbe(const uint8_t mac[6], int8_t rssi, uint8_t channel,
+                  const uint8_t* name, uint8_t name_length);
+  void queueRepeat(char type, const uint8_t mac[6], int8_t rssi, uint8_t channel);
+  bool active() const { return running; }
+  ReconMode mode() const { return active_mode; }
+
+ private:
+  void observeLists();
+  void drainProbeQueue();
+  void drainRepeatQueue();
+  void writeObservation(char type, const uint8_t mac[6], int rssi, uint8_t channel);
+  void writeProbe(const ReconProbeEvent& event);
+  void writeRelationship(const uint8_t station[6], const uint8_t access_point[6]);
+  void writeManifest(bool complete);
+  void drawDashboard(uint32_t current_time);
+  void recordUiEvent(char type, const uint8_t mac[6], int8_t rssi,
+                     const char* label = nullptr);
+
+  ReconMissionState state;
+  bool running = false;
+  ReconMode active_mode = ReconMode::WIFI_RECON;
+  uint32_t started_at = 0;
+  uint32_t last_sample = 0;
+  uint32_t last_dashboard = 0;
+  uint32_t ap_count = 0;
+  uint32_t station_count = 0;
+  uint32_t ble_count = 0;
+  uint32_t probe_count = 0;
+  uint32_t repeat_count = 0;
+  uint8_t pending_flush = 0;
+  uint8_t probe_pending_flush = 0;
+  ReconProbeQueue probe_queue;
+  ReconRepeatQueue repeat_queue;
+  ReconRepeatGate repeat_gate;
+  struct UiEvent {
+    uint8_t mac[6];
+    char label[13];
+    char type;
+    int8_t rssi;
+  } ui_events[4] = {};
+  uint8_t ui_event_head = 0;
+  #ifdef HAS_SD
+    File log_file;
+    File probe_file;
+    File relationship_file;
+    char session_dir[20] = {};
+  #endif
+};
+
+#endif

--- a/esp32_marauder/ReconMission.h
+++ b/esp32_marauder/ReconMission.h
@@ -83,8 +83,9 @@ class ReconMission {
     char ap_name[17];
   } ui_relationships[3] = {};
   uint8_t ui_relationship_head = 0;
-  int8_t signal_history[6] = {};
+  int8_t signal_history[64] = {};
   uint8_t signal_history_count = 0;
+  int8_t pending_signal_peak = -128;
   uint16_t channel_activity[DUAL_BAND_CHANNELS] = {};
   #ifdef HAS_SD
     File log_file;

--- a/esp32_marauder/ReconMission.h
+++ b/esp32_marauder/ReconMission.h
@@ -83,9 +83,13 @@ class ReconMission {
     char ap_name[17];
   } ui_relationships[3] = {};
   uint8_t ui_relationship_head = 0;
-  int8_t signal_history[64] = {};
-  uint8_t signal_history_count = 0;
-  int8_t pending_signal_peak = -128;
+  uint8_t churn_in_history[64] = {};
+  uint8_t churn_out_history[64] = {};
+  uint8_t churn_history_count = 0;
+  uint16_t pending_churn_in = 0;
+  uint16_t pending_churn_out = 0;
+  uint32_t band_24_observations = 0;
+  uint32_t band_5_observations = 0;
   uint16_t channel_activity[DUAL_BAND_CHANNELS] = {};
   #ifdef HAS_SD
     File log_file;

--- a/esp32_marauder/ReconMission.h
+++ b/esp32_marauder/ReconMission.h
@@ -6,6 +6,7 @@
 #include "configs.h"
 #include "ReconProbeQueue.h"
 #include "ReconMissionState.h"
+#include "ReconUi.h"
 
 #include <Arduino.h>
 #ifdef HAS_SD
@@ -13,6 +14,9 @@
 #endif
 
 enum class ReconMode : uint8_t { WIFI_RECON, BLE_RECON };
+
+struct Station;
+struct AccessPoint;
 
 class ReconMission {
  public:
@@ -22,6 +26,8 @@ class ReconMission {
   void queueProbe(const uint8_t mac[6], int8_t rssi, uint8_t channel,
                   const uint8_t* name, uint8_t name_length);
   void queueRepeat(char type, const uint8_t mac[6], int8_t rssi, uint8_t channel);
+  void queueDeauth(const uint8_t transmitter[6], const uint8_t bssid[6],
+                   int8_t rssi, uint8_t channel, uint16_t reason);
   bool active() const { return running; }
   ReconMode mode() const { return active_mode; }
 
@@ -29,9 +35,14 @@ class ReconMission {
   void observeLists();
   void drainProbeQueue();
   void drainRepeatQueue();
+  void drainDeauthQueue();
   void writeObservation(char type, const uint8_t mac[6], int rssi, uint8_t channel);
   void writeProbe(const ReconProbeEvent& event);
   void writeRelationship(const uint8_t station[6], const uint8_t access_point[6]);
+  void recordRelationship(const Station& station, const AccessPoint& access_point);
+  void recordSignal(int8_t rssi, uint8_t channel);
+  void pruneStaleDevices(uint32_t current_time);
+  void rebuildStationLinks();
   void writeManifest(bool complete);
   void drawDashboard(uint32_t current_time);
   void recordUiEvent(char type, const uint8_t mac[6], int8_t rssi,
@@ -43,15 +54,19 @@ class ReconMission {
   uint32_t started_at = 0;
   uint32_t last_sample = 0;
   uint32_t last_dashboard = 0;
+  uint32_t last_prune = 0;
+  uint32_t last_deauth = 0;
   uint32_t ap_count = 0;
   uint32_t station_count = 0;
   uint32_t ble_count = 0;
   uint32_t probe_count = 0;
   uint32_t repeat_count = 0;
+  uint32_t deauth_count = 0;
   uint8_t pending_flush = 0;
   uint8_t probe_pending_flush = 0;
   ReconProbeQueue probe_queue;
   ReconRepeatQueue repeat_queue;
+  ReconDeauthQueue deauth_queue;
   ReconRepeatGate repeat_gate;
   struct UiEvent {
     uint8_t mac[6];
@@ -60,6 +75,15 @@ class ReconMission {
     int8_t rssi;
   } ui_events[4] = {};
   uint8_t ui_event_head = 0;
+  struct UiRelationship {
+    uint8_t station[6];
+    uint8_t access_point[6];
+    char ap_name[17];
+  } ui_relationships[3] = {};
+  uint8_t ui_relationship_head = 0;
+  int8_t signal_history[6] = {};
+  uint8_t signal_history_count = 0;
+  uint16_t channel_activity[14] = {};
   #ifdef HAS_SD
     File log_file;
     File probe_file;

--- a/esp32_marauder/ReconMission.h
+++ b/esp32_marauder/ReconMission.h
@@ -29,6 +29,7 @@ class ReconMission {
   void queueDeauth(const uint8_t transmitter[6], const uint8_t bssid[6],
                    int8_t rssi, uint8_t channel, uint16_t reason);
   bool active() const { return running; }
+  bool suppressScanUi() const { return suppress_scan_ui; }
   ReconMode mode() const { return active_mode; }
 
  private:
@@ -50,6 +51,7 @@ class ReconMission {
 
   ReconMissionState state;
   bool running = false;
+  bool suppress_scan_ui = false;
   ReconMode active_mode = ReconMode::WIFI_RECON;
   uint32_t started_at = 0;
   uint32_t last_sample = 0;
@@ -83,7 +85,7 @@ class ReconMission {
   uint8_t ui_relationship_head = 0;
   int8_t signal_history[6] = {};
   uint8_t signal_history_count = 0;
-  uint16_t channel_activity[14] = {};
+  uint16_t channel_activity[DUAL_BAND_CHANNELS] = {};
   #ifdef HAS_SD
     File log_file;
     File probe_file;

--- a/esp32_marauder/ReconMissionState.h
+++ b/esp32_marauder/ReconMissionState.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+enum class ReconSource : uint8_t { AP_LIST = 0, STATION_LIST = 1, BLE_LIST = 2 };
+
+struct ReconRange {
+  size_t begin;
+  size_t end;
+};
+
+inline uint8_t reconRssiLevel(int8_t rssi) {
+  if (rssi <= -127) return 0;
+  if (rssi <= -100) return 1;
+  if (rssi >= -30) return 8;
+  return static_cast<uint8_t>(1 + ((rssi + 100) * 7) / 70);
+}
+
+class ReconMissionState {
+ public:
+  void reset() {
+    for (size_t& cursor : cursors) cursor = 0;
+  }
+
+  ReconRange consume(ReconSource source, size_t size) {
+    size_t& cursor = cursors[static_cast<uint8_t>(source)];
+    if (size < cursor) cursor = 0;
+    const ReconRange range = {cursor, size};
+    cursor = size;
+    return range;
+  }
+
+ private:
+  size_t cursors[3] = {0, 0, 0};
+};

--- a/esp32_marauder/ReconProbeQueue.h
+++ b/esp32_marauder/ReconProbeQueue.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+constexpr size_t RECON_PROBE_NAME_MAX = 24;
+constexpr size_t RECON_PROBE_QUEUE_SIZE = 8;
+constexpr size_t RECON_REPEAT_TRACKED = 24;
+
+struct ReconProbeEvent {
+  uint32_t elapsed_ms;
+  uint8_t mac[6];
+  int8_t rssi;
+  uint8_t channel;
+  uint8_t name_length;
+  char name[RECON_PROBE_NAME_MAX];
+};
+
+class ReconProbeQueue {
+ public:
+  void reset() { head = tail = dropped_count = 0; }
+
+  bool push(const ReconProbeEvent& event) {
+    const uint8_t next = (head + 1) % RECON_PROBE_QUEUE_SIZE;
+    if (next == tail) {
+      dropped_count++;
+      return false;
+    }
+    entries[head] = event;
+    head = next;
+    return true;
+  }
+
+  bool pop(ReconProbeEvent& event) {
+    if (tail == head) return false;
+    event = entries[tail];
+    tail = (tail + 1) % RECON_PROBE_QUEUE_SIZE;
+    return true;
+  }
+
+  uint16_t dropped() const { return dropped_count; }
+
+ private:
+  ReconProbeEvent entries[RECON_PROBE_QUEUE_SIZE] = {};
+  uint8_t head = 0;
+  uint8_t tail = 0;
+  uint16_t dropped_count = 0;
+};
+
+struct ReconRepeatEvent {
+  uint8_t mac[6];
+  int8_t rssi;
+  uint8_t channel;
+  char type;
+};
+
+class ReconRepeatQueue {
+ public:
+  void reset() { head = tail = dropped_count = 0; }
+  bool push(const ReconRepeatEvent& event) {
+    const uint8_t next = (head + 1) % RECON_PROBE_QUEUE_SIZE;
+    if (next == tail) { dropped_count++; return false; }
+    entries[head] = event;
+    head = next;
+    return true;
+  }
+  bool pop(ReconRepeatEvent& event) {
+    if (tail == head) return false;
+    event = entries[tail];
+    tail = (tail + 1) % RECON_PROBE_QUEUE_SIZE;
+    return true;
+  }
+  uint16_t dropped() const { return dropped_count; }
+
+ private:
+  ReconRepeatEvent entries[RECON_PROBE_QUEUE_SIZE] = {};
+  uint8_t head = 0;
+  uint8_t tail = 0;
+  uint16_t dropped_count = 0;
+};
+
+class ReconRepeatGate {
+ public:
+  void reset() { memset(entries, 0, sizeof(entries)); }
+  bool accept(const uint8_t mac[6], int8_t rssi, uint32_t now) {
+    Entry* free_entry = nullptr;
+    Entry* oldest = &entries[0];
+    for (Entry& entry : entries) {
+      if (!entry.used) { if (!free_entry) free_entry = &entry; continue; }
+      if (entry.last_seen < oldest->last_seen) oldest = &entry;
+      if (memcmp(entry.mac, mac, 6) != 0) continue;
+      const bool changed = rssi != -128 && entry.rssi != -128 &&
+                           abs(static_cast<int>(rssi) - entry.rssi) >= 12;
+      const bool returned = now - entry.last_seen >= 30000;
+      if (changed || returned) {
+        entry.last_seen = now;
+        entry.rssi = rssi;
+        return true;
+      }
+      return false;
+    }
+    Entry* entry = free_entry ? free_entry : oldest;
+    memcpy(entry->mac, mac, 6);
+    entry->last_seen = now;
+    entry->rssi = rssi;
+    entry->used = true;
+    return false;
+  }
+
+ private:
+  struct Entry {
+    uint8_t mac[6];
+    uint32_t last_seen;
+    int8_t rssi;
+    bool used;
+  };
+  Entry entries[RECON_REPEAT_TRACKED] = {};
+};

--- a/esp32_marauder/ReconProbeQueue.h
+++ b/esp32_marauder/ReconProbeQueue.h
@@ -81,6 +81,39 @@ class ReconRepeatQueue {
   uint16_t dropped_count = 0;
 };
 
+struct ReconDeauthEvent {
+  uint8_t transmitter[6];
+  uint8_t bssid[6];
+  int8_t rssi;
+  uint8_t channel;
+  uint16_t reason;
+};
+
+class ReconDeauthQueue {
+ public:
+  void reset() { head = tail = dropped_count = 0; }
+  bool push(const ReconDeauthEvent& event) {
+    const uint8_t next = (head + 1) % RECON_PROBE_QUEUE_SIZE;
+    if (next == tail) { dropped_count++; return false; }
+    entries[head] = event;
+    head = next;
+    return true;
+  }
+  bool pop(ReconDeauthEvent& event) {
+    if (tail == head) return false;
+    event = entries[tail];
+    tail = (tail + 1) % RECON_PROBE_QUEUE_SIZE;
+    return true;
+  }
+  uint16_t dropped() const { return dropped_count; }
+
+ private:
+  ReconDeauthEvent entries[RECON_PROBE_QUEUE_SIZE] = {};
+  uint8_t head = 0;
+  uint8_t tail = 0;
+  uint16_t dropped_count = 0;
+};
+
 class ReconRepeatGate {
  public:
   void reset() { memset(entries, 0, sizeof(entries)); }

--- a/esp32_marauder/ReconUi.h
+++ b/esp32_marauder/ReconUi.h
@@ -44,6 +44,13 @@ inline uint8_t reconChannelsOnPage(uint8_t page, uint8_t channel_count) {
   return remaining < RECON_CHANNELS_PER_PAGE ? remaining : RECON_CHANNELS_PER_PAGE;
 }
 
+inline uint8_t reconChurnHeight(uint8_t value, uint8_t peak, uint8_t height) {
+  if (!value || !height) return 0;
+  if (!peak) peak = 1;
+  const uint16_t scaled = 1 + (static_cast<uint16_t>(value) * (height - 1)) / peak;
+  return scaled > height ? height : scaled;
+}
+
 inline uint8_t reconSignalSegments(int8_t rssi) {
   if (rssi <= -127) return 0;
   if (rssi <= -90) return 1;

--- a/esp32_marauder/ReconUi.h
+++ b/esp32_marauder/ReconUi.h
@@ -6,6 +6,8 @@
 
 constexpr uint32_t RECON_DEVICE_TTL_MS = 5UL * 60UL * 1000UL;
 constexpr uint32_t RECON_DEAUTH_ALERT_MS = 3000;
+constexpr uint32_t RECON_CHANNEL_PAGE_MS = 4000;
+constexpr uint8_t RECON_CHANNELS_PER_PAGE = 8;
 
 enum class ReconLayout : uint8_t {
   COMPACT_SQUARE,
@@ -26,6 +28,20 @@ inline ReconLayout reconLayoutFor(uint16_t width, uint16_t height) {
 inline uint8_t reconRelationshipRows(ReconLayout layout) {
   return layout == ReconLayout::LARGE ? 3 :
          layout == ReconLayout::NARROW_PORTRAIT ? 1 : 0;
+}
+
+inline uint8_t reconChannelPage(uint32_t elapsed_ms, uint8_t channel_count) {
+  if (!channel_count) return 0;
+  const uint8_t page_count =
+      (channel_count + RECON_CHANNELS_PER_PAGE - 1) / RECON_CHANNELS_PER_PAGE;
+  return (elapsed_ms / RECON_CHANNEL_PAGE_MS) % page_count;
+}
+
+inline uint8_t reconChannelsOnPage(uint8_t page, uint8_t channel_count) {
+  const uint16_t first = static_cast<uint16_t>(page) * RECON_CHANNELS_PER_PAGE;
+  if (first >= channel_count) return 0;
+  const uint8_t remaining = channel_count - first;
+  return remaining < RECON_CHANNELS_PER_PAGE ? remaining : RECON_CHANNELS_PER_PAGE;
 }
 
 inline uint8_t reconSignalSegments(int8_t rssi) {

--- a/esp32_marauder/ReconUi.h
+++ b/esp32_marauder/ReconUi.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <string.h>
 
-constexpr uint32_t RECON_DEVICE_TTL_MS = 5UL * 60UL * 1000UL;
+constexpr uint32_t RECON_DEVICE_TTL_MS = 2UL * 60UL * 1000UL;
 constexpr uint32_t RECON_DEAUTH_ALERT_MS = 3000;
 constexpr uint32_t RECON_CHANNEL_PAGE_MS = 4000;
 constexpr uint8_t RECON_CHANNELS_PER_PAGE = 8;

--- a/esp32_marauder/ReconUi.h
+++ b/esp32_marauder/ReconUi.h
@@ -53,6 +53,13 @@ inline uint8_t reconSignalSegments(int8_t rssi) {
   return 5;
 }
 
+inline uint8_t reconRssiPlotLevel(int8_t rssi) {
+  if (rssi <= -127) return 0;
+  if (rssi <= -100) return 1;
+  if (rssi >= -35) return 100;
+  return 1 + ((static_cast<int16_t>(rssi) + 100) * 99) / 65;
+}
+
 inline const char* reconProximityLabel(int8_t rssi) {
   if (rssi <= -127) return "NO SIGNAL";
   if (rssi <= -82) return "FAR";
@@ -62,7 +69,13 @@ inline const char* reconProximityLabel(int8_t rssi) {
 
 inline ReconSignalTrend reconSignalTrend(const int8_t* samples, size_t count) {
   if (!samples || count < 2) return ReconSignalTrend::STEADY;
-  const int delta = static_cast<int>(samples[count - 1]) - samples[0];
+  size_t first = 0;
+  while (first < count && samples[first] <= -127) first++;
+  if (first == count) return ReconSignalTrend::STEADY;
+  size_t last = count - 1;
+  while (last > first && samples[last] <= -127) last--;
+  if (last == first) return ReconSignalTrend::STEADY;
+  const int delta = static_cast<int>(samples[last]) - samples[first];
   if (delta >= 6) return ReconSignalTrend::APPROACHING;
   if (delta <= -6) return ReconSignalTrend::DEPARTING;
   return ReconSignalTrend::STEADY;

--- a/esp32_marauder/ReconUi.h
+++ b/esp32_marauder/ReconUi.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+constexpr uint32_t RECON_DEVICE_TTL_MS = 5UL * 60UL * 1000UL;
+constexpr uint32_t RECON_DEAUTH_ALERT_MS = 3000;
+
+enum class ReconLayout : uint8_t {
+  COMPACT_SQUARE,
+  COMPACT_LANDSCAPE,
+  NARROW_PORTRAIT,
+  LARGE
+};
+
+enum class ReconSignalTrend : int8_t { DEPARTING = -1, STEADY = 0, APPROACHING = 1 };
+
+inline ReconLayout reconLayoutFor(uint16_t width, uint16_t height) {
+  if (width <= 135 && height <= 160) return ReconLayout::COMPACT_SQUARE;
+  if (height < 160) return ReconLayout::COMPACT_LANDSCAPE;
+  if (width < 200) return ReconLayout::NARROW_PORTRAIT;
+  return ReconLayout::LARGE;
+}
+
+inline uint8_t reconRelationshipRows(ReconLayout layout) {
+  return layout == ReconLayout::LARGE ? 3 :
+         layout == ReconLayout::NARROW_PORTRAIT ? 1 : 0;
+}
+
+inline uint8_t reconSignalSegments(int8_t rssi) {
+  if (rssi <= -127) return 0;
+  if (rssi <= -90) return 1;
+  if (rssi <= -78) return 2;
+  if (rssi <= -67) return 3;
+  if (rssi <= -55) return 4;
+  return 5;
+}
+
+inline const char* reconProximityLabel(int8_t rssi) {
+  if (rssi <= -127) return "NO SIGNAL";
+  if (rssi <= -82) return "FAR";
+  if (rssi <= -65) return "MID";
+  return "NEAR";
+}
+
+inline ReconSignalTrend reconSignalTrend(const int8_t* samples, size_t count) {
+  if (!samples || count < 2) return ReconSignalTrend::STEADY;
+  const int delta = static_cast<int>(samples[count - 1]) - samples[0];
+  if (delta >= 6) return ReconSignalTrend::APPROACHING;
+  if (delta <= -6) return ReconSignalTrend::DEPARTING;
+  return ReconSignalTrend::STEADY;
+}
+
+inline bool reconDeviceExpired(uint32_t now, uint32_t last_seen,
+                               uint32_t ttl = RECON_DEVICE_TTL_MS) {
+  return last_seen != 0 && static_cast<uint32_t>(now - last_seen) >= ttl;
+}
+
+inline void reconTruncate(const char* source, char* output, size_t output_size) {
+  if (!output || output_size == 0) return;
+  if (!source) source = "";
+  const size_t length = strlen(source);
+  if (length < output_size) {
+    memcpy(output, source, length + 1);
+    return;
+  }
+  if (output_size < 5) {
+    memcpy(output, source, output_size - 1);
+    output[output_size - 1] = '\0';
+    return;
+  }
+  const size_t visible = output_size - 1;
+  const size_t prefix = (visible - 2) / 2;
+  const size_t suffix = visible - prefix - 2;
+  memcpy(output, source, prefix);
+  output[prefix] = '.';
+  output[prefix + 1] = '.';
+  memcpy(output + prefix + 2, source + length - suffix, suffix);
+  output[visible] = '\0';
+}

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -574,6 +574,7 @@ extern "C" {
                 ble_device.name = mac;
 
               ble_device.rssi = rssi;
+              ble_device.last_seen_ms = millis();
 
               memcpy(ble_device.mac, mac_char, sizeof(mac_char));
 
@@ -1272,6 +1273,7 @@ extern "C" {
                 ble_device.name = mac;
 
               ble_device.rssi = rssi;
+              ble_device.last_seen_ms = millis();
 
               memcpy(ble_device.mac, mac_char, sizeof(mac_char));
 
@@ -6701,6 +6703,15 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
     len -= 4;
 
     if ((wifi_scan_obj.currentScanMode == WIFI_SCAN_AP_STA) &&
+        (snifferPacket->payload[0] == 0xC0) && (len >= 26)) {
+      const uint16_t reason = snifferPacket->payload[24] |
+                              (static_cast<uint16_t>(snifferPacket->payload[25]) << 8);
+      recon_obj.queueDeauth(&snifferPacket->payload[10], &snifferPacket->payload[16],
+                            snifferPacket->rx_ctrl.rssi,
+                            snifferPacket->rx_ctrl.channel, reason);
+    }
+
+    if ((wifi_scan_obj.currentScanMode == WIFI_SCAN_AP_STA) &&
         (snifferPacket->payload[0] == 0x40) && (len > 26)) {
       const uint8_t name_length = snifferPacket->payload[25];
       if (name_length && (26 + name_length <= len)) {
@@ -6754,6 +6765,11 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
       int in_list = wifi_scan_obj.checkMatchAP(addr);
 
       if (in_list >= 0) {
+        AccessPoint access_point = access_points->get(in_list);
+        access_point.rssi = snifferPacket->rx_ctrl.rssi;
+        access_point.channel = snifferPacket->rx_ctrl.channel;
+        access_point.last_seen_ms = millis();
+        access_points->set(in_list, access_point);
         recon_obj.queueRepeat('A', &snifferPacket->payload[10],
                               snifferPacket->rx_ctrl.rssi,
                               snifferPacket->rx_ctrl.channel);
@@ -6849,6 +6865,7 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
           ap.packets = 0;
 
           ap.man = "";
+          ap.last_seen_ms = millis();
 
           access_points->add(ap);
         }
@@ -6931,6 +6948,9 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
       }
       if (mac_match) {
         in_list = true;
+        Station station = stations->get(i);
+        station.last_seen_ms = millis();
+        stations->set(i, station);
         break;
       }
     }
@@ -6957,7 +6977,8 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
                     snifferPacket->payload[frame_offset + 5]},
                     false,
                     0,
-                    static_cast<uint16_t>(ap_index)};
+                    static_cast<uint16_t>(ap_index),
+                    millis()};
 
       stations->add(sta);
     }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -628,7 +628,7 @@ extern "C" {
         
                 Serial.println();
         
-                if (!display_obj.printing) {
+                if (!recon_obj.suppressScanUi() && !display_obj.printing) {
                   display_obj.loading = true;
                   display_obj.display_buffer->add(display_string);
                   display_obj.loading = false;
@@ -1327,7 +1327,7 @@ extern "C" {
         
                 Serial.println();
         
-                if (!display_obj.printing) {
+                if (!recon_obj.suppressScanUi() && !display_obj.printing) {
                   display_obj.loading = true;
                   display_obj.display_buffer->add(display_string);
                   display_obj.loading = false;
@@ -6817,7 +6817,8 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
         Serial.print(F(" "));
 
         #ifdef HAS_SCREEN
-          display_obj.display_buffer->add(display_string);
+          if (!recon_obj.suppressScanUi())
+            display_obj.display_buffer->add(display_string);
         #endif
         
         if (essid == "") {
@@ -7019,7 +7020,8 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
 
       Serial.print(F(" "));
 
-      display_obj.display_buffer->add(display_string);
+      if (!recon_obj.suppressScanUi())
+        display_obj.display_buffer->add(display_string);
     #endif
 
     if (mem_check) {

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -1,5 +1,6 @@
 #include "esp_random.h"
 #include "WiFiScan.h"
+#include "ReconMission.h"
 #include "FoxHuntTarget.h"
 #include "BeaconFrame.h"
 #include "WdgResponse.h"
@@ -38,6 +39,7 @@ LinkedList<Flipper>* flippers;
 LinkedList<IPAddress>* ipList;
 LinkedList<ProbeReqSsid>* probe_req_ssids;
 LinkedList<BleDevice>* ble_devices;
+extern ReconMission recon_obj;
 
 size_t WiFiScan::retainedAccessPointCount() const {
   return access_points == nullptr ? 0 : access_points->size();
@@ -578,6 +580,7 @@ extern "C" {
               int device_match_check = wifi_scan_obj.seenBLEDevice(ble_device);
 
               if (device_match_check >= 0) {
+                recon_obj.queueRepeat('B', ble_device.mac, ble_device.rssi, 0);
                 ble_device.selected = ble_devices->get(device_match_check).selected;
                 ble_device.name = ble_devices->get(device_match_check).name;
                 memcpy(ble_device.mac, ble_devices->get(device_match_check).mac, sizeof(mac_char));
@@ -1275,6 +1278,7 @@ extern "C" {
               int device_match_check = wifi_scan_obj.seenBLEDevice(ble_device);
 
               if (device_match_check >= 0) {
+                recon_obj.queueRepeat('B', ble_device.mac, ble_device.rssi, 0);
                 ble_device.selected = ble_devices->get(device_match_check).selected;
                 ble_device.name = ble_devices->get(device_match_check).name;
                 memcpy(ble_device.mac, ble_devices->get(device_match_check).mac, sizeof(mac_char));
@@ -6696,6 +6700,16 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
   {
     len -= 4;
 
+    if ((wifi_scan_obj.currentScanMode == WIFI_SCAN_AP_STA) &&
+        (snifferPacket->payload[0] == 0x40) && (len > 26)) {
+      const uint8_t name_length = snifferPacket->payload[25];
+      if (name_length && (26 + name_length <= len)) {
+        recon_obj.queueProbe(&snifferPacket->payload[10], snifferPacket->rx_ctrl.rssi,
+                             snifferPacket->rx_ctrl.channel,
+                             &snifferPacket->payload[26], name_length);
+      }
+    }
+
     // If we dont the buffer size is not 0, don't write or else we get CORRUPT_HEAP
     #ifdef HAS_SCREEN
       int buf = display_obj.display_buffer->size();
@@ -6738,6 +6752,12 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
       #endif
 
       int in_list = wifi_scan_obj.checkMatchAP(addr);
+
+      if (in_list >= 0) {
+        recon_obj.queueRepeat('A', &snifferPacket->payload[10],
+                              snifferPacket->rx_ctrl.rssi,
+                              snifferPacket->rx_ctrl.channel);
+      }
 
       if (in_list < 0) {
       
@@ -6918,6 +6938,11 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
     getMAC(dst_addr, snifferPacket->payload, 4);
 
     // Check if dest is broadcast
+    if (in_list) {
+      recon_obj.queueRepeat('S', &snifferPacket->payload[frame_offset],
+                            snifferPacket->rx_ctrl.rssi,
+                            snifferPacket->rx_ctrl.channel);
+    }
     if ((in_list) || (strcmp(dst_addr, "ff:ff:ff:ff:ff:ff") == 0))
       return;
     
@@ -6931,7 +6956,8 @@ void WiFiScan::apSnifferCallbackFull(void* buf, wifi_promiscuous_pkt_type_t type
                     snifferPacket->payload[frame_offset + 4],
                     snifferPacket->payload[frame_offset + 5]},
                     false,
-                    0};
+                    0,
+                    static_cast<uint16_t>(ap_index)};
 
       stations->add(sta);
     }

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -355,6 +355,7 @@ struct BleDevice {
   String   name;
   bool     selected = false;
   int      rssi     = -128;
+  uint32_t last_seen_ms = 0;
 };
 
 #ifdef HAS_PSRAM

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -37,6 +37,7 @@ https://www.online-utility.org/image/convert/to/XBM
 
 #include "settings.h"
 #include "CommandLine.h"
+#include "ReconMission.h"
 #include "lang_var.h"
 
 #ifdef HAS_T_DONGLE_DISPLAY
@@ -78,6 +79,7 @@ EvilPortal evil_portal_obj;
 Buffer buffer_obj;
 Settings settings_obj;
 CommandLine cli_obj;
+ReconMission recon_obj;
 
 #ifdef HAS_T_DONGLE_DISPLAY
   TDongleDisplay t_dongle_display;
@@ -458,6 +460,7 @@ void loop()
   // Update all of our objects
   cli_obj.main(currentTime);
   wifi_scan_obj.main(currentTime);
+  recon_obj.main(currentTime);
 
   #ifdef HAS_T_DONGLE_DISPLAY
     t_dongle_display.update(currentTime, wifi_scan_obj);

--- a/esp32_marauder/utils.h
+++ b/esp32_marauder/utils.h
@@ -22,6 +22,7 @@ struct Station {
   bool selected;
   uint16_t packets;
   uint16_t ap;
+  uint32_t last_seen_ms = 0;
 };
 
 struct ProbeReqSsid {

--- a/test/test_recon_mission_state/test_main.cpp
+++ b/test/test_recon_mission_state/test_main.cpp
@@ -1,0 +1,46 @@
+#include <unity.h>
+
+#include "ReconMissionState.h"
+
+void test_consumes_only_new_entries() {
+  ReconMissionState state;
+  ReconRange first = state.consume(ReconSource::AP_LIST, 4);
+  ReconRange second = state.consume(ReconSource::AP_LIST, 6);
+  TEST_ASSERT_EQUAL_UINT32(0, first.begin);
+  TEST_ASSERT_EQUAL_UINT32(4, first.end);
+  TEST_ASSERT_EQUAL_UINT32(4, second.begin);
+  TEST_ASSERT_EQUAL_UINT32(6, second.end);
+}
+
+void test_handles_source_lists_being_cleared() {
+  ReconMissionState state;
+  state.consume(ReconSource::BLE_LIST, 5);
+  ReconRange after_clear = state.consume(ReconSource::BLE_LIST, 2);
+  TEST_ASSERT_EQUAL_UINT32(0, after_clear.begin);
+  TEST_ASSERT_EQUAL_UINT32(2, after_clear.end);
+}
+
+void test_tracks_sources_independently() {
+  ReconMissionState state;
+  state.consume(ReconSource::AP_LIST, 3);
+  ReconRange stations = state.consume(ReconSource::STATION_LIST, 2);
+  TEST_ASSERT_EQUAL_UINT32(0, stations.begin);
+  TEST_ASSERT_EQUAL_UINT32(2, stations.end);
+}
+
+void test_maps_rssi_to_eight_non_directional_levels() {
+  TEST_ASSERT_EQUAL_UINT8(0, reconRssiLevel(-128));
+  TEST_ASSERT_EQUAL_UINT8(1, reconRssiLevel(-100));
+  TEST_ASSERT_EQUAL_UINT8(4, reconRssiLevel(-65));
+  TEST_ASSERT_EQUAL_UINT8(8, reconRssiLevel(-30));
+  TEST_ASSERT_EQUAL_UINT8(8, reconRssiLevel(-10));
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_consumes_only_new_entries);
+  RUN_TEST(test_handles_source_lists_being_cleared);
+  RUN_TEST(test_tracks_sources_independently);
+  RUN_TEST(test_maps_rssi_to_eight_non_directional_levels);
+  return UNITY_END();
+}

--- a/test/test_recon_probe_queue/test_main.cpp
+++ b/test/test_recon_probe_queue/test_main.cpp
@@ -34,10 +34,29 @@ void test_repeat_gate_handles_timer_rollover() {
   TEST_ASSERT_TRUE(gate.accept(mac, -60, 25000));
 }
 
+void test_deauth_queue_preserves_alert_details() {
+  ReconDeauthQueue queue;
+  ReconDeauthEvent expected = {};
+  expected.transmitter[5] = 0xAA;
+  expected.bssid[5] = 0xBB;
+  expected.rssi = -63;
+  expected.channel = 11;
+  expected.reason = 7;
+  TEST_ASSERT_TRUE(queue.push(expected));
+  ReconDeauthEvent actual = {};
+  TEST_ASSERT_TRUE(queue.pop(actual));
+  TEST_ASSERT_EQUAL_UINT8(0xAA, actual.transmitter[5]);
+  TEST_ASSERT_EQUAL_UINT8(0xBB, actual.bssid[5]);
+  TEST_ASSERT_EQUAL_INT8(-63, actual.rssi);
+  TEST_ASSERT_EQUAL_UINT8(11, actual.channel);
+  TEST_ASSERT_EQUAL_UINT16(7, actual.reason);
+}
+
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_probe_queue_is_bounded_and_fifo);
   RUN_TEST(test_repeat_gate_emits_changes_and_returns);
   RUN_TEST(test_repeat_gate_handles_timer_rollover);
+  RUN_TEST(test_deauth_queue_preserves_alert_details);
   return UNITY_END();
 }

--- a/test/test_recon_probe_queue/test_main.cpp
+++ b/test/test_recon_probe_queue/test_main.cpp
@@ -1,0 +1,43 @@
+#include <unity.h>
+
+#include "ReconProbeQueue.h"
+
+void test_probe_queue_is_bounded_and_fifo() {
+  ReconProbeQueue queue;
+  ReconProbeEvent event = {};
+  for (uint8_t index = 0; index < RECON_PROBE_QUEUE_SIZE - 1; index++) {
+    event.channel = index;
+    TEST_ASSERT_TRUE(queue.push(event));
+  }
+  TEST_ASSERT_FALSE(queue.push(event));
+  TEST_ASSERT_EQUAL_UINT16(1, queue.dropped());
+  for (uint8_t index = 0; index < RECON_PROBE_QUEUE_SIZE - 1; index++) {
+    TEST_ASSERT_TRUE(queue.pop(event));
+    TEST_ASSERT_EQUAL_UINT8(index, event.channel);
+  }
+  TEST_ASSERT_FALSE(queue.pop(event));
+}
+
+void test_repeat_gate_emits_changes_and_returns() {
+  ReconRepeatGate gate;
+  const uint8_t mac[6] = {0, 1, 2, 3, 4, 5};
+  TEST_ASSERT_FALSE(gate.accept(mac, -50, 1000));
+  TEST_ASSERT_FALSE(gate.accept(mac, -55, 2000));
+  TEST_ASSERT_TRUE(gate.accept(mac, -70, 3000));
+  TEST_ASSERT_TRUE(gate.accept(mac, -70, 33000));
+}
+
+void test_repeat_gate_handles_timer_rollover() {
+  ReconRepeatGate gate;
+  const uint8_t mac[6] = {6, 5, 4, 3, 2, 1};
+  TEST_ASSERT_FALSE(gate.accept(mac, -60, UINT32_MAX - 10000));
+  TEST_ASSERT_TRUE(gate.accept(mac, -60, 25000));
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_probe_queue_is_bounded_and_fifo);
+  RUN_TEST(test_repeat_gate_emits_changes_and_returns);
+  RUN_TEST(test_repeat_gate_handles_timer_rollover);
+  return UNITY_END();
+}

--- a/test/test_recon_ui/test_main.cpp
+++ b/test/test_recon_ui/test_main.cpp
@@ -28,16 +28,27 @@ void test_signal_segments_and_labels_are_monotonic() {
   TEST_ASSERT_EQUAL_STRING("NEAR", reconProximityLabel(-50));
 }
 
+void test_rssi_plot_mapping_clamps_and_increases() {
+  TEST_ASSERT_EQUAL_UINT8(0, reconRssiPlotLevel(-128));
+  TEST_ASSERT_EQUAL_UINT8(1, reconRssiPlotLevel(-100));
+  TEST_ASSERT_TRUE(reconRssiPlotLevel(-80) < reconRssiPlotLevel(-60));
+  TEST_ASSERT_EQUAL_UINT8(100, reconRssiPlotLevel(-35));
+  TEST_ASSERT_EQUAL_UINT8(100, reconRssiPlotLevel(-10));
+}
+
 void test_signal_trend_uses_meaningful_change_threshold() {
   const int8_t approaching[] = {-82, -78, -70};
   const int8_t departing[] = {-55, -60, -66};
   const int8_t steady[] = {-70, -68, -71};
+  const int8_t with_gaps[] = {-128, -82, -75, -128};
   TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconSignalTrend::APPROACHING),
                         static_cast<int>(reconSignalTrend(approaching, 3)));
   TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconSignalTrend::DEPARTING),
                         static_cast<int>(reconSignalTrend(departing, 3)));
   TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconSignalTrend::STEADY),
                         static_cast<int>(reconSignalTrend(steady, 3)));
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconSignalTrend::APPROACHING),
+                        static_cast<int>(reconSignalTrend(with_gaps, 4)));
 }
 
 void test_decay_is_wrap_safe_and_ignores_unknown_timestamps() {
@@ -69,6 +80,7 @@ int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_layout_profiles_cover_supported_display_shapes);
   RUN_TEST(test_signal_segments_and_labels_are_monotonic);
+  RUN_TEST(test_rssi_plot_mapping_clamps_and_increases);
   RUN_TEST(test_signal_trend_uses_meaningful_change_threshold);
   RUN_TEST(test_decay_is_wrap_safe_and_ignores_unknown_timestamps);
   RUN_TEST(test_channel_pages_cycle_and_include_partial_final_page);

--- a/test/test_recon_ui/test_main.cpp
+++ b/test/test_recon_ui/test_main.cpp
@@ -53,7 +53,8 @@ void test_signal_trend_uses_meaningful_change_threshold() {
 
 void test_decay_is_wrap_safe_and_ignores_unknown_timestamps() {
   TEST_ASSERT_FALSE(reconDeviceExpired(500000, 0));
-  TEST_ASSERT_FALSE(reconDeviceExpired(400000, 200000));
+  TEST_ASSERT_FALSE(reconDeviceExpired(319999, 200000));
+  TEST_ASSERT_TRUE(reconDeviceExpired(320000, 200000));
   TEST_ASSERT_TRUE(reconDeviceExpired(500000, 200000));
   TEST_ASSERT_TRUE(reconDeviceExpired(0x00000020, 0xFFF00000, 100000));
 }

--- a/test/test_recon_ui/test_main.cpp
+++ b/test/test_recon_ui/test_main.cpp
@@ -47,6 +47,16 @@ void test_decay_is_wrap_safe_and_ignores_unknown_timestamps() {
   TEST_ASSERT_TRUE(reconDeviceExpired(0x00000020, 0xFFF00000, 100000));
 }
 
+void test_channel_pages_cycle_and_include_partial_final_page() {
+  TEST_ASSERT_EQUAL_UINT8(0, reconChannelPage(0, 51));
+  TEST_ASSERT_EQUAL_UINT8(1, reconChannelPage(RECON_CHANNEL_PAGE_MS, 51));
+  TEST_ASSERT_EQUAL_UINT8(6, reconChannelPage(RECON_CHANNEL_PAGE_MS * 6, 51));
+  TEST_ASSERT_EQUAL_UINT8(0, reconChannelPage(RECON_CHANNEL_PAGE_MS * 7, 51));
+  TEST_ASSERT_EQUAL_UINT8(8, reconChannelsOnPage(0, 51));
+  TEST_ASSERT_EQUAL_UINT8(3, reconChannelsOnPage(6, 51));
+  TEST_ASSERT_EQUAL_UINT8(0, reconChannelsOnPage(7, 51));
+}
+
 void test_truncation_preserves_both_ends() {
   char output[10];
   reconTruncate("MarauderNetwork", output, sizeof(output));
@@ -61,6 +71,7 @@ int main(int, char**) {
   RUN_TEST(test_signal_segments_and_labels_are_monotonic);
   RUN_TEST(test_signal_trend_uses_meaningful_change_threshold);
   RUN_TEST(test_decay_is_wrap_safe_and_ignores_unknown_timestamps);
+  RUN_TEST(test_channel_pages_cycle_and_include_partial_final_page);
   RUN_TEST(test_truncation_preserves_both_ends);
   return UNITY_END();
 }

--- a/test/test_recon_ui/test_main.cpp
+++ b/test/test_recon_ui/test_main.cpp
@@ -68,6 +68,13 @@ void test_channel_pages_cycle_and_include_partial_final_page() {
   TEST_ASSERT_EQUAL_UINT8(0, reconChannelsOnPage(7, 51));
 }
 
+void test_churn_height_scales_and_clamps() {
+  TEST_ASSERT_EQUAL_UINT8(0, reconChurnHeight(0, 10, 20));
+  TEST_ASSERT_EQUAL_UINT8(10, reconChurnHeight(5, 10, 20));
+  TEST_ASSERT_EQUAL_UINT8(20, reconChurnHeight(10, 10, 20));
+  TEST_ASSERT_EQUAL_UINT8(20, reconChurnHeight(20, 10, 20));
+}
+
 void test_truncation_preserves_both_ends() {
   char output[10];
   reconTruncate("MarauderNetwork", output, sizeof(output));
@@ -84,6 +91,7 @@ int main(int, char**) {
   RUN_TEST(test_signal_trend_uses_meaningful_change_threshold);
   RUN_TEST(test_decay_is_wrap_safe_and_ignores_unknown_timestamps);
   RUN_TEST(test_channel_pages_cycle_and_include_partial_final_page);
+  RUN_TEST(test_churn_height_scales_and_clamps);
   RUN_TEST(test_truncation_preserves_both_ends);
   return UNITY_END();
 }

--- a/test/test_recon_ui/test_main.cpp
+++ b/test/test_recon_ui/test_main.cpp
@@ -1,0 +1,66 @@
+#include <unity.h>
+
+#include "ReconUi.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_layout_profiles_cover_supported_display_shapes() {
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconLayout::COMPACT_SQUARE),
+                        static_cast<int>(reconLayoutFor(128, 128)));
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconLayout::COMPACT_LANDSCAPE),
+                        static_cast<int>(reconLayoutFor(240, 135)));
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconLayout::NARROW_PORTRAIT),
+                        static_cast<int>(reconLayoutFor(135, 240)));
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconLayout::LARGE),
+                        static_cast<int>(reconLayoutFor(240, 320)));
+  TEST_ASSERT_EQUAL_UINT8(3, reconRelationshipRows(ReconLayout::LARGE));
+  TEST_ASSERT_EQUAL_UINT8(0, reconRelationshipRows(ReconLayout::COMPACT_SQUARE));
+}
+
+void test_signal_segments_and_labels_are_monotonic() {
+  TEST_ASSERT_EQUAL_UINT8(0, reconSignalSegments(-128));
+  TEST_ASSERT_EQUAL_UINT8(1, reconSignalSegments(-95));
+  TEST_ASSERT_EQUAL_UINT8(3, reconSignalSegments(-67));
+  TEST_ASSERT_EQUAL_UINT8(5, reconSignalSegments(-40));
+  TEST_ASSERT_EQUAL_STRING("FAR", reconProximityLabel(-90));
+  TEST_ASSERT_EQUAL_STRING("MID", reconProximityLabel(-72));
+  TEST_ASSERT_EQUAL_STRING("NEAR", reconProximityLabel(-50));
+}
+
+void test_signal_trend_uses_meaningful_change_threshold() {
+  const int8_t approaching[] = {-82, -78, -70};
+  const int8_t departing[] = {-55, -60, -66};
+  const int8_t steady[] = {-70, -68, -71};
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconSignalTrend::APPROACHING),
+                        static_cast<int>(reconSignalTrend(approaching, 3)));
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconSignalTrend::DEPARTING),
+                        static_cast<int>(reconSignalTrend(departing, 3)));
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(ReconSignalTrend::STEADY),
+                        static_cast<int>(reconSignalTrend(steady, 3)));
+}
+
+void test_decay_is_wrap_safe_and_ignores_unknown_timestamps() {
+  TEST_ASSERT_FALSE(reconDeviceExpired(500000, 0));
+  TEST_ASSERT_FALSE(reconDeviceExpired(400000, 200000));
+  TEST_ASSERT_TRUE(reconDeviceExpired(500000, 200000));
+  TEST_ASSERT_TRUE(reconDeviceExpired(0x00000020, 0xFFF00000, 100000));
+}
+
+void test_truncation_preserves_both_ends() {
+  char output[10];
+  reconTruncate("MarauderNetwork", output, sizeof(output));
+  TEST_ASSERT_EQUAL_STRING("Mar..work", output);
+  reconTruncate("short", output, sizeof(output));
+  TEST_ASSERT_EQUAL_STRING("short", output);
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_layout_profiles_cover_supported_display_shapes);
+  RUN_TEST(test_signal_segments_and_labels_are_monotonic);
+  RUN_TEST(test_signal_trend_uses_meaningful_change_threshold);
+  RUN_TEST(test_decay_is_wrap_safe_and_ignores_unknown_timestamps);
+  RUN_TEST(test_truncation_preserves_both_ends);
+  return UNITY_END();
+}

--- a/tools/RECON_CONVERTER_README.md
+++ b/tools/RECON_CONVERTER_README.md
@@ -1,0 +1,39 @@
+# Marauder Recon Converter
+
+The converter turns one Marauder `/recon/m####/` mission directory into a portable report. It runs on your computer; it is not installed on the Marauder or copied to its SD card.
+
+## Desktop app
+
+1. Copy the complete `m####` directory from the Marauder SD card to your computer.
+2. Open `Marauder-Recon-Converter` for your operating system.
+3. Select the copied mission directory and choose **Build Report**.
+4. The converter opens `report/index.html` and creates `m####-report.zip` beside it.
+
+You can also drag a mission directory onto the executable on operating systems that pass dropped folders as command-line arguments.
+
+## Python fallback
+
+Python 3.10 or newer is sufficient; there are no third-party runtime dependencies.
+
+```text
+python3 tools/recon_report.py /path/to/m0042 --zip
+```
+
+## Inputs
+
+- `session.json`: mission manifest and completion state.
+- `obs.rlog`: AP, station, BLE, repeat, and change observations.
+- `probes.rlog`: Wi-Fi probe-request observations, when present.
+- `relations.rlog`: observed station-to-AP relationships, when present.
+- `.pcap`: packet capture for separate inspection in Wireshark.
+
+Keep the input files together and retain them as the authoritative raw mission data.
+
+## Outputs
+
+- `report/index.html`: self-contained interactive report with timeline scrubbing.
+- `report/observations.csv`: spreadsheet-friendly observations.
+- `report/mission.json`: expanded observations and relationships.
+- `m####-report.zip`: portable copy of the generated report.
+
+Relationship entries are observations, not identity claims. A client probing for an SSID does not prove ownership or a current association. Interrupted missions marked `active` can be converted if their complete records are intact; final counters and duration may be incomplete.

--- a/tools/recon_converter.py
+++ b/tools/recon_converter.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Small desktop front end for the Marauder Recon report converter."""
+
+from __future__ import annotations
+
+import sys
+import webbrowser
+from pathlib import Path
+
+from tools.recon_report import ReconReportError, convert
+
+
+def run_conversion(mission: Path) -> Path:
+    return convert(mission, make_zip=True) / "index.html"
+
+
+def gui() -> int:
+    import tkinter as tk
+    from tkinter import filedialog, messagebox
+
+    root = tk.Tk()
+    root.title("Marauder Recon Converter")
+    root.geometry("520x235")
+    root.configure(bg="#080c13")
+    selected = tk.StringVar(value="Select a /recon/m#### mission folder")
+    tk.Label(root, text="MARAUDER RECON", fg="#28e7ff", bg="#080c13",
+             font=("TkDefaultFont", 18, "bold")).pack(pady=(24, 5))
+    tk.Label(root, textvariable=selected, fg="#a9b8c8", bg="#080c13",
+             wraplength=470).pack(pady=10)
+
+    def choose() -> None:
+        folder = filedialog.askdirectory(title="Select Recon mission folder")
+        if folder:
+            selected.set(folder)
+
+    def build() -> None:
+        mission = Path(selected.get())
+        try:
+            report = run_conversion(mission)
+        except (OSError, ReconReportError) as error:
+            messagebox.showerror("Conversion failed", str(error))
+            return
+        webbrowser.open(report.as_uri())
+        messagebox.showinfo("Report ready", f"Created report and ZIP in:\n{mission}")
+
+    buttons = tk.Frame(root, bg="#080c13")
+    buttons.pack(pady=15)
+    tk.Button(buttons, text="SELECT MISSION", command=choose, width=18).pack(side="left", padx=7)
+    tk.Button(buttons, text="BUILD REPORT", command=build, width=18).pack(side="left", padx=7)
+    root.mainloop()
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) == 2:
+        try:
+            report = run_conversion(Path(sys.argv[1]))
+        except (OSError, ReconReportError) as error:
+            print(f"Conversion failed: {error}", file=sys.stderr)
+            return 2
+        webbrowser.open(report.as_uri())
+        print(report)
+        return 0
+    return gui()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/recon_report.py
+++ b/tools/recon_report.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Convert an ESP32 Marauder Recon mission into portable report files."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import json
+import struct
+import zipfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+MAGIC = b"RCN1"
+RECORD = struct.Struct("<Iii6sbBc")
+PROBE_MAGIC = b"PRB1"
+PROBE_RECORD = struct.Struct("<Iii6sbBB24s")
+RELATIONSHIP_MAGIC = b"REL1"
+RELATIONSHIP_RECORD = struct.Struct("<6s6s")
+TYPE_NAMES = {"a": "access-point", "s": "station", "b": "ble"}
+GPS_COORDINATE_SCALE = 1_000_000
+
+
+class ReconReportError(ValueError):
+    """Raised when a mission cannot be safely converted."""
+
+
+@dataclass(frozen=True)
+class Observation:
+    elapsed_ms: int
+    latitude: float | None
+    longitude: float | None
+    mac: str
+    rssi: int
+    channel: int
+    type: str
+    event: str
+    ssid: str | None
+
+
+@dataclass(frozen=True)
+class Relationship:
+    source: str
+    target: str
+    kind: str
+    confidence: str
+
+
+def _mac(value: bytes) -> str:
+    return ":".join(f"{octet:02X}" for octet in value)
+
+
+def read_observations(path: Path) -> list[Observation]:
+    data = path.read_bytes()
+    if not data.startswith(MAGIC):
+        raise ReconReportError(f"{path} is not an RCN1 observation log")
+    payload = data[len(MAGIC) :]
+    if len(payload) % RECORD.size:
+        raise ReconReportError(f"{path} ends with an incomplete observation")
+
+    observations = []
+    for values in RECORD.iter_unpack(payload):
+        elapsed, latitude, longitude, mac, rssi, channel, raw_type = values
+        kind = raw_type.decode("ascii", errors="replace")
+        base_kind = kind.lower()
+        if base_kind not in TYPE_NAMES:
+            raise ReconReportError(f"Unknown observation type {kind!r}")
+        has_position = latitude != 0 or longitude != 0
+        observations.append(
+            Observation(
+                elapsed_ms=elapsed,
+                latitude=latitude / GPS_COORDINATE_SCALE if has_position else None,
+                longitude=longitude / GPS_COORDINATE_SCALE if has_position else None,
+                mac=_mac(mac),
+                rssi=rssi,
+                channel=channel,
+                type=TYPE_NAMES[base_kind],
+                event="repeat" if kind.isupper() else "new",
+                ssid=None,
+            )
+        )
+    return observations
+
+
+def read_probes(path: Path) -> list[Observation]:
+    data = path.read_bytes()
+    if not data.startswith(PROBE_MAGIC):
+        raise ReconReportError(f"{path} is not a PRB1 probe log")
+    payload = data[len(PROBE_MAGIC) :]
+    if len(payload) % PROBE_RECORD.size:
+        raise ReconReportError(f"{path} ends with an incomplete probe")
+    probes = []
+    for values in PROBE_RECORD.iter_unpack(payload):
+        elapsed, latitude, longitude, mac, rssi, channel, length, raw_name = values
+        if length > len(raw_name):
+            raise ReconReportError("Probe name length exceeds record capacity")
+        has_position = latitude != 0 or longitude != 0
+        probes.append(
+            Observation(
+                elapsed_ms=elapsed,
+                latitude=latitude / GPS_COORDINATE_SCALE if has_position else None,
+                longitude=longitude / GPS_COORDINATE_SCALE if has_position else None,
+                mac=_mac(mac),
+                rssi=rssi,
+                channel=channel,
+                type="probe-request",
+                event="probe",
+                ssid=raw_name[:length].decode("utf-8", errors="replace"),
+            )
+        )
+    return probes
+
+
+def read_relationships(path: Path) -> list[Relationship]:
+    data = path.read_bytes()
+    if not data.startswith(RELATIONSHIP_MAGIC):
+        raise ReconReportError(f"{path} is not a REL1 relationship log")
+    payload = data[len(RELATIONSHIP_MAGIC) :]
+    if len(payload) % RELATIONSHIP_RECORD.size:
+        raise ReconReportError(f"{path} ends with an incomplete relationship")
+    unique = {
+        (_mac(station), _mac(access_point))
+        for station, access_point in RELATIONSHIP_RECORD.iter_unpack(payload)
+    }
+    return [
+        Relationship(station, access_point, "station-to-access-point", "observed")
+        for station, access_point in sorted(unique)
+    ]
+
+
+def load_mission(directory: Path) -> tuple[dict, list[Observation], list[Relationship]]:
+    manifest_path = directory / "session.json"
+    log_path = directory / "obs.rlog"
+    if not manifest_path.is_file() or not log_path.is_file():
+        raise ReconReportError("Mission must contain session.json and obs.rlog")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as error:
+        raise ReconReportError(f"Invalid session.json: {error}") from error
+    if manifest.get("schema") != 1:
+        raise ReconReportError("Unsupported Recon manifest schema")
+    observations = read_observations(log_path)
+    probe_path = directory / manifest.get("probes", "probes.rlog")
+    if probe_path.is_file():
+        observations.extend(read_probes(probe_path))
+        observations.sort(key=lambda item: item.elapsed_ms)
+    relation_path = directory / manifest.get("relationships", "relations.rlog")
+    relationships = read_relationships(relation_path) if relation_path.is_file() else []
+    relationships.extend(
+        Relationship(item.mac, item.ssid, "client-to-probed-ssid", "observed")
+        for item in observations
+        if item.event == "probe" and item.ssid
+    )
+    relationships = list(dict.fromkeys(relationships))
+    return manifest, observations, relationships
+
+
+def write_csv(path: Path, observations: list[Observation]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=Observation.__dataclass_fields__)
+        writer.writeheader()
+        writer.writerows(asdict(observation) for observation in observations)
+
+
+def write_json(path: Path, manifest: dict, observations: list[Observation],
+               relationships: list[Relationship]) -> None:
+    payload = {
+        "manifest": manifest,
+        "observations": [asdict(item) for item in observations],
+        "relationships": [asdict(item) for item in relationships],
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _route_points(observations: list[Observation]) -> str:
+    points = [item for item in observations if item.latitude is not None]
+    if not points:
+        return '<div class="empty">No GPS fixes were recorded.</div>'
+    latitudes = [item.latitude for item in points]
+    longitudes = [item.longitude for item in points]
+    lat_span = max(max(latitudes) - min(latitudes), 0.0001)
+    lon_span = max(max(longitudes) - min(longitudes), 0.0001)
+    coordinates = []
+    for item in points:
+        x = 20 + ((item.longitude - min(longitudes)) / lon_span) * 560
+        y = 180 - ((item.latitude - min(latitudes)) / lat_span) * 160
+        coordinates.append(f"{x:.1f},{y:.1f}")
+    return (
+        '<svg viewBox="0 0 600 200" role="img" aria-label="GPS sighting plot">'
+        '<defs><filter id="glow"><feGaussianBlur stdDeviation="3" result="b"/>'
+        '<feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>'
+        '</filter></defs><polyline class="route" points="'
+        + " ".join(coordinates)
+        + '"/></svg>'
+    )
+
+
+def write_html(path: Path, manifest: dict, observations: list[Observation],
+               relationships: list[Relationship]) -> None:
+    counts = {name: 0 for name in TYPE_NAMES.values()}
+    for item in observations:
+        if item.event == "new":
+            counts[item.type] += 1
+    probe_count = sum(item.event == "probe" for item in observations)
+    repeat_count = sum(item.event == "repeat" for item in observations)
+    duration = int(manifest.get("duration_ms", 0)) // 1000
+    rows = "".join(
+        f'<tr data-time="{item.elapsed_ms}">'
+        f"<td>{item.elapsed_ms / 1000:.1f}s</td><td>{html.escape(item.event)}</td><td>{html.escape(item.type)}</td>"
+        f"<td>{item.mac}</td><td>{html.escape(item.ssid or '-')}</td><td>{item.rssi}</td><td>{item.channel or '-'}</td>"
+        f"<td>{item.latitude:.6f}, {item.longitude:.6f}</td></tr>" if item.latitude is not None else
+        f'<tr data-time="{item.elapsed_ms}">'
+        f"<td>{item.elapsed_ms / 1000:.1f}s</td><td>{html.escape(item.event)}</td><td>{html.escape(item.type)}</td>"
+        f"<td>{item.mac}</td><td>{html.escape(item.ssid or '-')}</td><td>{item.rssi}</td><td>{item.channel or '-'}</td><td>-</td></tr>"
+        for item in observations
+    )
+    relationship_rows = "".join(
+        "<tr>"
+        f"<td>{html.escape(item.kind)}</td><td>{html.escape(item.source)}</td>"
+        f"<td>{html.escape(item.target)}</td><td>{html.escape(item.confidence)}</td></tr>"
+        for item in relationships
+    ) or '<tr><td colspan="4" class="empty">No relationships were recorded.</td></tr>'
+    replay_max = max((item.elapsed_ms for item in observations), default=0)
+    document = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>Marauder Recon Report</title><style>
+:root{{--bg:#05070b;--panel:#101520;--line:#273247;--text:#eaf6ff;--muted:#91a4b8;--cyan:#28e7ff;--mag:#ff3fca}}
+*{{box-sizing:border-box}} body{{margin:0;background:radial-gradient(circle at top,#12213a,var(--bg) 45%);color:var(--text);font:14px system-ui,sans-serif}}
+main{{max-width:1100px;margin:auto;padding:28px}} h1{{letter-spacing:.12em;margin:0;color:var(--cyan)}} .sub{{color:var(--muted);margin:6px 0 24px}}
+.grid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px}} .card,.panel{{background:#101520dd;border:1px solid var(--line);border-radius:10px;box-shadow:0 0 20px #0008}}
+.card{{padding:15px}} .value{{font-size:25px;color:var(--mag)}} .label{{color:var(--muted);text-transform:uppercase;font-size:11px}}
+.panel{{margin-top:16px;padding:16px;overflow:auto}} h2{{font-size:14px;letter-spacing:.1em;color:var(--cyan)}} svg{{width:100%;height:200px;background:linear-gradient(#09111d 1px,transparent 1px),linear-gradient(90deg,#09111d 1px,transparent 1px);background-size:30px 30px}}
+.route{{fill:none;stroke:var(--mag);stroke-width:3;filter:url(#glow)}} table{{width:100%;border-collapse:collapse;white-space:nowrap}} th,td{{padding:8px;border-bottom:1px solid var(--line);text-align:left}} th{{color:var(--cyan)}} .empty{{color:var(--muted);padding:28px;text-align:center}}
+.replay{{display:flex;gap:14px;align-items:center}} .replay input{{width:100%;accent-color:var(--mag)}} .hidden{{display:none}}
+</style></head><body><main><h1>RECON MISSION</h1>
+<div class="sub">{html.escape(path.parent.parent.name)} · {html.escape(str(manifest.get('mode', 'unknown')).upper())} · {html.escape(str(manifest.get('state', 'unknown')).upper())}</div>
+<section class="grid"><div class="card"><div class="value">{len(observations)}</div><div class="label">Sightings</div></div>
+<div class="card"><div class="value">{counts['access-point']}</div><div class="label">Access points</div></div>
+<div class="card"><div class="value">{counts['station']}</div><div class="label">Stations</div></div>
+<div class="card"><div class="value">{counts['ble']}</div><div class="label">BLE devices</div></div>
+<div class="card"><div class="value">{probe_count}</div><div class="label">Probe requests</div></div>
+<div class="card"><div class="value">{repeat_count}</div><div class="label">Changed / returned</div></div>
+<div class="card"><div class="value">{len(relationships)}</div><div class="label">Relationships</div></div>
+<div class="card"><div class="value">{duration // 60}:{duration % 60:02d}</div><div class="label">Duration</div></div></section>
+<section class="panel"><h2>GPS SIGHTING PLOT</h2>{_route_points(observations)}</section>
+<section class="panel"><h2>MISSION REPLAY</h2><div class="replay"><button id="play">PLAY</button><input id="scrub" type="range" min="0" max="{replay_max}" value="{replay_max}" step="100"><output id="clock"></output></div></section>
+<section class="panel"><h2>OBSERVED RELATIONSHIPS</h2><table><thead><tr><th>Kind</th><th>Source</th><th>Target</th><th>Confidence</th></tr></thead><tbody>{relationship_rows}</tbody></table></section>
+<section class="panel"><h2>OBSERVATION TIMELINE</h2><table><thead><tr><th>Elapsed</th><th>Event</th><th>Type</th><th>MAC</th><th>SSID</th><th>RSSI</th><th>Channel</th><th>Position</th></tr></thead><tbody>{rows}</tbody></table></section>
+</main><script>
+const scrub=document.getElementById('scrub'),clock=document.getElementById('clock'),play=document.getElementById('play');let timer;
+function render(){{const now=Number(scrub.value);clock.value=(now/1000).toFixed(1)+'s';document.querySelectorAll('tr[data-time]').forEach(row=>row.classList.toggle('hidden',Number(row.dataset.time)>now));}}
+scrub.addEventListener('input',render);play.addEventListener('click',()=>{{if(timer){{clearInterval(timer);timer=null;play.textContent='PLAY';return;}}scrub.value=0;play.textContent='PAUSE';timer=setInterval(()=>{{scrub.value=Math.min(Number(scrub.max),Number(scrub.value)+250);render();if(scrub.value==scrub.max){{clearInterval(timer);timer=null;play.textContent='PLAY';}}}},50);}});render();
+</script></body></html>"""
+    path.write_text(document, encoding="utf-8")
+
+
+def convert(directory: Path, output: Path | None = None, make_zip: bool = False) -> Path:
+    directory = directory.resolve()
+    manifest, observations, relationships = load_mission(directory)
+    output = (output or directory / "report").resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    write_csv(output / "observations.csv", observations)
+    write_json(output / "mission.json", manifest, observations, relationships)
+    write_html(output / "index.html", manifest, observations, relationships)
+    if make_zip:
+        archive = output.parent / f"{directory.name}-report.zip"
+        with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as bundle:
+            for item in sorted(output.iterdir()):
+                bundle.write(item, item.name)
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mission", type=Path, help="Mission directory containing session.json")
+    parser.add_argument("--output", type=Path, help="Report output directory")
+    parser.add_argument("--zip", action="store_true", help="Also create a portable ZIP")
+    arguments = parser.parse_args()
+    try:
+        output = convert(arguments.mission, arguments.output, arguments.zip)
+    except (OSError, ReconReportError) as error:
+        parser.error(str(error))
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_recon_report.py
+++ b/tools/test_recon_report.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import csv
+import json
+import struct
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from tools.recon_report import ReconReportError, convert, read_observations, read_probes, read_relationships
+
+
+class ReconReportTests(unittest.TestCase):
+    @staticmethod
+    def make_mission(root: Path) -> Path:
+        mission = root / "m0042"
+        mission.mkdir()
+        (mission / "session.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "state": "complete",
+                    "mode": "wifi",
+                    "duration_ms": 65000,
+                }
+            ),
+            encoding="utf-8",
+        )
+        records = [
+            struct.pack(
+                "<Iii6sbBc",
+                1500,
+                38856850,
+                -77225850,
+                bytes.fromhex("001122334455"),
+                -42,
+                6,
+                b"a",
+            ),
+            struct.pack(
+                "<Iii6sbBc",
+                2500,
+                0,
+                0,
+                bytes.fromhex("AABBCCDDEEFF"),
+                -70,
+                0,
+                b"s",
+            ),
+        ]
+        (mission / "obs.rlog").write_bytes(b"RCN1" + b"".join(records))
+        probe = struct.pack(
+            "<Iii6sbBB24s",
+            2000,
+            38856860,
+            -77225860,
+            bytes.fromhex("AABBCCDDEEFF"),
+            -55,
+            6,
+            8,
+            b"Marauder".ljust(24, b"\0"),
+        )
+        (mission / "probes.rlog").write_bytes(b"PRB1" + probe)
+        relation = struct.pack("<6s6s", bytes.fromhex("AABBCCDDEEFF"), bytes.fromhex("001122334455"))
+        (mission / "relations.rlog").write_bytes(b"REL1" + relation)
+        return mission
+
+    def test_decodes_packed_records(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            mission = self.make_mission(Path(temporary))
+            observations = read_observations(mission / "obs.rlog")
+            self.assertEqual(len(observations), 2)
+            self.assertEqual(observations[0].mac, "00:11:22:33:44:55")
+            self.assertEqual(observations[0].latitude, 38.85685)
+            self.assertEqual(observations[0].longitude, -77.22585)
+            self.assertEqual(observations[0].type, "access-point")
+            self.assertEqual(observations[0].event, "new")
+            self.assertIsNone(observations[1].latitude)
+
+    def test_decodes_probe_names_and_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            mission = self.make_mission(Path(temporary))
+            probes = read_probes(mission / "probes.rlog")
+            self.assertEqual(probes[0].ssid, "Marauder")
+            self.assertEqual(probes[0].event, "probe")
+            self.assertEqual(probes[0].mac, "AA:BB:CC:DD:EE:FF")
+            self.assertEqual(probes[0].latitude, 38.85686)
+            self.assertEqual(probes[0].longitude, -77.22586)
+
+    def test_decodes_and_deduplicates_relationships(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            mission = self.make_mission(Path(temporary))
+            relation = (mission / "relations.rlog").read_bytes()[4:]
+            (mission / "relations.rlog").write_bytes(b"REL1" + relation + relation)
+            relationships = read_relationships(mission / "relations.rlog")
+            self.assertEqual(len(relationships), 1)
+            self.assertEqual(relationships[0].source, "AA:BB:CC:DD:EE:FF")
+            self.assertEqual(relationships[0].target, "00:11:22:33:44:55")
+
+    def test_generates_portable_report_and_zip(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            mission = self.make_mission(Path(temporary))
+            output = convert(mission, make_zip=True)
+            self.assertEqual(
+                {item.name for item in output.iterdir()},
+                {"observations.csv", "mission.json", "index.html"},
+            )
+            with (output / "observations.csv").open(encoding="utf-8") as source:
+                rows = list(csv.DictReader(source))
+            self.assertEqual(rows[1]["type"], "probe-request")
+            report = (output / "index.html").read_text(encoding="utf-8")
+            self.assertIn("RECON MISSION", report)
+            self.assertIn("GPS SIGHTING PLOT", report)
+            self.assertIn("MISSION REPLAY", report)
+            self.assertIn("OBSERVED RELATIONSHIPS", report)
+            self.assertIn("38.856850, -77.225850", report)
+            payload = json.loads((output / "mission.json").read_text(encoding="utf-8"))
+            self.assertEqual(len(payload["relationships"]), 2)
+            archive = mission / "m0042-report.zip"
+            self.assertTrue(archive.is_file())
+            with zipfile.ZipFile(archive) as bundle:
+                self.assertEqual(
+                    set(bundle.namelist()),
+                    {"observations.csv", "mission.json", "index.html"},
+                )
+
+    def test_rejects_truncated_or_unknown_records(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "obs.rlog"
+            path.write_bytes(b"RCN1broken")
+            with self.assertRaisesRegex(ReconReportError, "incomplete"):
+                read_observations(path)
+            path.write_bytes(b"NOPE")
+            with self.assertRaisesRegex(ReconReportError, "not an RCN1"):
+                read_observations(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Wi-Fi and BLE Recon missions with SD capture, structured observations, relationships, and a desktop report converter
- add cross-display live intelligence for environment churn, band balance, channel activity, associations, probes, and deauthentication events
- retain discoveries for Fox Hunt while pruning stale devices after two minutes and isolating Recon from scan-owned display output