### PR TITLE
Add Heltec WiFi LoRa 32 V4 support (headless CLI + SSD1306 status screen)

### DIFF
--- a/esp32_marauder/HeltecOLED.cpp
+++ b/esp32_marauder/HeltecOLED.cpp
@@ -1,0 +1,129 @@
+#include "HeltecOLED.h"
+
+#ifdef HELTEC_WIFI_LORA_32_V4
+
+#include "WiFiScan.h"
+#include "CommandLine.h"
+
+// Marauder globals we read for the status view
+extern WiFiScan wifi_scan_obj;
+extern LinkedList<AccessPoint>* access_points;
+extern LinkedList<Station>* stations;
+extern LinkedList<ssid>* ssids;
+
+// Live sniff counters (file-scope globals in WiFiScan.cpp)
+extern int num_beacon;
+extern int num_deauth;
+extern int num_probe;
+
+HeltecOLED heltec_oled;
+
+void HeltecOLED::begin() {
+  // Power the peripheral rail. On Heltec boards Vext is ACTIVE-LOW.
+  pinMode(HELTEC_VEXT, OUTPUT);
+  digitalWrite(HELTEC_VEXT, LOW);
+  delay(50);
+
+  // Hardware reset pulse for the SSD1306
+  pinMode(HELTEC_OLED_RST, OUTPUT);
+  digitalWrite(HELTEC_OLED_RST, HIGH); delay(1);
+  digitalWrite(HELTEC_OLED_RST, LOW);  delay(10);
+  digitalWrite(HELTEC_OLED_RST, HIGH); delay(10);
+
+  // OLED sits on its own I2C bus (17/18), not the default Wire pins (3/4)
+  Wire.begin(HELTEC_OLED_SDA, HELTEC_OLED_SCL);
+
+  _ok = _d.begin(SSD1306_SWITCHCAPVCC, HELTEC_OLED_ADDR);
+  if (!_ok) {
+    Serial.println(F("[OLED] SSD1306 init FAILED (Heltec V4)"));
+    return;
+  }
+
+  _d.clearDisplay();
+  _d.setTextColor(SSD1306_WHITE);
+  _d.setTextSize(1);
+  _d.setCursor(0, 0);
+  _d.println(F("ESP32 Marauder"));
+  _d.println(F(HARDWARE_NAME));
+  _d.print(F("fw "));
+  _d.println(F(MARAUDER_VERSION));
+  _d.display();
+  Serial.println(F("[OLED] Heltec V4 status display up"));
+}
+
+const char* HeltecOLED::modeStr(uint8_t m) {
+  switch (m) {
+    case WIFI_SCAN_OFF:         return "Idle";
+    case WIFI_SCAN_AP:          return "Scan AP";
+    case WIFI_SCAN_STATION:     return "Scan STA";
+    case WIFI_SCAN_AP_STA:      return "Scan AP+STA";
+    case WIFI_SCAN_ALL:         return "Scan ALL";
+    case WIFI_SCAN_PROBE:       return "Sniff Probe";
+    case WIFI_SCAN_DEAUTH:      return "Sniff Deauth";
+    case WIFI_SCAN_EAPOL:       return "Sniff PMKID";
+    case WIFI_SCAN_ACTIVE_EAPOL:return "Actv EAPOL";
+    case WIFI_SCAN_RAW_CAPTURE: return "Raw Cap";
+    case WIFI_SCAN_EVIL_PORTAL: return "EvilPortal";
+    case WIFI_SCAN_PACKET_RATE: return "Pkt Rate";
+    case WIFI_SCAN_SIG_STREN:   return "Signal";
+    case WIFI_SCAN_MULTISSID:   return "MultiSSID";
+    default:                    return "Busy";
+  }
+}
+
+void HeltecOLED::update(uint32_t now) {
+  if (!_ok) return;
+  if (now - _last < 500) return;   // ~2 Hz refresh
+  _last = now;
+  _spin = (uint8_t)((_spin + 1) & 3);
+  draw();
+}
+
+void HeltecOLED::draw() {
+  int ap  = access_points ? access_points->size() : 0;
+  int sta = stations      ? stations->size()      : 0;
+  long rx = (long)num_beacon + (long)num_probe + (long)num_deauth; // sniffed frames
+  long tx = wifi_scan_obj.getPacketsSent();                        // frames sent (attacks)
+  uint8_t mode = wifi_scan_obj.currentScanMode;
+  uint8_t ch   = wifi_scan_obj.set_channel;
+  uint32_t up  = millis() / 1000UL;
+  uint32_t freeK = ESP.getFreeHeap() / 1024UL;
+  static const char spin[4] = {'|','/','-','\\'};
+
+  _d.clearDisplay();
+
+  // Inverted title bar
+  _d.fillRect(0, 0, HELTEC_OLED_W, 11, SSD1306_WHITE);
+  _d.setTextColor(SSD1306_BLACK);
+  _d.setCursor(2, 2);
+  _d.print(F("Marauder "));
+  _d.print(F(MARAUDER_VERSION));
+  _d.setCursor(HELTEC_OLED_W - 8, 2);
+  _d.print(spin[_spin]);
+
+  _d.setTextColor(SSD1306_WHITE);
+
+  _d.setCursor(0, 14);
+  _d.print(F("Mode: "));
+  _d.print(modeStr(mode));
+
+  _d.setCursor(0, 24);
+  _d.print(F("AP:"));   _d.print(ap);
+  _d.print(F("  STA:")); _d.print(sta);
+
+  _d.setCursor(0, 34);
+  _d.print(F("RX:")); _d.print(rx);
+  _d.print(F("  TX:")); _d.print(tx);
+
+  _d.setCursor(0, 44);
+  _d.print(F("CH:")); _d.print(ch);
+  _d.print(F("  Up ")); _d.print(up / 60UL); _d.print('m');
+  _d.print(up % 60UL); _d.print('s');
+
+  _d.setCursor(0, 54);
+  _d.print(F("Heap ")); _d.print(freeK); _d.print(F("K"));
+
+  _d.display();
+}
+
+#endif // HELTEC_WIFI_LORA_32_V4

--- a/esp32_marauder/HeltecOLED.h
+++ b/esp32_marauder/HeltecOLED.h
@@ -1,0 +1,39 @@
+#pragma once
+#ifndef HeltecOLED_h
+#define HeltecOLED_h
+
+#include "configs.h"
+
+#ifdef HELTEC_WIFI_LORA_32_V4
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+
+// Heltec WiFi LoRa 32 V4 OLED wiring (from Heltec core V4 variant)
+#define HELTEC_OLED_SDA   17
+#define HELTEC_OLED_SCL   18
+#define HELTEC_OLED_RST   21
+#define HELTEC_VEXT       36   // active-LOW power enable for the peripheral rail
+#define HELTEC_OLED_W     128
+#define HELTEC_OLED_H     64
+#define HELTEC_OLED_ADDR  0x3C
+
+class HeltecOLED {
+  public:
+    void begin();
+    void update(uint32_t now);
+  private:
+    Adafruit_SSD1306 _d = Adafruit_SSD1306(HELTEC_OLED_W, HELTEC_OLED_H, &Wire, HELTEC_OLED_RST);
+    bool _ok = false;
+    uint32_t _last = 0;
+    uint8_t _spin = 0;
+    void draw();
+    const char* modeStr(uint8_t m);
+};
+
+extern HeltecOLED heltec_oled;
+
+#endif // HELTEC_WIFI_LORA_32_V4
+#endif // HeltecOLED_h

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -784,6 +784,9 @@ class WiFiScan
 
 
   public:
+    // Added: expose attack TX counter for external status displays
+    int getPacketsSent() { return packets_sent; }
+
     struct FoxHuntTarget {
       uint8_t mac[6] = {};
       String name = "";

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -19,6 +19,7 @@
   //#define MARAUDER_V7_1
   //#define MARAUDER_KIT
   //#define GENERIC_ESP32
+  //#define HELTEC_WIFI_LORA_32_V4
   //#define MARAUDER_FLIPPER
   //#define MARAUDER_MULTIBOARD_S3
   //#define ESP32_LDDB
@@ -115,6 +116,8 @@
     #define HARDWARE_NAME "Dual Mini C5"
   #elif defined(MARAUDER_M5_NANO_C6)
     #define HARDWARE_NAME "M5 Nano C6"
+  #elif defined(HELTEC_WIFI_LORA_32_V4)
+    #define HARDWARE_NAME "Heltec WiFi LoRa 32 V4"
   #else
     #define HARDWARE_NAME "ESP32"
   #endif
@@ -409,6 +412,20 @@
     //#define HAS_NEOPIXEL_LED
     //#define HAS_PWR_MGMT
     //#define HAS_SCREEN
+    //#define HAS_SD
+    //#define HAS_TEMP_SENSOR
+    //#define HAS_GPS
+    //#define HAS_NIMBLE_2
+  #endif
+
+  #ifdef HELTEC_WIFI_LORA_32_V4
+    //#define FLIPPER_ZERO_HAT
+    //#define HAS_BATTERY
+    #define HAS_BT
+    //#define HAS_BUTTONS
+    //#define HAS_NEOPIXEL_LED
+    //#define HAS_PWR_MGMT
+    //#define HAS_SCREEN            // 0.96" SSD1306 driven by HeltecOLED, not TFT_eSPI
     //#define HAS_SD
     //#define HAS_TEMP_SENSOR
     //#define HAS_GPS

--- a/esp32_marauder/esp32_marauder.ino
+++ b/esp32_marauder/esp32_marauder.ino
@@ -20,6 +20,9 @@ https://www.online-utility.org/image/convert/to/XBM
 
 #include "Assets.h"
 #include "WiFiScan.h"
+#ifdef HELTEC_WIFI_LORA_32_V4
+  #include "HeltecOLED.h"
+#endif
 #ifdef HAS_SD
   #include "SDInterface.h"
 #endif
@@ -425,6 +428,10 @@ void setup()
   wifi_scan_obj.StartScan(WIFI_SCAN_OFF);
   
   cli_obj.RunSetup();
+
+  #ifdef HELTEC_WIFI_LORA_32_V4
+    heltec_oled.begin();
+  #endif
 }
 
 
@@ -458,6 +465,10 @@ void loop()
   // Update all of our objects
   cli_obj.main(currentTime);
   wifi_scan_obj.main(currentTime);
+
+  #ifdef HELTEC_WIFI_LORA_32_V4
+    heltec_oled.update(currentTime);
+  #endif
 
   #ifdef HAS_T_DONGLE_DISPLAY
     t_dongle_display.update(currentTime, wifi_scan_obj);


### PR DESCRIPTION
## Add Heltec WiFi LoRa 32 V4 support (headless CLI + SSD1306 status screen)

Adds a first-class board target `HELTEC_WIFI_LORA_32_V4` for the **Heltec WiFi LoRa 32 V4** (ESP32-S3R2, native USB, 0.96" SSD1306).

### Why
The V4 is a very common ESP32-S3 board (Meshtastic/LoRa), but it trips people up under Marauder: unlike the V3 it **dropped the CP2102 UART bridge and uses the ESP32-S3's native USB**. The generic ESP32-S3 build routes `Serial` to UART0's pins, which the V4 doesn't expose on its USB port — so it "flashes fine, then goes silent." This target fixes that (build with `USB CDC On Boot = Enabled`, `USB Mode = Hardware CDC and JTAG`) and adds a usable OLED.

### What's in it
- **New board target** `HELTEC_WIFI_LORA_32_V4` (WiFi + BLE, headless; no TFT_eSPI UI).
- **`HeltecOLED` module** — a lightweight `Adafruit_SSD1306` status screen (the V4's OLED is I2C mono, so it can't run Marauder's TFT UI). Shows: firmware/mode, AP/STA counts, RX (sniffed frames) / TX (frames sent), channel, uptime, free heap. Refreshes ~2 Hz. All guarded by the board flag, so no other target pulls the new dependency.
- **`WiFiScan::getPacketsSent()`** accessor so external status views can read the TX counter without touching internals.

Pins come from Heltec's own V4 variant: `SDA_OLED=17, SCL_OLED=18, RST_OLED=21`, and the OLED rail is powered via `Vext=36` (active-LOW — the usual "why is my Heltec OLED dark" gotcha, handled in `HeltecOLED::begin()`).

### Build notes
- Arduino core: `esp32:esp32@2.0.x` (matches the vendored NimBLE 1.4.1).
- FQBN menu: `USBMode=hwcdc, CDCOnBoot=cdc, PSRAM=disabled` (S3R2 is 2 MB **QSPI** PSRAM, not OPI), `FlashSize=16M`, `PartitionScheme=huge_app`.
- New dependency **for this target only**: `Adafruit SSD1306` (+ Adafruit GFX / BusIO).
- Links with `-Wl,--allow-multiple-definition` (same raw-frame-injection override path other targets use).

### Testing
Built, flashed, and verified on real V4 hardware: CLI over native USB, `scanall`, `sniffprobe`, `sniffpmkid` (captured a complete EAPOL), `attack -t rickroll`, `sniffbt`, and the OLED status screen updating live during scans.

### Files
- `esp32_marauder/configs.h` — target, feature block, hardware name
- `esp32_marauder/esp32_marauder.ino` — `begin()`/`update()` hooks (guarded)
- `esp32_marauder/WiFiScan.h` — `getPacketsSent()` accessor
- `esp32_marauder/HeltecOLED.h`, `esp32_marauder/HeltecOLED.cpp` — new
