### PR TITLE
Fix M5StickC Plus2 screen orientation

### DIFF
--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -1034,7 +1034,7 @@
 
       #define EXT_BUTTON_WIDTH 0
 
-      #define SCREEN_ORIENTATION 0
+      #define SCREEN_ORIENTATION 1
 
       #define CHAR_WIDTH 6
       #define SCREEN_WIDTH TFT_HEIGHT // Originally 240


### PR DESCRIPTION
## Summary

- rotate the M5StickC Plus2 display to landscape orientation
- align the TFT rotation with the existing 240x135 UI coordinate space

## Problem

The Plus2 profile used rotation 0 while SCREEN_WIDTH and SCREEN_HEIGHT describe a landscape display. This caused the interface to be clipped horizontally and left part of the display height unused.

## Validation

- built successfully for esp32:esp32:m5stick-c:PartitionScheme=min_spiffs with MARAUDER_M5STICKCP2
- flashed and hash-verified the application on a physical M5StickC Plus2
- confirmed stable boot without a reset loop