### PR TITLE
Add responsive JCMK boot splash

### DIFF
--- a/esp32_marauder/BootSplash.cpp
+++ b/esp32_marauder/BootSplash.cpp
@@ -21,6 +21,10 @@ BootSplashLayout bootSplashLayout(int16_t screen_width,
   layout.logo_height = available_height < height_from_width
       ? available_height : height_from_width;
   if (layout.logo_height < 24) layout.logo_height = 24;
+  if (v8_portrait) {
+    layout.logo_height /= 2;
+    layout.logo_y += (available_height - layout.logo_height) / 2;
+  }
   layout.logo_width = layout.logo_height * 240 / 316;
   layout.logo_x = (screen_width - layout.logo_width) / 2;
   return layout;

--- a/test/test_boot_splash/test_main.cpp
+++ b/test/test_boot_splash/test_main.cpp
@@ -24,14 +24,18 @@ void test_layout_fits_mini_v3() {
   TEST_ASSERT_EQUAL_UINT8(1, layout.text_size);
 }
 
-void test_layout_fits_v8_and_uses_more_logo_area() {
+void test_layout_fits_v8_with_half_size_logo() {
   const marauder::BootSplashLayout mini =
       marauder::bootSplashLayout(128, 128);
   const marauder::BootSplashLayout v8 =
       marauder::bootSplashLayout(240, 320);
   assertLayoutFits(240, 320);
   TEST_ASSERT_EQUAL_UINT8(1, v8.text_size);
-  TEST_ASSERT_GREATER_THAN_INT16(mini.logo_height * 2, v8.logo_height);
+  TEST_ASSERT_EQUAL_INT16(79, v8.logo_x);
+  TEST_ASSERT_EQUAL_INT16(101, v8.logo_y);
+  TEST_ASSERT_EQUAL_INT16(81, v8.logo_width);
+  TEST_ASSERT_EQUAL_INT16(107, v8.logo_height);
+  TEST_ASSERT_GREATER_THAN_INT16(mini.logo_height, v8.logo_height);
 }
 
 void test_layout_fits_landscape_and_square_displays() {
@@ -44,7 +48,7 @@ void test_layout_fits_landscape_and_square_displays() {
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_layout_fits_mini_v3);
-  RUN_TEST(test_layout_fits_v8_and_uses_more_logo_area);
+  RUN_TEST(test_layout_fits_v8_with_half_size_logo);
   RUN_TEST(test_layout_fits_landscape_and_square_displays);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- add a responsive monochrome JCMK boot splash across supported displays
- keep the original compact V8 text while reducing and centering its logo at 50% size
- cover splash sizing and placement with native regression tests