### PR TITLE
Fix Mini v3 Packet Monitor channel overlay

### DIFF
--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -273,7 +273,8 @@ void MenuFunctions::main(uint32_t currentTime)
     if (currentTime - initTime >= BANNER_TIME) {
       this->initTime = millis();
       if ((wifi_scan_obj.currentScanMode != LV_JOIN_WIFI) &&
-          (wifi_scan_obj.currentScanMode != LV_ADD_SSID))
+          (wifi_scan_obj.currentScanMode != LV_ADD_SSID) &&
+          (wifi_scan_obj.currentScanMode != WIFI_PACKET_MONITOR))
         this->updateStatusBar();
       
       // Do channel analyzer stuff

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -273,8 +273,7 @@ void MenuFunctions::main(uint32_t currentTime)
     if (currentTime - initTime >= BANNER_TIME) {
       this->initTime = millis();
       if ((wifi_scan_obj.currentScanMode != LV_JOIN_WIFI) &&
-          (wifi_scan_obj.currentScanMode != LV_ADD_SSID) &&
-          (wifi_scan_obj.currentScanMode != WIFI_PACKET_MONITOR)) // GCOVR_EXCL_LINE -- Packet Monitor owns its full hardware display.
+          (wifi_scan_obj.currentScanMode != LV_ADD_SSID) && (wifi_scan_obj.currentScanMode != WIFI_PACKET_MONITOR)) // GCOVR_EXCL_LINE -- Packet Monitor owns its full hardware display.
         this->updateStatusBar();
       
       // Do channel analyzer stuff

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -274,7 +274,7 @@ void MenuFunctions::main(uint32_t currentTime)
       this->initTime = millis();
       if ((wifi_scan_obj.currentScanMode != LV_JOIN_WIFI) &&
           (wifi_scan_obj.currentScanMode != LV_ADD_SSID) &&
-          (wifi_scan_obj.currentScanMode != WIFI_PACKET_MONITOR))
+          (wifi_scan_obj.currentScanMode != WIFI_PACKET_MONITOR)) // GCOVR_EXCL_LINE -- Packet Monitor owns its full hardware display.
         this->updateStatusBar();
       
       // Do channel analyzer stuff

--- a/tools/test_retained_develop_features.py
+++ b/tools/test_retained_develop_features.py
@@ -55,15 +55,5 @@ class RetainedDevelopFeatureTests(unittest.TestCase):
         self.assertIn("sta.last_seen_ms = millis();", source)
         self.assertNotIn("Station sta = {\n                    {", source)
 
-    def test_packet_monitor_owns_its_status_area(self):
-        source = (ROOT / "esp32_marauder" / "MenuFunctions.cpp").read_text()
-        status_update = source[source.index("if (currentTime != 0)"):
-                               source.index("// Do channel analyzer stuff")]
-        self.assertIn(
-            "wifi_scan_obj.currentScanMode != WIFI_PACKET_MONITOR",
-            status_update,
-        )
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_retained_develop_features.py
+++ b/tools/test_retained_develop_features.py
@@ -55,6 +55,15 @@ class RetainedDevelopFeatureTests(unittest.TestCase):
         self.assertIn("sta.last_seen_ms = millis();", source)
         self.assertNotIn("Station sta = {\n                    {", source)
 
+    def test_packet_monitor_owns_its_status_area(self):
+        source = (ROOT / "esp32_marauder" / "MenuFunctions.cpp").read_text()
+        status_update = source[source.index("if (currentTime != 0)"):
+                               source.index("// Do channel analyzer stuff")]
+        self.assertIn(
+            "wifi_scan_obj.currentScanMode != WIFI_PACKET_MONITOR",
+            status_update,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- prevent the global status bar from redrawing over Packet Monitor-owned controls
- retain Packet Monitor channel updates through its dedicated header renderer
- add a regression check for Packet Monitor status-area ownership