### PR TITLE
Fix Bluetooth Recon device intelligence

### DIFF
--- a/esp32_marauder/ReconMission.cpp
+++ b/esp32_marauder/ReconMission.cpp
@@ -277,12 +277,12 @@ void ReconMission::pruneStaleDevices(uint32_t current_time) {
 }
 
 void ReconMission::writeObservation(char type, const uint8_t mac[6], int rssi,
-                                    uint8_t channel) {
+                                    uint8_t channel, const char* label) {
   if (type == 'a') { ap_count++; pending_churn_in++; }
   else if (type == 's') { station_count++; pending_churn_in++; }
   else if (type == 'b') { ble_count++; pending_churn_in++; }
   else if (type != 'd') repeat_count++;
-  recordUiEvent(type, mac, static_cast<int8_t>(rssi));
+  recordUiEvent(type, mac, static_cast<int8_t>(rssi), label);
   recordSignal(static_cast<int8_t>(rssi), channel);
 
   ReconLogRecord record = {};
@@ -434,7 +434,21 @@ void ReconMission::drainRepeatQueue() {
     const bool available = repeat_queue.pop(event);
     portEXIT_CRITICAL(&probe_queue_mux);
     if (!available) break;
-    writeObservation(event.type, event.mac, event.rssi, event.channel);
+    const char* label = nullptr;
+    #ifdef HAS_BT
+      String ble_label;
+      if (event.type == 'B' && ble_devices) {
+        for (int index = 0; index < ble_devices->size(); index++) {
+          const BleDevice& device = ble_devices->get(index);
+          if (!memcmp(device.mac, event.mac, sizeof(event.mac))) {
+            ble_label = device.device_type;
+            label = ble_label.c_str();
+            break;
+          }
+        }
+      }
+    #endif
+    writeObservation(event.type, event.mac, event.rssi, event.channel, label);
   }
 }
 
@@ -629,9 +643,11 @@ void ReconMission::drawDashboard(uint32_t current_time) {
     char band_label[20];
     snprintf(band_label, sizeof(band_label), "2G%u 5G%u", band_24_percent, band_5_percent);
     #if TFT_HEIGHT >= 160
-      display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-      display_obj.tft.drawCentreString(band_label, graph_x + graph_width / 2,
-                                       graph_y + graph_height - 12, 1);
+      if (active_mode == ReconMode::WIFI_RECON) {
+        display_obj.tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+        display_obj.tft.drawCentreString(band_label, graph_x + graph_width / 2,
+                                         graph_y + graph_height - 12, 1);
+      }
     #endif
 
     display_obj.tft.setTextSize(1);
@@ -708,17 +724,27 @@ void ReconMission::drawDashboard(uint32_t current_time) {
       #if TFT_WIDTH >= 200
         const int16_t relation_y = body_top + 112;
         display_obj.tft.drawFastHLine(6, relation_y - 6, TFT_WIDTH - 12, TFT_DARKGREY);
-        display_obj.tft.setTextColor(TFT_MAGENTA, TFT_BLACK);
-        display_obj.tft.drawString("NEW ASSOCIATIONS", 8, relation_y, 1);
+        display_obj.tft.setTextColor(active_mode == ReconMode::WIFI_RECON
+                                       ? TFT_MAGENTA : TFT_CYAN, TFT_BLACK);
+        display_obj.tft.drawString(active_mode == ReconMode::WIFI_RECON
+                                     ? "NEW ASSOCIATIONS" : "DEVICE TYPE", 8, relation_y, 1);
         for (uint8_t row = 0; row < 3; row++) {
-          const UiRelationship& relationship =
-              ui_relationships[(ui_relationship_head + row) % 3];
-          if (!relationship.ap_name[0]) continue;
-          char ap_name[13];
-          reconTruncate(relationship.ap_name, ap_name, sizeof(ap_name));
-          snprintf(line, sizeof(line), "%02X:%02X:%02X > %s",
-                   relationship.station[3], relationship.station[4], relationship.station[5],
-                   ap_name);
+          if (active_mode == ReconMode::WIFI_RECON) {
+            const UiRelationship& relationship =
+                ui_relationships[(ui_relationship_head + row) % 3];
+            if (!relationship.ap_name[0]) continue;
+            char ap_name[13];
+            reconTruncate(relationship.ap_name, ap_name, sizeof(ap_name));
+            snprintf(line, sizeof(line), "%02X:%02X:%02X > %s",
+                     relationship.station[3], relationship.station[4], relationship.station[5],
+                     ap_name);
+          } else {
+            const UiEvent& event = ui_events[(ui_event_head + row + 1) % 4];
+            if (event.type != 'b') continue;
+            snprintf(line, sizeof(line), "%02X:%02X:%02X > %s",
+                     event.mac[3], event.mac[4], event.mac[5],
+                     event.label[0] ? event.label : "BLE");
+          }
           display_obj.tft.setTextColor(row == 2 ? TFT_CYAN : TFT_LIGHTGREY, TFT_BLACK);
           display_obj.tft.drawString(line, 8, relation_y + 15 + row * 14, 1);
         }
@@ -774,6 +800,9 @@ void ReconMission::drawDashboard(uint32_t current_time) {
         } else {
           const UiEvent& latest = ui_events[(ui_event_head + 3) % 4];
           if (latest.type == 'p') snprintf(line, sizeof(line), "PROBE %.12s", latest.label);
+          else if (latest.type == 'b') snprintf(line, sizeof(line), "%02X:%02X > %.8s",
+                                                latest.mac[4], latest.mac[5],
+                                                latest.label[0] ? latest.label : "BLE");
           else if (latest.type) snprintf(line, sizeof(line), "%c %02X:%02X:%02X",
                                          latest.type, latest.mac[3], latest.mac[4], latest.mac[5]);
           else snprintf(line, sizeof(line), "Waiting...");
@@ -819,7 +848,7 @@ void ReconMission::observeLists() {
         const ReconRange range = state.consume(ReconSource::BLE_LIST, ble_devices->size());
         for (size_t index = range.begin; index < range.end; index++) {
           const BleDevice& device = ble_devices->get(index);
-          writeObservation('b', device.mac, device.rssi, 0);
+          writeObservation('b', device.mac, device.rssi, 0, device.device_type.c_str());
         }
       }
     #endif

--- a/esp32_marauder/ReconMission.h
+++ b/esp32_marauder/ReconMission.h
@@ -37,7 +37,8 @@ class ReconMission {
   void drainProbeQueue();
   void drainRepeatQueue();
   void drainDeauthQueue();
-  void writeObservation(char type, const uint8_t mac[6], int rssi, uint8_t channel);
+  void writeObservation(char type, const uint8_t mac[6], int rssi, uint8_t channel,
+                        const char* label = nullptr);
   void writeProbe(const ReconProbeEvent& event);
   void writeRelationship(const uint8_t station[6], const uint8_t access_point[6]);
   void recordRelationship(const Station& station, const AccessPoint& access_point);

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -568,6 +568,7 @@ extern "C" {
             if (buf >= 0)
             {
               BleDevice ble_device;
+              ble_device.device_type = wifi_scan_obj.classifyBLEDevice(advertisedDevice);
               if (name_length > 0)
                 ble_device.name = name;
               else
@@ -1267,6 +1268,7 @@ extern "C" {
             if (buf >= 0)
             {
               BleDevice ble_device;
+              ble_device.device_type = wifi_scan_obj.classifyBLEDevice(advertisedDevice);
               if (name_length > 0)
                 ble_device.name = name;
               else
@@ -1984,6 +1986,68 @@ bool WiFiScan::isBlockedIdentifier(uint16_t id) {
   }
   return false;
 }
+
+#ifdef HAS_BT
+String WiFiScan::classifyBLEDevice(const NimBLEAdvertisedDevice* advertised_device) {
+  if (!advertised_device) return "BLE";
+
+  #ifndef HAS_NIMBLE_2
+    const uint8_t* payload = advertised_device->getPayload();
+    const size_t payload_length = advertised_device->getPayloadLength();
+  #else
+    const std::vector<unsigned char>& payload_bytes = advertised_device->getPayload();
+    const uint8_t* payload = payload_bytes.data();
+    const size_t payload_length = payload_bytes.size();
+  #endif
+
+  bool find_my = advertised_device->isAdvertisingService(FMNA_SERVICE_UUID) ||
+                 advertised_device->isAdvertisingService(DULT_SERVICE_UUID);
+  bool flipper = false;
+  if (payload) {
+    for (size_t index = 0; index + 3 < payload_length; index++) {
+      if ((payload[index] == 0x1E && payload[index + 1] == 0xFF &&
+           payload[index + 2] == 0x4C && payload[index + 3] == 0x00) ||
+          (payload[index] == 0x4C && payload[index + 1] == 0x00 &&
+           payload[index + 2] == 0x12))
+        find_my = true;
+      if ((payload[index] == 0x81 || payload[index] == 0x82 ||
+           payload[index] == 0x83) && payload[index + 1] == 0x30)
+        flipper = true;
+    }
+  }
+  if (find_my) return "FindMy";
+  if (flipper) return "Flipper";
+
+  bool meta = false;
+  bool blocked = false;
+  if (advertised_device->haveManufacturerData()) {
+    const std::string manufacturer_data = advertised_device->getManufacturerData();
+    if (manufacturer_data.length() >= 2) {
+      const uint16_t identifier =
+          (static_cast<uint8_t>(manufacturer_data[1]) << 8) |
+          static_cast<uint8_t>(manufacturer_data[0]);
+      blocked = isBlockedIdentifier(identifier);
+      meta = isMetaIdentifier(identifier);
+    }
+  }
+  if (advertised_device->haveServiceUUID()) {
+    for (int index = 0; index < advertised_device->getServiceUUIDCount(); index++) {
+      const String uuid = advertised_device->getServiceUUID(index).toString().c_str();
+      const uint16_t identifier = extract16BitFromUUID(uuid);
+      if (!identifier) continue;
+      blocked = blocked || isBlockedIdentifier(identifier);
+      meta = meta || isMetaIdentifier(identifier);
+    }
+  }
+  if (meta && !blocked) return "Meta";
+
+  String serial;
+  const String name = advertised_device->getName().c_str();
+  if (payload && isFlockCamera(payload, payload_length, name, &serial)) return "Flock";
+  if (name.length()) return name;
+  return "BLE";
+}
+#endif
 
 bool WiFiScan::isHostAlive(IPAddress ip) {
   if (ip != IPAddress(0, 0, 0, 0))

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -353,6 +353,7 @@ struct Flipper {
 struct BleDevice {
   uint8_t  mac[6];
   String   name;
+  String   device_type;
   bool     selected = false;
   int      rssi     = -128;
   uint32_t last_seen_ms = 0;
@@ -1009,6 +1010,9 @@ class WiFiScan
     uint16_t rssiToColor(int8_t rssi);
     bool isMetaIdentifier(uint16_t id);
     bool isBlockedIdentifier(uint16_t id);
+    #ifdef HAS_BT
+      String classifyBLEDevice(const NimBLEAdvertisedDevice* advertised_device);
+    #endif
     void setFoxHuntTarget(const uint8_t mac[6], const String& name, int8_t rssi, uint8_t channel, bool bluetooth, const String& advertised_address = "");
     bool updateFoxHuntRssi(const uint8_t mac[6], int8_t rssi, uint8_t channel = 0);
     bool updateBluetoothFoxHuntRssi(const uint8_t mac[6], const String& advertised_address, int8_t rssi);


### PR DESCRIPTION
## Summary
- replace BLE Recon association and Wi-Fi band UI with device-type activity
- identify FindMy, Flipper, Meta, Flock, named, and generic BLE devices
- show the last three MAC bytes beside each BLE device type