### PR TITLE
Fix SD browser selection and BLE Recon Fox Hunt routing

### DIFF
--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -146,6 +146,11 @@ void MenuFunctions::displayMenuButtons() {
 // Function to check menu input
 void MenuFunctions::main(uint32_t currentTime)
 {
+  #ifdef HAS_SD
+    if (sd_browser_release_pending && current_menu != &sdDeleteMenu)
+      this->releaseSDDeleteBrowserResources();
+  #endif
+
   #if defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV)
     this->updateKeyboard();
   #endif
@@ -1871,9 +1876,7 @@ void MenuFunctions::RunSetup()
   htmlMenu.list = new LinkedList<MenuNode>();
   miniKbMenu.list = new LinkedList<MenuNode>();
   #ifdef HAS_SD
-    sdDeleteMenu.list = new LinkedList<MenuNode>();
-    sd_browser_entries = new LinkedList<SDDirectoryEntry>();
-    sd_delete_selection = new LinkedList<String>();
+    sdDeleteMenu.list = nullptr;
   #endif
 
   // Bluetooth menu stuff
@@ -4252,7 +4255,39 @@ void MenuFunctions::toggleSDDeleteSelection(const String& path) {
   sd_delete_selection->add(path);
 }
 
+void MenuFunctions::ensureSDDeleteBrowserResources() {
+  if (sdDeleteMenu.list == nullptr)
+    sdDeleteMenu.list = new LinkedList<MenuNode>();
+  if (sd_browser_entries == nullptr)
+    sd_browser_entries = new LinkedList<SDDirectoryEntry>();
+  if (sd_delete_selection == nullptr)
+    sd_delete_selection = new LinkedList<String>();
+  sd_browser_release_pending = false;
+}
+
+void MenuFunctions::releaseSDDeleteBrowserResources() {
+  if (sdDeleteMenu.list != nullptr) {
+    sdDeleteMenu.list->clear();
+    delete sdDeleteMenu.list;
+    sdDeleteMenu.list = nullptr;
+  }
+  if (sd_browser_entries != nullptr) {
+    sd_browser_entries->clear();
+    delete sd_browser_entries;
+    sd_browser_entries = nullptr;
+  }
+  if (sd_delete_selection != nullptr) {
+    sd_delete_selection->clear();
+    delete sd_delete_selection;
+    sd_delete_selection = nullptr;
+  }
+  sd_browser_path = "/";
+  sd_browser_release_pending = false;
+}
+
 void MenuFunctions::buildSDDeleteBrowser(const String& path, bool reset_selection) {
+  this->ensureSDDeleteBrowserResources();
+
   if (reset_selection)
     sd_delete_selection->clear();
 
@@ -4299,6 +4334,17 @@ void MenuFunctions::buildSDDeleteBrowser(const String& path, bool reset_selectio
       delay(1000);
       this->buildSDDeleteBrowser("/");
       this->changeMenu(&sdDeleteMenu, true);
+    });
+
+    this->addNodes(&sdDeleteMenu, "Deselect All", TFTYELLOW, 0, [this]() {
+      sd_delete_selection->clear();
+      for (int index = 0; index < current_menu->list->size(); index++) {
+        MenuNode node = current_menu->list->get(index);
+        node.selected = false;
+        current_menu->list->set(index, node);
+      }
+      this->buildButtons(current_menu, menu_start_index);
+      this->displayCurrentMenu(menu_start_index);
     });
   }
 
@@ -4553,6 +4599,10 @@ uint16_t MenuFunctions::getColor(uint16_t color) {
 
 // Function to change menu
 void MenuFunctions::changeMenu(Menu* menu, bool simple_change) {
+  #ifdef HAS_SD
+    const bool leaving_sd_browser = current_menu == &sdDeleteMenu && menu != &sdDeleteMenu;
+  #endif
+
   if (!simple_change) {
     //display_obj.initScrollValues();
     //display_obj.setupScrollArea(TOP_FIXED_AREA, BOT_FIXED_AREA);
@@ -4570,6 +4620,11 @@ void MenuFunctions::changeMenu(Menu* menu, bool simple_change) {
   buildButtons(menu);
 
   displayCurrentMenu();
+
+  #ifdef HAS_SD
+    if (leaving_sd_browser)
+      sd_browser_release_pending = true;
+  #endif
 
   //#ifdef MARAUDER_V8
   //  digitalWrite(TFT_BL, HIGH);

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -1685,7 +1685,16 @@ void MenuFunctions::buildFoxTargetList(FoxHuntListKind type, int context_ap) {
       add_item(i, airtags->get(i).rssi, 0, airtags->get(i).last_seen, airtags->get(i).mac);
   } else if (type == FoxHuntListKind::FLIPPER_TARGETS) {
     for (int i = 0; i < flippers->size(); i++)
-      add_item(i, -128, 0, 0, flippers->get(i).name.length() ? flippers->get(i).name : flippers->get(i).mac);
+      add_item(i, flippers->get(i).rssi, 0, flippers->get(i).last_seen,
+               flippers->get(i).name.length() ? flippers->get(i).name : flippers->get(i).mac);
+  } else if (type == FoxHuntListKind::META_TARGETS || type == FoxHuntListKind::FLOCK_TARGETS) {
+    const String device_type = type == FoxHuntListKind::META_TARGETS ? "Meta" : "Flock";
+    for (int i = 0; i < ble_devices->size(); i++) {
+      const BleDevice& device = ble_devices->get(i);
+      if (device.device_type == device_type)
+        add_item(i, device.rssi, 0, device.last_seen_ms,
+                 device.name.length() ? device.name : macToString(device.mac));
+    }
   }
 
   std::vector<TargetListItem> filtered;
@@ -1723,9 +1732,13 @@ void MenuFunctions::buildFoxTargetList(FoxHuntListKind type, int context_ap) {
     } else if (type == FoxHuntListKind::FINDMY_TARGETS) {
       label = String(airtags->get(index).rssi) + " " + airtags->get(index).mac;
       color = TFTWHITE;
-    } else {
+    } else if (type == FoxHuntListKind::FLIPPER_TARGETS) {
       label = flippers->get(index).name.length() ? flippers->get(index).name : flippers->get(index).mac;
       color = TFTORANGE;
+    } else {
+      const BleDevice& device = ble_devices->get(index);
+      label = String(device.rssi) + " " + (device.name.length() ? device.name : macToString(device.mac));
+      color = type == FoxHuntListKind::META_TARGETS ? TFTWHITE : TFTORANGE;
     }
 
     this->addNodes(menu, label.c_str(), color, 255, [this, type, context_ap, index]() {
@@ -1755,11 +1768,19 @@ void MenuFunctions::buildFoxTargetList(FoxHuntListKind type, int context_ap) {
         uint8_t mac[6];
         convertMacStringToUint8(flippers->get(index).mac, mac);
         String name = flippers->get(index).name.length() ? flippers->get(index).name : flippers->get(index).mac;
-        wifi_scan_obj.setFoxHuntTarget(mac, name, -128, 0, true, flippers->get(index).mac);
+        wifi_scan_obj.setFoxHuntTarget(mac, name, flippers->get(index).rssi, 0, true, flippers->get(index).mac);
+      } else if (type == FoxHuntListKind::META_TARGETS || type == FoxHuntListKind::FLOCK_TARGETS) {
+        const BleDevice& device = ble_devices->get(index);
+        wifi_scan_obj.setFoxHuntTarget(device.mac, device.name, device.rssi, 0, true, macToString(device.mac));
       }
       display_obj.clearScreen();
       this->drawStatusBar();
-      wifi_scan_obj.StartScan(type == FoxHuntListKind::BLE_TARGETS || type == FoxHuntListKind::FINDMY_TARGETS || type == FoxHuntListKind::FLIPPER_TARGETS ? BT_SCAN_FOX_HUNT : WIFI_SCAN_SIG_STREN, TFT_CYAN);
+      wifi_scan_obj.StartScan(type == FoxHuntListKind::BLE_TARGETS ||
+                              type == FoxHuntListKind::FINDMY_TARGETS ||
+                              type == FoxHuntListKind::FLIPPER_TARGETS ||
+                              type == FoxHuntListKind::META_TARGETS ||
+                              type == FoxHuntListKind::FLOCK_TARGETS
+                                ? BT_SCAN_FOX_HUNT : WIFI_SCAN_SIG_STREN, TFT_CYAN);
     });
   }
   this->changeMenu(menu, true);
@@ -1783,6 +1804,8 @@ void MenuFunctions::buildBluetoothFoxHuntMenu() {
   this->addNodes(&foxHuntMenu, "BLE Devices", TFTCYAN, BLUETOOTH, [this]() { buildFoxTargetList(FoxHuntListKind::BLE_TARGETS); });
   this->addNodes(&foxHuntMenu, "FindMy", TFTWHITE, BLUETOOTH, [this]() { buildFoxTargetList(FoxHuntListKind::FINDMY_TARGETS); });
   this->addNodes(&foxHuntMenu, "Flipper Zero", TFTORANGE, FLIPPER, [this]() { buildFoxTargetList(FoxHuntListKind::FLIPPER_TARGETS); });
+  this->addNodes(&foxHuntMenu, "Meta", TFTWHITE, BLUETOOTH, [this]() { buildFoxTargetList(FoxHuntListKind::META_TARGETS); });
+  this->addNodes(&foxHuntMenu, "Flock", TFTORANGE, FLOCK, [this]() { buildFoxTargetList(FoxHuntListKind::FLOCK_TARGETS); });
   this->changeMenu(&foxHuntMenu, true);
 }
 
@@ -3557,7 +3580,7 @@ void MenuFunctions::RunSetup()
 
       sdDeleteMenu.parentMenu = &deviceMenu;
 
-      this->addNodes(&deviceMenu, "Delete SD Files", TFTCYAN, SD_UPDATE, [this]() {
+      this->addNodes(&deviceMenu, "SD File Browser", TFTCYAN, SD_UPDATE, [this]() {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(false);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -4241,7 +4264,7 @@ void MenuFunctions::buildSDDeleteBrowser(const String& path, bool reset_selectio
   delete sdDeleteMenu.list;
   sdDeleteMenu.list = new LinkedList<MenuNode>();
   sdDeleteMenu.selected = 0;
-  sdDeleteMenu.name = path == "/" ? "SD Card" : path;
+  sdDeleteMenu.name = path == "/" ? "SD File Browser" : path;
 
   this->addNodes(&sdDeleteMenu, text09, TFTLIGHTGREY, 0, [this, path]() {
     if (path == "/") {
@@ -4296,8 +4319,9 @@ void MenuFunctions::buildSDDeleteBrowser(const String& path, bool reset_selectio
         SD_UPDATE,
         [this, entry]() {
           this->toggleSDDeleteSelection(entry.path);
-          this->buildSDDeleteBrowser(sd_browser_path);
-          this->changeMenu(&sdDeleteMenu, true);
+          MenuNode node = current_menu->list->get(current_menu->selected);
+          node.selected = this->isSDFileSelected(entry.path);
+          current_menu->list->set(current_menu->selected, node);
         },
         this->isSDFileSelected(entry.path)
       );

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -141,6 +141,8 @@ class MenuFunctions
       BLE_TARGETS,
       FINDMY_TARGETS,
       FLIPPER_TARGETS,
+      META_TARGETS,
+      FLOCK_TARGETS,
     };
 
     String u_result = "";

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -194,6 +194,9 @@ class MenuFunctions
     LinkedList<SDDirectoryEntry>* sd_browser_entries = nullptr;
     LinkedList<String>* sd_delete_selection = nullptr;
     String sd_browser_path = "/";
+    bool sd_browser_release_pending = false;
+    void ensureSDDeleteBrowserResources();
+    void releaseSDDeleteBrowserResources();
 
     // WiFi menu stuff
     Menu wifiSnifferMenu;

--- a/esp32_marauder/ReconMission.cpp
+++ b/esp32_marauder/ReconMission.cpp
@@ -15,6 +15,10 @@
 extern LinkedList<AccessPoint>* access_points;
 extern LinkedList<Station>* stations;
 extern LinkedList<BleDevice>* ble_devices;
+#ifdef HAS_BT
+  extern LinkedList<AirTag>* airtags;
+  extern LinkedList<Flipper>* flippers;
+#endif
 extern WiFiScan wifi_scan_obj;
 extern Buffer buffer_obj;
 #ifdef HAS_SCREEN
@@ -269,6 +273,18 @@ void ReconMission::pruneStaleDevices(uint32_t current_time) {
           ble_devices->remove(index);
           pending_churn_out++;
         }
+      }
+    }
+    if (airtags) {
+      for (int index = airtags->size() - 1; index >= 0; index--) {
+        if (reconDeviceExpired(current_time, airtags->get(index).last_seen))
+          airtags->remove(index);
+      }
+    }
+    if (flippers) {
+      for (int index = flippers->size() - 1; index >= 0; index--) {
+        if (reconDeviceExpired(current_time, flippers->get(index).last_seen))
+          flippers->remove(index);
       }
     }
   #endif

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -552,6 +552,8 @@ extern "C" {
               Flipper flipper;
               flipper.mac = mac;
               flipper.name = name;
+              flipper.rssi = rssi;
+              flipper.last_seen = millis();
 
               flippers->add(flipper);
 
@@ -578,6 +580,7 @@ extern "C" {
               ble_device.last_seen_ms = millis();
 
               memcpy(ble_device.mac, mac_char, sizeof(mac_char));
+              wifi_scan_obj.retainBLEFoxHuntSubtype(advertisedDevice, ble_device);
 
               int device_match_check = wifi_scan_obj.seenBLEDevice(ble_device);
 
@@ -1252,6 +1255,8 @@ extern "C" {
               Flipper flipper;
               flipper.mac = mac;
               flipper.name = name;
+              flipper.rssi = rssi;
+              flipper.last_seen = millis();
 
               flippers->add(flipper);
 
@@ -1278,6 +1283,7 @@ extern "C" {
               ble_device.last_seen_ms = millis();
 
               memcpy(ble_device.mac, mac_char, sizeof(mac_char));
+              wifi_scan_obj.retainBLEFoxHuntSubtype(advertisedDevice, ble_device);
 
               int device_match_check = wifi_scan_obj.seenBLEDevice(ble_device);
 
@@ -2046,6 +2052,63 @@ String WiFiScan::classifyBLEDevice(const NimBLEAdvertisedDevice* advertised_devi
   if (payload && isFlockCamera(payload, payload_length, name, &serial)) return "Flock";
   if (name.length()) return name;
   return "BLE";
+}
+
+void WiFiScan::retainBLEFoxHuntSubtype(const NimBLEAdvertisedDevice* advertised_device,
+                                      const BleDevice& ble_device) {
+  if (!advertised_device) return;
+
+  String mac = advertised_device->getAddress().toString().c_str();
+  mac.toUpperCase();
+
+  if (ble_device.device_type == "FindMy") {
+    for (int index = 0; index < airtags->size(); index++) {
+      if (airtags->get(index).mac != mac) continue;
+      AirTag airtag = airtags->get(index);
+      airtag.rssi = ble_device.rssi;
+      airtag.last_seen = ble_device.last_seen_ms;
+      airtags->set(index, airtag);
+      return;
+    }
+
+    AirTag airtag;
+    airtag.mac = mac;
+    #ifndef HAS_NIMBLE_2
+      const uint8_t* payload = advertised_device->getPayload();
+      const size_t payload_length = advertised_device->getPayloadLength();
+      if (payload && payload_length)
+        airtag.payload.assign(payload, payload + payload_length);
+    #else
+      airtag.payload = advertised_device->getPayload();
+    #endif
+    airtag.payloadSize = airtag.payload.size();
+    airtag.rssi = ble_device.rssi;
+    airtag.last_seen = ble_device.last_seen_ms;
+    airtag.is_fmna = advertised_device->isAdvertisingService(FMNA_SERVICE_UUID);
+    airtag.is_dult = advertised_device->isAdvertisingService(DULT_SERVICE_UUID);
+    airtag.is_airtag = !airtag.is_fmna && !airtag.is_dult;
+    airtag.device_address = advertised_device->getAddress();
+    airtags->add(airtag);
+    return;
+  }
+
+  if (ble_device.device_type == "Flipper") {
+    for (int index = 0; index < flippers->size(); index++) {
+      if (flippers->get(index).mac != mac) continue;
+      Flipper flipper = flippers->get(index);
+      flipper.name = advertised_device->getName().c_str();
+      flipper.rssi = ble_device.rssi;
+      flipper.last_seen = ble_device.last_seen_ms;
+      flippers->set(index, flipper);
+      return;
+    }
+    Flipper flipper;
+    flipper.mac = mac;
+    flipper.name = advertised_device->getName().c_str();
+    flipper.rssi = ble_device.rssi;
+    flipper.last_seen = ble_device.last_seen_ms;
+    flippers->add(flipper);
+  }
 }
 #endif
 

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -348,6 +348,8 @@ struct AirTag {
 struct Flipper {
   String mac;
   String name;
+  int8_t rssi = -128;
+  uint32_t last_seen = 0;
 };
 
 struct BleDevice {
@@ -1012,6 +1014,8 @@ class WiFiScan
     bool isBlockedIdentifier(uint16_t id);
     #ifdef HAS_BT
       String classifyBLEDevice(const NimBLEAdvertisedDevice* advertised_device);
+      void retainBLEFoxHuntSubtype(const NimBLEAdvertisedDevice* advertised_device,
+                                   const BleDevice& ble_device);
     #endif
     void setFoxHuntTarget(const uint8_t mac[6], const String& name, int8_t rssi, uint8_t channel, bool bluetooth, const String& advertised_address = "");
     bool updateFoxHuntRssi(const uint8_t mac[6], int8_t rssi, uint8_t channel = 0);


### PR DESCRIPTION
## Summary

- rename Delete SD Files to SD File Browser and toggle selections in place without rebuilding the directory menu
- add a root-level Deselect All action that preserves the current menu position
- release browser entries, selected paths, and menu nodes after fully exiting, then recreate them on re-entry
- retain Recon-discovered FindMy and Flipper devices in their Fox Hunt target lists
- add Meta and Flock Fox Hunt target views backed by the existing BLE classifiers and two-minute Recon decay
