### PR TITLE
Improve GPS Tracker session dashboard

### DIFF
--- a/esp32_marauder/GpsTrackerStats.cpp
+++ b/esp32_marauder/GpsTrackerStats.cpp
@@ -1,0 +1,78 @@
+#include "GpsTrackerStats.h"
+
+#include <math.h>
+
+namespace marauder {
+namespace {
+constexpr double kDegreesToRadians = 0.017453292519943295;
+constexpr double kEarthRadiusMeters = 6371000.0;
+constexpr float kMaximumPlausibleSpeedMps = 120.0f;
+}
+
+void GpsTrackerStats::reset(uint32_t now_ms) {
+  start_ms_ = now_ms;
+  last_fix_ms_ = now_ms;
+  last_latitude_e6_ = 0;
+  last_longitude_e6_ = 0;
+  distance_m_ = 0.0f;
+  speed_mps_ = 0.0f;
+  logged_points_ = 0;
+  has_fix_ = false;
+}
+
+uint32_t GpsTrackerStats::elapsedMs(uint32_t now_ms) const {
+  return now_ms - start_ms_;
+}
+
+float GpsTrackerStats::distanceBetweenMeters(int32_t latitude_a_e6,
+                                             int32_t longitude_a_e6,
+                                             int32_t latitude_b_e6,
+                                             int32_t longitude_b_e6) {
+  const double lat_a = latitude_a_e6 * 0.000001 * kDegreesToRadians;
+  const double lat_b = latitude_b_e6 * 0.000001 * kDegreesToRadians;
+  const double delta_lat = lat_b - lat_a;
+  const double delta_lon =
+      (longitude_b_e6 - longitude_a_e6) * 0.000001 * kDegreesToRadians;
+  const double sin_lat = sin(delta_lat * 0.5);
+  const double sin_lon = sin(delta_lon * 0.5);
+  const double haversine = sin_lat * sin_lat +
+      cos(lat_a) * cos(lat_b) * sin_lon * sin_lon;
+  const double bounded_haversine = haversine > 1.0 ? 1.0 : haversine;
+  const double arc = 2.0 * atan2(sqrt(bounded_haversine),
+                                 sqrt(1.0 - bounded_haversine));
+  return static_cast<float>(kEarthRadiusMeters * arc);
+}
+
+bool GpsTrackerStats::update(int32_t latitude_e6, int32_t longitude_e6,
+                             float accuracy_m, uint32_t now_ms) {
+  ++logged_points_;
+  if (!has_fix_) {
+    last_latitude_e6_ = latitude_e6;
+    last_longitude_e6_ = longitude_e6;
+    last_fix_ms_ = now_ms;
+    has_fix_ = true;
+    return true;
+  }
+
+  const uint32_t delta_ms = now_ms - last_fix_ms_;
+  const float step_m = distanceBetweenMeters(last_latitude_e6_,
+                                             last_longitude_e6_, latitude_e6,
+                                             longitude_e6);
+  const float jitter_floor_m = accuracy_m > 3.0f ? accuracy_m : 3.0f;
+  const float maximum_step_m = delta_ms * 0.001f * kMaximumPlausibleSpeedMps;
+
+  last_latitude_e6_ = latitude_e6;
+  last_longitude_e6_ = longitude_e6;
+  last_fix_ms_ = now_ms;
+
+  if (delta_ms == 0 || step_m < jitter_floor_m || step_m > maximum_step_m) {
+    speed_mps_ = 0.0f;
+    return false;
+  }
+
+  distance_m_ += step_m;
+  speed_mps_ = step_m / (delta_ms * 0.001f);
+  return true;
+}
+
+}  // namespace marauder

--- a/esp32_marauder/GpsTrackerStats.h
+++ b/esp32_marauder/GpsTrackerStats.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace marauder {
+
+class GpsTrackerStats {
+ public:
+  void reset(uint32_t now_ms);
+  bool update(int32_t latitude_e6, int32_t longitude_e6, float accuracy_m,
+              uint32_t now_ms);
+
+  uint32_t elapsedMs(uint32_t now_ms) const;
+  float distanceMeters() const { return distance_m_; }
+  float speedMetersPerSecond() const { return speed_mps_; }
+  uint32_t loggedPoints() const { return logged_points_; }
+  bool hasFix() const { return has_fix_; }
+
+  static float distanceBetweenMeters(int32_t latitude_a_e6,
+                                     int32_t longitude_a_e6,
+                                     int32_t latitude_b_e6,
+                                     int32_t longitude_b_e6);
+
+ private:
+  uint32_t start_ms_ = 0;
+  uint32_t last_fix_ms_ = 0;
+  int32_t last_latitude_e6_ = 0;
+  int32_t last_longitude_e6_ = 0;
+  float distance_m_ = 0.0f;
+  float speed_mps_ = 0.0f;
+  uint32_t logged_points_ = 0;
+  bool has_fix_ = false;
+};
+
+}  // namespace marauder

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -4204,8 +4204,10 @@ void WiFiScan::writeFooter(bool poi) {
 }
 
 void WiFiScan::RunSetupGPSTracker(uint8_t scan_mode) {
-  if (scan_mode == GPS_TRACKER)
+  if (scan_mode == GPS_TRACKER) {
     this->startGPX("tracker");
+    this->gps_tracker_stats.reset(millis());
+  }
   else if (scan_mode == GPS_POI)
     this->startGPX("poi");
 
@@ -4217,10 +4219,15 @@ bool WiFiScan::RunGPSInfo(bool tracker, bool display, bool poi) {
   bool return_val = true;
   #ifdef HAS_GPS
     String text=gps_obj.getText();
+    const uint32_t now_ms = millis();
 
     if (tracker) {
       if (gps_obj.getFixStatus()) {
         this->logPoint(gps_obj.getLat(), gps_obj.getLon(), gps_obj.getAlt(), gps_obj.getDatetime(), poi);
+        if (!poi) {
+          this->gps_tracker_stats.update(gps_obj.getLatInt(), gps_obj.getLonInt(),
+                                         gps_obj.getAccuracy(), now_ms);
+        }
       }
       else
         return_val = false;
@@ -4229,35 +4236,83 @@ bool WiFiScan::RunGPSInfo(bool tracker, bool display, bool poi) {
     if (display) {
       //Serial.println(F("Refreshing GPS Data on screen..."));
       #ifdef HAS_SCREEN
+        const int16_t content_top = (SCREEN_HEIGHT / 3) - 6;
+        const bool compact = SCREEN_HEIGHT <= 160 || SCREEN_WIDTH <= 160;
+        const bool expanded = SCREEN_HEIGHT >= 240 && SCREEN_WIDTH >= 200;
+        const uint32_t elapsed_seconds = this->gps_tracker_stats.elapsedMs(now_ms) / 1000;
+        const uint32_t elapsed_hours = elapsed_seconds / 3600;
+        const uint8_t elapsed_minutes = (elapsed_seconds / 60) % 60;
+        const uint8_t elapsed_secs = elapsed_seconds % 60;
+        char elapsed_text[16];
+        snprintf(elapsed_text, sizeof(elapsed_text), "%02lu:%02u:%02u",
+                 static_cast<unsigned long>(elapsed_hours), elapsed_minutes, elapsed_secs);
+        const float distance_m = this->gps_tracker_stats.distanceMeters();
+        const String distance_text = distance_m >= 1000.0f
+            ? String(distance_m / 1000.0f, 2) + " km"
+            : String(distance_m, 1) + " m";
 
-        // Get screen position ready
         display_obj.tft.setTextWrap(false);
         display_obj.tft.setFreeFont(NULL);
-        display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
         display_obj.tft.setTextSize(1);
-        display_obj.tft.setTextColor(TFT_CYAN);
+        display_obj.tft.fillRect(0, content_top, SCREEN_WIDTH,
+                                 SCREEN_HEIGHT - content_top, TFT_BLACK);
 
-        // Clean up screen first
-        //display_obj.tft.fillRect(0, 0, 240, STATUS_BAR_WIDTH, STATUSBAR_COLOR);
-        display_obj.tft.fillRect(0, (SCREEN_HEIGHT / 3) - 6, SCREEN_WIDTH, SCREEN_HEIGHT - ((SCREEN_HEIGHT / 3) - 6), TFT_BLACK);
-
-        // Print the GPS data: 3
-        display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
-        if (gps_obj.getFixStatus())
-          display_obj.tft.println(F("  Good Fix: Yes"));
-        else {
+        if (!gps_obj.getFixStatus()) {
           return_val = false;
-          display_obj.tft.println(F("  Good Fix: No"));
         }
-          
-        if(text != "") display_obj.tft.println("      Text: " + text);
 
-        display_obj.tft.println(" Sats: " + gps_obj.getNumSatsString());
-        display_obj.tft.println("  Acc: " + (String)gps_obj.getAccuracy());
-        display_obj.tft.println("  Lat: " + gps_obj.getLat());
-        display_obj.tft.println("  Lon: " + gps_obj.getLon());
-        display_obj.tft.println("  Alt: " + (String)gps_obj.getAlt());
-        display_obj.tft.println("  D/T: " + gps_obj.getDatetime());
+        if (compact) {
+          display_obj.tft.setCursor(0, content_top + 6);
+          display_obj.tft.setTextColor(gps_obj.getFixStatus() ? TFT_GREEN : TFT_RED);
+          display_obj.tft.print(gps_obj.getFixStatus() ? F("FIX") : F("NO FIX"));
+          display_obj.tft.setTextColor(TFT_CYAN);
+          display_obj.tft.println("  SAT " + gps_obj.getNumSatsString() + "  " + elapsed_text);
+          display_obj.tft.println("DIST " + distance_text);
+          display_obj.tft.println("LAT  " + gps_obj.getLat());
+          display_obj.tft.println("LON  " + gps_obj.getLon());
+          display_obj.tft.println("ALT " + String(gps_obj.getAlt(), 1) + "m  ACC " +
+                                  String(gps_obj.getAccuracy(), 1) + "m");
+          display_obj.tft.println("SPD " + String(this->gps_tracker_stats.speedMetersPerSecond() * 3.6f, 1) +
+                                  "km/h  PTS " + String(this->gps_tracker_stats.loggedPoints()));
+        }
+        else {
+          int16_t y = content_top + 10;
+          display_obj.tft.setCursor(8, y);
+          display_obj.tft.setTextColor(gps_obj.getFixStatus() ? TFT_GREEN : TFT_RED);
+          display_obj.tft.setTextSize(expanded ? 2 : 1);
+          display_obj.tft.print(gps_obj.getFixStatus() ? F("GPS FIX") : F("NO GPS FIX"));
+          display_obj.tft.setTextColor(TFT_CYAN);
+          display_obj.tft.setTextSize(1);
+          display_obj.tft.setCursor(SCREEN_WIDTH - 72, y + 3);
+          display_obj.tft.print("SATS " + gps_obj.getNumSatsString());
+
+          y += expanded ? 30 : 18;
+          display_obj.tft.setCursor(8, y);
+          display_obj.tft.setTextSize(expanded ? 2 : 1);
+          display_obj.tft.println(distance_text);
+          display_obj.tft.setTextSize(1);
+          display_obj.tft.setCursor(SCREEN_WIDTH / 2, y + (expanded ? 4 : 0));
+          display_obj.tft.println(elapsed_text);
+
+          y += expanded ? 28 : 16;
+          display_obj.tft.setCursor(8, y);
+          display_obj.tft.println("LAT  " + gps_obj.getLat());
+          display_obj.tft.setCursor(8, y + 16);
+          display_obj.tft.println("LON  " + gps_obj.getLon());
+          display_obj.tft.setCursor(8, y + 36);
+          display_obj.tft.println("ALT " + String(gps_obj.getAlt(), 1) + " m");
+          display_obj.tft.setCursor(SCREEN_WIDTH / 2, y + 36);
+          display_obj.tft.println("ACC " + String(gps_obj.getAccuracy(), 1) + " m");
+          display_obj.tft.setCursor(8, y + 52);
+          display_obj.tft.println("SPEED " + String(this->gps_tracker_stats.speedMetersPerSecond() * 3.6f, 1) + " km/h");
+          display_obj.tft.setCursor(SCREEN_WIDTH / 2, y + 52);
+          display_obj.tft.println("POINTS " + String(this->gps_tracker_stats.loggedPoints()));
+          if (expanded) {
+            display_obj.tft.setCursor(8, y + 72);
+            display_obj.tft.setTextColor(TFT_GREEN);
+            display_obj.tft.println(F("GPX LOGGING ACTIVE"));
+          }
+        }
       #endif
 
       // Display to serial
@@ -4275,6 +4330,12 @@ bool WiFiScan::RunGPSInfo(bool tracker, bool display, bool poi) {
       Serial.println("  Lon: " + gps_obj.getLon());
       Serial.println("  Alt: " + (String)gps_obj.getAlt());
       Serial.println("  D/T: " + gps_obj.getDatetime());
+      if (tracker && !poi) {
+        Serial.println(" Dist: " + String(this->gps_tracker_stats.distanceMeters(), 1) + " m");
+        Serial.println(" Speed: " + String(this->gps_tracker_stats.speedMetersPerSecond() * 3.6f, 1) + " km/h");
+        Serial.println(" Elapsed: " + String(this->gps_tracker_stats.elapsedMs(now_ms) / 1000) + " s");
+        Serial.println(" Points: " + String(this->gps_tracker_stats.loggedPoints()));
+      }
     }
   #endif
 

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -5,6 +5,7 @@
 
 #include "configs.h"
 #include "utils.h"
+#include "GpsTrackerStats.h"
 
 #include <ArduinoJson.h>
 #include <algorithm>
@@ -433,6 +434,7 @@ class WiFiScan
     //int num_deauth = 0; // RED
 
     uint32_t initTime = 0;
+    marauder::GpsTrackerStats gps_tracker_stats;
     uint32_t last_ui_update = 0;
     uint32_t last_sour_apple_update = 0;
     bool run_setup = true;

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ build_src_filter =
   +<IPv4Range.cpp>
   +<FirmwareMetadata.cpp>
   +<MenuMarquee.cpp>
+  +<GpsTrackerStats.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/test_gps_tracker_stats/test_main.cpp
+++ b/test/test_gps_tracker_stats/test_main.cpp
@@ -1,0 +1,63 @@
+#include <unity.h>
+
+#include "GpsTrackerStats.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_reset_clears_session_and_elapsed_handles_rollover() {
+  marauder::GpsTrackerStats stats;
+  stats.reset(UINT32_MAX - 10);
+
+  TEST_ASSERT_EQUAL_UINT32(16, stats.elapsedMs(5));
+  TEST_ASSERT_EQUAL_UINT32(0, stats.loggedPoints());
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, stats.distanceMeters());
+}
+
+void test_known_coordinates_produce_expected_distance() {
+  const float distance = marauder::GpsTrackerStats::distanceBetweenMeters(
+      40748147, -73985364, 40758147, -73985364);
+  TEST_ASSERT_FLOAT_WITHIN(2.0f, 1111.95f, distance);
+}
+
+void test_first_fix_sets_origin_without_adding_distance() {
+  marauder::GpsTrackerStats stats;
+  stats.reset(1000);
+
+  TEST_ASSERT_TRUE(stats.update(40748147, -73985364, 2.0f, 2000));
+  TEST_ASSERT_TRUE(stats.hasFix());
+  TEST_ASSERT_EQUAL_UINT32(1, stats.loggedPoints());
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, stats.distanceMeters());
+}
+
+void test_real_movement_accumulates_and_reports_speed() {
+  marauder::GpsTrackerStats stats;
+  stats.reset(0);
+  stats.update(40748147, -73985364, 2.0f, 1000);
+
+  TEST_ASSERT_TRUE(stats.update(40748237, -73985364, 2.0f, 2000));
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 10.0f, stats.distanceMeters());
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 10.0f, stats.speedMetersPerSecond());
+  TEST_ASSERT_EQUAL_UINT32(2, stats.loggedPoints());
+}
+
+void test_accuracy_jitter_and_impossible_jump_are_not_accumulated() {
+  marauder::GpsTrackerStats stats;
+  stats.reset(0);
+  stats.update(40748147, -73985364, 8.0f, 1000);
+
+  TEST_ASSERT_FALSE(stats.update(40748192, -73985364, 8.0f, 2000));
+  TEST_ASSERT_FALSE(stats.update(41748192, -73985364, 2.0f, 3000));
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, stats.distanceMeters());
+  TEST_ASSERT_EQUAL_UINT32(3, stats.loggedPoints());
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_reset_clears_session_and_elapsed_handles_rollover);
+  RUN_TEST(test_known_coordinates_produce_expected_distance);
+  RUN_TEST(test_first_fix_sets_origin_without_adding_distance);
+  RUN_TEST(test_real_movement_accumulates_and_reports_speed);
+  RUN_TEST(test_accuracy_jitter_and_impossible_jump_are_not_accumulated);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- add responsive compact and expanded GPS Tracker dashboards
- show fix, satellites, elapsed time, distance, coordinates, altitude, accuracy, speed, and logged points
- filter GPS jitter and implausible jumps from distance totals while retaining GPX logging
- expose session telemetry over serial for non-display hardware
- add native tracker math and rollover tests

## Validation
- 80/80 native tests pass
- Mini v3 ESP32-C5 8 MB default_8MB build passes
- V8 ESP32-C5 8 MB default_8MB build passes