### PR TITLE
Fix human-mode SPIFFS CLI responses

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -587,6 +587,8 @@ void CommandLine::runCommand(String input) {
       uint8_t error = 0;
       if (machine && operation != 1)
         machineResult(transaction_id, command, "started", "OK");
+      else if (!machine && operation != 1)
+        Serial.printf("SPIFFS %s started\n", operation == 0 ? "backup" : "restore");
 
       bool success = sd_obj.migrateSPIFFS(operation, files, bytes, error);
       if (machine) {
@@ -597,6 +599,21 @@ void CommandLine::runCommand(String input) {
                                  operation == 1 ? "BACKUP_INSPECTION_FAILED" : "RESTORE_FAILED";
           machineResult(transaction_id, command, "error", storageErrorCode(error, fallback));
         }
+      }
+      else if (success) {
+        const char* action = operation == 0 ? "backup complete" :
+                             operation == 1 ? "backup status" : "restore complete";
+        Serial.printf("SPIFFS %s: %u files, %u bytes%s\n", action,
+                      static_cast<unsigned int>(files),
+                      static_cast<unsigned int>(bytes),
+                      operation == 2 ? "; rebooting" : "");
+      }
+      else {
+        const char* fallback = operation == 0 ? "BACKUP_FAILED" :
+                               operation == 1 ? "BACKUP_INSPECTION_FAILED" : "RESTORE_FAILED";
+        Serial.printf("SPIFFS %s failed: %s\n",
+                      operation == 0 ? "backup" : operation == 1 ? "backup status" : "restore",
+                      storageErrorCode(error, fallback));
       }
       if (success && operation == 2) {
         delay(1000);

--- a/tools/test_spiffs_machine_protocol.py
+++ b/tools/test_spiffs_machine_protocol.py
@@ -38,6 +38,18 @@ class SpiffsMachineProtocolTests(unittest.TestCase):
         self.assertIn("File backup = SD.open(backup_path)", method)
         self.assertIn('copyTree(SD, backup_path, nullptr', method)
 
+    def test_human_spiffs_commands_report_lifecycle_and_results(self):
+        source = (ROOT / "esp32_marauder" / "CommandLine.cpp").read_text()
+        start = source.index("cmd_args.get(0) == BACKUP_SPIFFS_CMD ||")
+        commands = source[start:source.index("// GCOVR_EXCL_STOP", start)]
+
+        self.assertIn('else if (!machine && operation != 1)', commands)
+        self.assertIn('Serial.printf("SPIFFS %s started\\n"', commands)
+        self.assertIn('operation == 1 ? "backup status"', commands)
+        self.assertIn('operation == 2 ? "; rebooting" : ""', commands)
+        self.assertIn('Serial.printf("SPIFFS %s failed: %s\\n"', commands)
+        self.assertIn('storageErrorCode(error, fallback)', commands)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- report start, success, status, and failure results for SPIFFS commands without `--machine`
- preserve the framed machine protocol used by automation
- add regression coverage for human-mode command responses