### PR TITLE
Fix T-Dongle display corruption from shared LED bus

### DIFF
--- a/esp32_marauder/LedInterface.cpp
+++ b/esp32_marauder/LedInterface.cpp
@@ -96,6 +96,16 @@ void LedInterface::setColor(int r, int g, int b) {
 #ifdef HAS_T_DONGLE_LED
 void LedInterface::writeApa102Color(uint8_t red, uint8_t green, uint8_t blue) {
   const uint8_t brightness = (red || green || blue) ? 10 : 0;
+
+  // The APA102 shares the TFT/SD clock and data lines on shipped T-Dongle
+  // hardware. Keep both SPI peripherals deselected while bit-banging the LED;
+  // otherwise the LED frame can be interpreted as display or SD traffic and
+  // leave the panel lit black.
+  pinMode(T_DONGLE_TFT_CS_PIN, OUTPUT);
+  digitalWrite(T_DONGLE_TFT_CS_PIN, HIGH);
+  pinMode(SD_CS, OUTPUT);
+  digitalWrite(SD_CS, HIGH);
+
   this->t_dongle_led.startFrame();
   this->t_dongle_led.sendColor(red, green, blue, brightness);
   this->t_dongle_led.endFrame(1);

--- a/esp32_marauder/LedInterface.cpp
+++ b/esp32_marauder/LedInterface.cpp
@@ -1,4 +1,7 @@
 #include "LedInterface.h"
+#ifdef HAS_T_DONGLE_LED
+  #include "TDongleBus.h"
+#endif
 
 
 LedInterface::LedInterface() {
@@ -97,14 +100,7 @@ void LedInterface::setColor(int r, int g, int b) {
 void LedInterface::writeApa102Color(uint8_t red, uint8_t green, uint8_t blue) {
   const uint8_t brightness = (red || green || blue) ? 10 : 0;
 
-  // The APA102 shares the TFT/SD clock and data lines on shipped T-Dongle
-  // hardware. Keep both SPI peripherals deselected while bit-banging the LED;
-  // otherwise the LED frame can be interpreted as display or SD traffic and
-  // leave the panel lit black.
-  pinMode(T_DONGLE_TFT_CS_PIN, OUTPUT);
-  digitalWrite(T_DONGLE_TFT_CS_PIN, HIGH);
-  pinMode(SD_CS, OUTPUT);
-  digitalWrite(SD_CS, HIGH);
+  deselectTDongleSharedSpi(T_DONGLE_TFT_CS_PIN, SD_CS);
 
   this->t_dongle_led.startFrame();
   this->t_dongle_led.sendColor(red, green, blue, brightness);

--- a/esp32_marauder/TDongleBus.cpp
+++ b/esp32_marauder/TDongleBus.cpp
@@ -1,0 +1,11 @@
+#include "TDongleBus.h"
+
+#include <Arduino.h>
+
+void deselectTDongleSharedSpi(uint8_t tftCsPin, uint8_t sdCsPin) {
+  // The APA102 shares the TFT/SD clock and data lines on shipped T-Dongles.
+  pinMode(tftCsPin, OUTPUT);
+  digitalWrite(tftCsPin, HIGH);
+  pinMode(sdCsPin, OUTPUT);
+  digitalWrite(sdCsPin, HIGH);
+}

--- a/esp32_marauder/TDongleBus.h
+++ b/esp32_marauder/TDongleBus.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <stdint.h>
+
+void deselectTDongleSharedSpi(uint8_t tftCsPin, uint8_t sdCsPin);

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -527,6 +527,7 @@
     #define HAS_T_DONGLE_LED
     #define T_DONGLE_LED_DATA_PIN 2
     #define T_DONGLE_LED_CLOCK_PIN 6
+    #define T_DONGLE_TFT_CS_PIN 10
     #define T_DONGLE_SPI_SCLK_PIN 6
     #define T_DONGLE_SPI_MISO_PIN 7
     #define T_DONGLE_SPI_MOSI_PIN 2

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ build_src_filter =
   +<GpsTrackerStats.cpp>
   +<BootSplash.cpp>
   +<MenuInputRepeat.cpp>
+  +<TDongleBus.cpp>
 build_flags =
   -std=gnu++17
   -Wall

--- a/test/support/Arduino.h
+++ b/test/support/Arduino.h
@@ -5,6 +5,7 @@
 constexpr int LOW = 0;
 constexpr int HIGH = 1;
 constexpr int INPUT = 0;
+constexpr int OUTPUT = 1;
 constexpr int INPUT_PULLUP = 1;
 constexpr int INPUT_PULLDOWN = 2;
 
@@ -13,6 +14,9 @@ inline int read_value = LOW;
 inline uint32_t current_millis = 0;
 inline int pin_mode_pin = -1;
 inline int pin_mode_value = -1;
+inline int write_pins[2] = {-1, -1};
+inline int write_values[2] = {-1, -1};
+inline int write_count = 0;
 }
 
 inline void pinMode(int pin, int mode) {
@@ -20,6 +24,13 @@ inline void pinMode(int pin, int mode) {
   arduino_test::pin_mode_value = mode;
 }
 inline int digitalRead(int) { return arduino_test::read_value; }
+inline void digitalWrite(int pin, int value) {
+  if (arduino_test::write_count < 2) {
+    arduino_test::write_pins[arduino_test::write_count] = pin;
+    arduino_test::write_values[arduino_test::write_count] = value;
+  }
+  ++arduino_test::write_count;
+}
 inline uint32_t millis() { return arduino_test::current_millis; }
 
 namespace arduino_test {
@@ -28,9 +39,15 @@ inline void reset() {
   current_millis = 0;
   pin_mode_pin = -1;
   pin_mode_value = -1;
+  write_pins[0] = write_pins[1] = -1;
+  write_values[0] = write_values[1] = -1;
+  write_count = 0;
 }
 inline void setDigitalRead(int value) { read_value = value; }
 inline void setMillis(uint32_t value) { current_millis = value; }
 inline int lastPinModePin() { return pin_mode_pin; }
 inline int lastPinModeValue() { return pin_mode_value; }
+inline int digitalWriteCount() { return write_count; }
+inline int digitalWritePin(int index) { return write_pins[index]; }
+inline int digitalWriteValue(int index) { return write_values[index]; }
 }

--- a/test/test_t_dongle_bus/test_main.cpp
+++ b/test/test_t_dongle_bus/test_main.cpp
@@ -1,0 +1,22 @@
+#include <unity.h>
+
+#include "Arduino.h"
+#include "TDongleBus.h"
+
+void test_shared_spi_devices_are_deselected() {
+  arduino_test::reset();
+
+  deselectTDongleSharedSpi(10, 23);
+
+  TEST_ASSERT_EQUAL_INT(2, arduino_test::digitalWriteCount());
+  TEST_ASSERT_EQUAL_INT(10, arduino_test::digitalWritePin(0));
+  TEST_ASSERT_EQUAL_INT(HIGH, arduino_test::digitalWriteValue(0));
+  TEST_ASSERT_EQUAL_INT(23, arduino_test::digitalWritePin(1));
+  TEST_ASSERT_EQUAL_INT(HIGH, arduino_test::digitalWriteValue(1));
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_shared_spi_devices_are_deselected);
+  return UNITY_END();
+}

--- a/tools/test_t_dongle_hardware.py
+++ b/tools/test_t_dongle_hardware.py
@@ -15,6 +15,7 @@ class TDongleHardwareTests(unittest.TestCase):
         self.assertIn("#define HAS_GPS", feature_block)
         self.assertIn("#define T_DONGLE_LED_DATA_PIN 2", feature_block)
         self.assertIn("#define T_DONGLE_LED_CLOCK_PIN 6", feature_block)
+        self.assertIn("#define T_DONGLE_TFT_CS_PIN 10", feature_block)
         self.assertIn("#define T_DONGLE_SPI_SCLK_PIN 6", feature_block)
         self.assertIn("#define T_DONGLE_SPI_MISO_PIN 7", feature_block)
         self.assertIn("#define T_DONGLE_SPI_MOSI_PIN 2", feature_block)
@@ -37,6 +38,8 @@ class TDongleHardwareTests(unittest.TestCase):
         self.assertIn("t_dongle_led.sendColor(red, green, blue, brightness)", writer)
         self.assertIn("t_dongle_led.endFrame(1)", writer)
         self.assertIn("? 10 : 0", writer)
+        self.assertIn("digitalWrite(T_DONGLE_TFT_CS_PIN, HIGH)", writer)
+        self.assertIn("digitalWrite(SD_CS, HIGH)", writer)
         self.assertNotIn("SPI.begin", writer)
 
         header = (ROOT / "esp32_marauder" / "LedInterface.h").read_text()

--- a/tools/test_t_dongle_hardware.py
+++ b/tools/test_t_dongle_hardware.py
@@ -38,8 +38,7 @@ class TDongleHardwareTests(unittest.TestCase):
         self.assertIn("t_dongle_led.sendColor(red, green, blue, brightness)", writer)
         self.assertIn("t_dongle_led.endFrame(1)", writer)
         self.assertIn("? 10 : 0", writer)
-        self.assertIn("digitalWrite(T_DONGLE_TFT_CS_PIN, HIGH)", writer)
-        self.assertIn("digitalWrite(SD_CS, HIGH)", writer)
+        self.assertIn("deselectTDongleSharedSpi(T_DONGLE_TFT_CS_PIN, SD_CS)", writer)
         self.assertNotIn("SPI.begin", writer)
 
         header = (ROOT / "esp32_marauder" / "LedInterface.h").read_text()


### PR DESCRIPTION
## Summary
- deselect the T-Dongle TFT and SD peripherals before sending APA102 frames on their shared SPI lines
- add focused regression coverage for the shared-bus chip-select behavior