### PR TITLE
Add menu hold-repeat without breaking touch select

### DIFF
--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -662,8 +662,9 @@ void MenuFunctions::main(uint32_t currentTime)
       if (menu_navigation_active) {
         const int8_t held_button =
             display_obj.menuButton(&t_x, &t_y, pressed, true);
-        const int8_t released_button =
-            display_obj.menuButton(&t_x, &t_y, pressed);
+        const int8_t released_button = menuTouchReleasedButton(
+            menu_touch_button, held_button, pressed);
+        menu_touch_button = held_button;
         const bool up_event = menu_up_repeat.update(
             held_button == UP_BUTTON, currentTime);
         const bool down_event = menu_down_repeat.update(
@@ -674,6 +675,7 @@ void MenuFunctions::main(uint32_t currentTime)
       } else {
         menu_up_repeat.reset();
         menu_down_repeat.reset();
+        menu_touch_button = -1;
         menu_button = display_obj.menuButton(&t_x, &t_y, pressed);
       }
 

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -335,7 +335,17 @@ void MenuFunctions::main(uint32_t currentTime)
 
   // Brightness gesture: hold top or bottom zone 1.5s to enter brightness mode
   #ifdef HAS_ILI9341
-    if (pressed && (wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF ||
+    bool touching_menu_control = false;
+    if (pressed) {
+      for (uint8_t b = BUTTON_ARRAY_LEN; b < BUTTON_ARRAY_LEN + 3; b++) {
+        if (display_obj.key[b].contains(t_x, t_y)) {
+          touching_menu_control = true;
+          break;
+        }
+      }
+    }
+    if (pressed && !touching_menu_control &&
+        (wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF ||
                     wifi_scan_obj.currentScanMode == WIFI_CONNECTED)) {
       uint16_t zoneUp = TFT_HEIGHT * 25 / 100;
       uint16_t zoneDown = TFT_HEIGHT * 75 / 100;
@@ -644,9 +654,30 @@ void MenuFunctions::main(uint32_t currentTime)
       }*/
 
       // Detect up, down, select
-      uint8_t menu_button = display_obj.menuButton(&t_x, &t_y, pressed);
+      int8_t menu_button;
+      const bool menu_navigation_active =
+          wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF ||
+          wifi_scan_obj.currentScanMode == WIFI_CONNECTED ||
+          wifi_scan_obj.currentScanMode == OTA_UPDATE;
+      if (menu_navigation_active) {
+        const int8_t held_button =
+            display_obj.menuButton(&t_x, &t_y, pressed, true);
+        const int8_t released_button =
+            display_obj.menuButton(&t_x, &t_y, pressed);
+        const bool up_event = menu_up_repeat.update(
+            held_button == UP_BUTTON, currentTime);
+        const bool down_event = menu_down_repeat.update(
+            held_button == DOWN_BUTTON, currentTime);
+        menu_button = up_event ? UP_BUTTON :
+                      down_event ? DOWN_BUTTON :
+                      released_button == SELECT_BUTTON ? SELECT_BUTTON : -1;
+      } else {
+        menu_up_repeat.reset();
+        menu_down_repeat.reset();
+        menu_button = display_obj.menuButton(&t_x, &t_y, pressed);
+      }
 
-      if (menu_button > -1) {
+      if (menu_button >= 0) {
         if (menu_button == UP_BUTTON) {
           if ((wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF) ||
               (wifi_scan_obj.currentScanMode == WIFI_CONNECTED) ||
@@ -801,10 +832,21 @@ void MenuFunctions::main(uint32_t currentTime)
       #if !defined(MARAUDER_M5STICKC) || defined(MARAUDER_M5STICKCP2)
         #if (U_BTN >= 0 || defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV))
           #if (U_BTN >= 0)
-            if (u_btn.justPressed()) {
+            const bool up_just_pressed = u_btn.justPressed();
+            const bool up_is_pressed = u_btn.isPressedNow();
           #elif defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV)
-            if (this->isKeyPressed(';')) {
+            const bool up_just_pressed = this->isKeyPressed(';');
+            const bool up_is_pressed = up_just_pressed;
           #endif
+            const bool menu_navigation_active =
+                wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF ||
+                wifi_scan_obj.currentScanMode == WIFI_CONNECTED ||
+                wifi_scan_obj.currentScanMode == OTA_UPDATE;
+            const bool up_event = menu_navigation_active
+                ? menu_up_repeat.update(up_is_pressed, currentTime)
+                : up_just_pressed;
+            if (!menu_navigation_active) menu_up_repeat.reset();
+            if (up_event) {
               if ((wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF) ||
                   (wifi_scan_obj.currentScanMode == WIFI_CONNECTED) ||
                   (wifi_scan_obj.currentScanMode == OTA_UPDATE)) {
@@ -873,10 +915,21 @@ void MenuFunctions::main(uint32_t currentTime)
 
       #if (D_BTN >= 0 || defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV))
       #if (D_BTN >= 0)
-      if (d_btn.justPressed()){
+      const bool down_just_pressed = d_btn.justPressed();
+      const bool down_is_pressed = d_btn.isPressedNow();
       #elif defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV)
-      if (this->isKeyPressed('.')){
+      const bool down_just_pressed = this->isKeyPressed('.');
+      const bool down_is_pressed = down_just_pressed;
       #endif
+      const bool down_menu_navigation_active =
+          wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF ||
+          wifi_scan_obj.currentScanMode == WIFI_CONNECTED ||
+          wifi_scan_obj.currentScanMode == OTA_UPDATE;
+      const bool down_event = down_menu_navigation_active
+          ? menu_down_repeat.update(down_is_pressed, currentTime)
+          : down_just_pressed;
+      if (!down_menu_navigation_active) menu_down_repeat.reset();
+      if (down_event) {
         if ((wifi_scan_obj.currentScanMode == WIFI_SCAN_OFF) ||
             (wifi_scan_obj.currentScanMode == WIFI_CONNECTED) ||
             (wifi_scan_obj.currentScanMode == OTA_UPDATE)) {

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -162,6 +162,7 @@ class MenuFunctions
     uint32_t marquee_selected_since = 0;
     MenuInputRepeat menu_up_repeat;
     MenuInputRepeat menu_down_repeat;
+    int8_t menu_touch_button = -1;
 
     void buildWiFiFoxHuntMenu();
     void buildBluetoothFoxHuntMenu();

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -23,6 +23,7 @@
 #include "BatteryInterface.h"
 #include "SDInterface.h"
 #include "settings.h"
+#include "MenuInputRepeat.h"
 
 #ifdef HAS_BUTTONS
   #include "Switches.h"
@@ -159,6 +160,8 @@ class MenuFunctions
     uint16_t marquee_rendered_offset = 0;
     uint16_t marquee_max_offset = 0;
     uint32_t marquee_selected_since = 0;
+    MenuInputRepeat menu_up_repeat;
+    MenuInputRepeat menu_down_repeat;
 
     void buildWiFiFoxHuntMenu();
     void buildBluetoothFoxHuntMenu();

--- a/esp32_marauder/MenuInputRepeat.cpp
+++ b/esp32_marauder/MenuInputRepeat.cpp
@@ -1,0 +1,1 @@
+#include "MenuInputRepeat.h"

--- a/esp32_marauder/MenuInputRepeat.h
+++ b/esp32_marauder/MenuInputRepeat.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <stdint.h>
+
+class MenuInputRepeat {
+ public:
+  static constexpr uint32_t kHoldDelayMs = 1000;
+  static constexpr uint32_t kRepeatIntervalMs = 120;
+
+  bool update(bool pressed, uint32_t now) {
+    if (!pressed) {
+      active_ = false;
+      return false;
+    }
+    if (!active_) {
+      active_ = true;
+      pressed_at_ = now;
+      repeated_at_ = now;
+      return true;
+    }
+    if (static_cast<uint32_t>(now - pressed_at_) < kHoldDelayMs ||
+        static_cast<uint32_t>(now - repeated_at_) < kRepeatIntervalMs) {
+      return false;
+    }
+    repeated_at_ = now;
+    return true;
+  }
+
+  void reset() { active_ = false; }
+
+ private:
+  bool active_ = false;
+  uint32_t pressed_at_ = 0;
+  uint32_t repeated_at_ = 0;
+};

--- a/esp32_marauder/MenuInputRepeat.h
+++ b/esp32_marauder/MenuInputRepeat.h
@@ -2,6 +2,12 @@
 
 #include <stdint.h>
 
+inline int8_t menuTouchReleasedButton(int8_t previous_button,
+                                      int8_t current_button,
+                                      bool touch_pressed) {
+  return !touch_pressed && current_button < 0 ? previous_button : -1;
+}
+
 class MenuInputRepeat {
  public:
   static constexpr uint32_t kHoldDelayMs = 1000;

--- a/esp32_marauder/Switches.cpp
+++ b/esp32_marauder/Switches.cpp
@@ -52,6 +52,10 @@ bool Switches::getButtonState() {
 		return false;
 }
 
+bool Switches::isPressedNow() {
+	return this->getButtonState();
+}
+
 bool Switches::justPressed() {
 	bool btn_state = this->getButtonState();
 	

--- a/esp32_marauder/Switches.h
+++ b/esp32_marauder/Switches.h
@@ -30,6 +30,7 @@ class Switches {
 		bool justPressed();
 		bool justReleased();
 		bool isHeld();
+		bool isPressedNow();
 };
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ build_src_filter =
   +<MenuMarquee.cpp>
   +<GpsTrackerStats.cpp>
   +<BootSplash.cpp>
+  +<MenuInputRepeat.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/test_menu_input_repeat/test_main.cpp
+++ b/test/test_menu_input_repeat/test_main.cpp
@@ -1,0 +1,39 @@
+#include <unity.h>
+
+#include "MenuInputRepeat.h"
+
+void test_press_fires_immediately_then_waits_one_second() {
+  MenuInputRepeat repeat;
+  TEST_ASSERT_TRUE(repeat.update(true, 100));
+  TEST_ASSERT_FALSE(repeat.update(true, 1099));
+  TEST_ASSERT_TRUE(repeat.update(true, 1100));
+}
+
+void test_held_input_repeats_at_rapid_interval() {
+  MenuInputRepeat repeat;
+  TEST_ASSERT_TRUE(repeat.update(true, 0));
+  TEST_ASSERT_TRUE(repeat.update(true, 1000));
+  TEST_ASSERT_FALSE(repeat.update(true, 1119));
+  TEST_ASSERT_TRUE(repeat.update(true, 1120));
+  TEST_ASSERT_TRUE(repeat.update(true, 1240));
+}
+
+void test_release_resets_hold_timing() {
+  MenuInputRepeat repeat;
+  TEST_ASSERT_TRUE(repeat.update(true, 0));
+  TEST_ASSERT_FALSE(repeat.update(false, 500));
+  TEST_ASSERT_TRUE(repeat.update(true, 600));
+  TEST_ASSERT_FALSE(repeat.update(true, 1599));
+  TEST_ASSERT_TRUE(repeat.update(true, 1600));
+}
+
+void setUp() {}
+void tearDown() {}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_press_fires_immediately_then_waits_one_second);
+  RUN_TEST(test_held_input_repeats_at_rapid_interval);
+  RUN_TEST(test_release_resets_hold_timing);
+  return UNITY_END();
+}

--- a/test/test_menu_input_repeat/test_main.cpp
+++ b/test/test_menu_input_repeat/test_main.cpp
@@ -27,6 +27,22 @@ void test_release_resets_hold_timing() {
   TEST_ASSERT_TRUE(repeat.update(true, 1600));
 }
 
+void test_touch_select_release_survives_held_state_polling() {
+  constexpr int8_t select_button = 2;
+  TEST_ASSERT_EQUAL_INT8(-1,
+                         menuTouchReleasedButton(-1, select_button, true));
+  TEST_ASSERT_EQUAL_INT8(
+      select_button,
+      menuTouchReleasedButton(select_button, -1, false));
+}
+
+void test_touch_drag_off_does_not_select_before_release() {
+  constexpr int8_t select_button = 2;
+  TEST_ASSERT_EQUAL_INT8(
+      -1,
+      menuTouchReleasedButton(select_button, -1, true));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -35,5 +51,7 @@ int main(int, char**) {
   RUN_TEST(test_press_fires_immediately_then_waits_one_second);
   RUN_TEST(test_held_input_repeats_at_rapid_interval);
   RUN_TEST(test_release_resets_hold_timing);
+  RUN_TEST(test_touch_select_release_survives_held_state_polling);
+  RUN_TEST(test_touch_drag_off_does_not_select_before_release);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- add one-second Up/Down hold-repeat for touch and button menu navigation
- preserve V8 center Select release handling with regression coverage