### PR TITLE
Add multiple saved WiFi profiles with scan-first selection

### DIFF
--- a/esp32_marauder/CommandLine.cpp
+++ b/esp32_marauder/CommandLine.cpp
@@ -682,13 +682,8 @@ void CommandLine::runCommand(String input) {
         upload_dest = BOTH_UPLOAD;
 
       if (upload_dest > -1) {
-        String ssid = settings_obj.loadSetting<String>("ClientSSID");
-        String pw = settings_obj.loadSetting<String>("ClientPW");
-
-        Serial.println("Connecting to " + ssid);
-
-        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
-          Serial.println("Failed to connected to " + ssid);
+        if (!wifi_scan_obj.joinSavedWiFi(false)) {
+          Serial.println(F("Failed to connect to saved WiFi"));
           return;
         }
         delay(1000);
@@ -1684,7 +1679,7 @@ void CommandLine::runCommand(String input) {
       int index = cmd_args.get(ap_sw + 1).toInt();
       String password = cmd_args.get(pw_sw + 1);
       AccessPoint access_point = access_points->get(index);
-      Serial.println("Using SSID: " + (String)access_point.essid + " Password: " + (String)password);
+      Serial.println("Using SSID: " + (String)access_point.essid);
       //wifi_scan_obj.currentScanMode = LV_JOIN_WIFI;
       //wifi_scan_obj.StartScan(LV_JOIN_WIFI, TFT_YELLOW); 
       wifi_scan_obj.joinWiFi(access_point.essid, password, false);
@@ -1695,11 +1690,8 @@ void CommandLine::runCommand(String input) {
       #endif
     }
     else if (s_sw != -1) {
-      String ssid = settings_obj.loadSetting<String>("ClientSSID");
-      String pw = settings_obj.loadSetting<String>("ClientPW");
-
-      if ((ssid != "") && (pw != "")) {
-        wifi_scan_obj.joinWiFi(ssid, pw, false);
+      if (settings_obj.getSavedWifiCount() > 0) {
+        wifi_scan_obj.joinSavedWiFi(false);
         #ifdef HAS_SCREEN
           menu_function_obj.changeMenu(menu_function_obj.current_menu);
         #endif

--- a/esp32_marauder/MenuFunctions.cpp
+++ b/esp32_marauder/MenuFunctions.cpp
@@ -242,6 +242,10 @@ void MenuFunctions::main(uint32_t currentTime)
     if (sd_browser_release_pending && current_menu != &sdDeleteMenu)
       this->releaseSDDeleteBrowserResources();
   #endif
+  if (saved_wifi_release_pending && current_menu != &savedWifiMenu) {
+    this->releaseSavedWifiMenu();
+    saved_wifi_release_pending = false;
+  }
 
   #if defined(MARAUDER_CARDPUTER) || defined(MARAUDER_CARDPUTER_ADV)
     this->updateKeyboard();
@@ -2012,6 +2016,7 @@ void MenuFunctions::RunSetup()
   #endif*/
   wifiGeneralMenu.list = new LinkedList<MenuNode>();
   wifiAPMenu.list = new LinkedList<MenuNode>();
+  savedWifiMenu.list = nullptr;
   wifiIPMenu.list = new LinkedList<MenuNode>();
   apInfoMenu.list = new LinkedList<MenuNode>();
   setMacMenu.list = new LinkedList<MenuNode>();
@@ -2889,11 +2894,17 @@ void MenuFunctions::RunSetup()
             this->changeMenu(&miniKbMenu, true);
             String password = this->miniKeyboard(&miniKbMenu, true);
             if (password != "") {
-              Serial.println("Using SSID: " + (String)access_points->get(i).essid + " Password: " + (String)password);
+              Serial.println("Using SSID: " + (String)access_points->get(i).essid);
               wifi_scan_obj.currentScanMode = LV_JOIN_WIFI;
               wifi_scan_obj.StartScan(LV_JOIN_WIFI, TFT_YELLOW); 
               wifi_scan_obj.joinWiFi(access_points->get(i).essid, password);
-              this->changeMenu(current_menu, true);
+              if (wifi_scan_obj.hasPendingWifiCredential()) {
+                this->buildSavedWifiMenu(true);
+                this->changeMenu(&savedWifiMenu, true);
+              }
+              else {
+                this->changeMenu(current_menu, true);
+              }
             }
           #endif
 
@@ -2902,6 +2913,11 @@ void MenuFunctions::RunSetup()
             char passwordBuf[64] = {0};  // or prefill with existing SSID
             if (keyboardInput(passwordBuf, sizeof(passwordBuf), "Enter Password")) {
               wifi_scan_obj.joinWiFi(access_points->get(i).essid, String(passwordBuf), true);
+              if (wifi_scan_obj.hasPendingWifiCredential()) {
+                this->buildSavedWifiMenu(true);
+                this->changeMenu(&savedWifiMenu, true);
+                return;
+              }
             }
 
             this->changeMenu(&wifiGeneralMenu, true);
@@ -2912,52 +2928,13 @@ void MenuFunctions::RunSetup()
     });
 
     this->addNodes(&wifiGeneralMenu, "Join Saved WiFi", TFTWHITE, KEYBOARD_ICO, [this](){
-      String ssid = settings_obj.loadSetting<String>("ClientSSID");
-      String pw = settings_obj.loadSetting<String>("ClientPW");
+      wifi_scan_obj.joinSavedWiFi(true);
+      this->changeMenu(&wifiGeneralMenu, true);
+    });
 
-      if ((ssid != "") && (pw != "")) {
-        wifi_scan_obj.joinWiFi(ssid, pw, false);
-        this->changeMenu(&wifiGeneralMenu, true);
-      }
-      else {
-        wifiAPMenu.parentMenu = &wifiGeneralMenu;
-
-        // Add the back button
-        wifiAPMenu.list->clear();
-          this->addNodes(&wifiAPMenu, text09, TFTLIGHTGREY, 0, [this]() {
-          this->changeMenu(wifiAPMenu.parentMenu, true);
-        });
-
-        // Populate the menu with buttons
-        for (int i = 0; i < access_points->size(); i++) {
-          // This is the menu node
-          this->addNodes(&wifiAPMenu, access_points->get(i).essid.c_str(), TFTCYAN, 255, [this, i](){
-            // Join WiFi using mini keyboard
-            #ifdef HAS_MINI_KB
-              this->changeMenu(&miniKbMenu, true);
-              String password = this->miniKeyboard(&miniKbMenu, true);
-              if (password != "") {
-                Serial.println("Using SSID: " + (String)access_points->get(i).essid + " Password: " + (String)password);
-                wifi_scan_obj.currentScanMode = LV_JOIN_WIFI;
-                wifi_scan_obj.StartScan(LV_JOIN_WIFI, TFT_YELLOW); 
-                wifi_scan_obj.joinWiFi(access_points->get(i).essid, password);
-                this->changeMenu(current_menu, true);
-              }
-            #endif
-
-            // Join WiFi using touch screen keyboard
-            #ifdef HAS_TOUCH
-              char passwordBuf[64] = {0};  // or prefill with existing SSID
-              if (keyboardInput(passwordBuf, sizeof(passwordBuf), "Enter Password")) {
-                wifi_scan_obj.joinWiFi(access_points->get(i).essid, String(passwordBuf), true);
-              }
-
-              this->changeMenu(&wifiGeneralMenu, true);
-            #endif
-          });
-        }
-        this->changeMenu(&wifiAPMenu, true);
-      }
+    this->addNodes(&wifiGeneralMenu, "Manage Saved WiFi", TFTWHITE, SETTINGS, [this](){
+      this->buildSavedWifiMenu(false);
+      this->changeMenu(&savedWifiMenu, true);
     });
 
     this->addNodes(&wifiGeneralMenu, "Start AP", TFTGREEN, KEYBOARD_ICO, [this](){
@@ -2978,7 +2955,7 @@ void MenuFunctions::RunSetup()
             this->changeMenu(&miniKbMenu, true);
             String password = this->miniKeyboard(&miniKbMenu, true);
             if (password != "") {
-              Serial.println("Using SSID: " + (String)ssids->get(i).essid + " Password: " + (String)password);
+              Serial.println("Using SSID: " + (String)ssids->get(i).essid);
               wifi_scan_obj.currentScanMode = LV_JOIN_WIFI;
               wifi_scan_obj.StartScan(LV_JOIN_WIFI, TFT_YELLOW); 
               wifi_scan_obj.startWiFi(ssids->get(i).essid, password);
@@ -2990,7 +2967,7 @@ void MenuFunctions::RunSetup()
           #ifdef HAS_TOUCH
             char passwordBuf[64] = {0};  // or prefill with existing SSID
             if (keyboardInput(passwordBuf, sizeof(passwordBuf), "Enter Password")) {
-              Serial.println("Using SSID: " + (String)ssids->get(i).essid + " Password: " + String(passwordBuf));
+              Serial.println("Using SSID: " + (String)ssids->get(i).essid);
               wifi_scan_obj.startWiFi(ssids->get(i).essid, String(passwordBuf));
             }
 
@@ -3044,10 +3021,7 @@ void MenuFunctions::RunSetup()
     this->addNodes(&uploadAllMenu, "WiGLE", TFTLIGHTGREY, 0, [this]() {
       display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
 
-      String ssid = settings_obj.loadSetting<String>("ClientSSID");
-      String pw = settings_obj.loadSetting<String>("ClientPW");
-
-      if ((ssid == "") && (pw == "")) {
+      if (settings_obj.getSavedWifiCount() == 0) {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(true);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3056,9 +3030,7 @@ void MenuFunctions::RunSetup()
         display_obj.tft.setTextWrap(false);
       }
       else {
-        display_obj.clearScreen();
-        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2, true);
-        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+        if (!wifi_scan_obj.joinSavedWiFi(true)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
           display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3093,12 +3065,9 @@ void MenuFunctions::RunSetup()
       this->changeMenu(uploadAllMenu.parentMenu, true);
     });
     this->addNodes(&uploadAllMenu, "WDGWars", TFTLIGHTGREY, 0, [this]() {
-      String ssid = settings_obj.loadSetting<String>("ClientSSID");
-      String pw = settings_obj.loadSetting<String>("ClientPW");
-
       display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
 
-      if ((ssid == "") && (pw == "")) {
+      if (settings_obj.getSavedWifiCount() == 0) {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(true);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3107,9 +3076,7 @@ void MenuFunctions::RunSetup()
         display_obj.tft.setTextWrap(false);
       }
       else {
-        display_obj.clearScreen();
-        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2, true);
-        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+        if (!wifi_scan_obj.joinSavedWiFi(true)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
           display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3144,12 +3111,9 @@ void MenuFunctions::RunSetup()
       this->changeMenu(uploadAllMenu.parentMenu, true);
     });
     this->addNodes(&uploadAllMenu, "Both", TFTLIGHTGREY, 0, [this]() {
-      String ssid = settings_obj.loadSetting<String>("ClientSSID");
-      String pw = settings_obj.loadSetting<String>("ClientPW");
-
       display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
 
-      if ((ssid == "") && (pw == "")) {
+      if (settings_obj.getSavedWifiCount() == 0) {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(true);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3158,9 +3122,7 @@ void MenuFunctions::RunSetup()
         display_obj.tft.setTextWrap(false);
       }
       else {
-        display_obj.clearScreen();
-        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2, true);
-        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+        if (!wifi_scan_obj.joinSavedWiFi(true)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
           display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3234,12 +3196,9 @@ void MenuFunctions::RunSetup()
       this->changeMenu(actionMenu.parentMenu, true);
     });
     this->addNodes(&actionMenu, "WiGLE", TFTLIGHTGREY, 0, [this]() {
-      String ssid = settings_obj.loadSetting<String>("ClientSSID");
-      String pw = settings_obj.loadSetting<String>("ClientPW");
-
       display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
 
-      if ((ssid == "") && (pw == "")) {
+      if (settings_obj.getSavedWifiCount() == 0) {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(true);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3248,9 +3207,7 @@ void MenuFunctions::RunSetup()
         display_obj.tft.setTextWrap(false);
       }
       else {
-        display_obj.clearScreen();
-        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2, true);
-        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+        if (!wifi_scan_obj.joinSavedWiFi(true)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
           display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3281,12 +3238,9 @@ void MenuFunctions::RunSetup()
       this->changeMenu(&actionMenu, true);
     });
     this->addNodes(&actionMenu, "WDGWars", TFTLIGHTGREY, 0, [this]() {
-      String ssid = settings_obj.loadSetting<String>("ClientSSID");
-      String pw = settings_obj.loadSetting<String>("ClientPW");
-
       display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
 
-      if ((ssid == "") && (pw == "")) {
+      if (settings_obj.getSavedWifiCount() == 0) {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(true);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3295,9 +3249,7 @@ void MenuFunctions::RunSetup()
         display_obj.tft.setTextWrap(false);
       }
       else {
-        display_obj.clearScreen();
-        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2, true);
-        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+        if (!wifi_scan_obj.joinSavedWiFi(true)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
           display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3327,12 +3279,9 @@ void MenuFunctions::RunSetup()
       this->changeMenu(&actionMenu, true);
     });
     this->addNodes(&actionMenu, "Both", TFTLIGHTGREY, 0, [this]() {
-      String ssid = settings_obj.loadSetting<String>("ClientSSID");
-      String pw = settings_obj.loadSetting<String>("ClientPW");
-
       display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
 
-      if ((ssid == "") && (pw == "")) {
+      if (settings_obj.getSavedWifiCount() == 0) {
         display_obj.clearScreen();
         display_obj.tft.setTextWrap(true);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -3341,9 +3290,7 @@ void MenuFunctions::RunSetup()
         display_obj.tft.setTextWrap(false);
       }
       else {
-        display_obj.clearScreen();
-        display_obj.showCenterText(String("Connecting to " + ssid).c_str(), TFT_HEIGHT / 2, true);
-        if (!wifi_scan_obj.joinWiFi(ssid, pw, false)) {
+        if (!wifi_scan_obj.joinSavedWiFi(true)) {
           display_obj.clearScreen();
           display_obj.tft.setTextWrap(true);
           display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
@@ -4334,6 +4281,50 @@ void MenuFunctions::RunSetup()
     #endif
   }
 #endif
+
+void MenuFunctions::releaseSavedWifiMenu() {
+  if (savedWifiMenu.list != nullptr) {
+    savedWifiMenu.list->clear();
+    delete savedWifiMenu.list;
+    savedWifiMenu.list = nullptr;
+  }
+}
+
+void MenuFunctions::buildSavedWifiMenu(bool replace_mode) {
+  this->releaseSavedWifiMenu();
+  savedWifiMenu.list = new LinkedList<MenuNode>();
+  savedWifiMenu.selected = 0;
+  savedWifiMenu.parentMenu = &wifiGeneralMenu;
+  savedWifiMenu.name = replace_mode ? "Replace Saved WiFi" : "Saved WiFi";
+
+  this->addNodes(&savedWifiMenu, replace_mode ? "Cancel" : text09, TFTLIGHTGREY, 0, [this, replace_mode]() {
+    if (replace_mode)
+      wifi_scan_obj.discardPendingWifiCredential();
+    this->changeMenu(savedWifiMenu.parentMenu, true);
+    saved_wifi_release_pending = true;
+  });
+
+  const uint8_t count = settings_obj.getSavedWifiCount();
+  for (uint8_t index = 0; index < count; index++) {
+    String ssid;
+    String password;
+    if (!settings_obj.loadSavedWifiCredential(index, ssid, password))
+      continue;
+    String label = replace_mode ? "Replace " + ssid : "Remove " + ssid;
+    this->addNodes(&savedWifiMenu, label.c_str(), replace_mode ? TFTORANGE : TFTRED, 0, [this, index, replace_mode]() {
+      if (replace_mode)
+        wifi_scan_obj.savePendingWifiCredential(index);
+      else
+        settings_obj.removeSavedWifiCredential(index);
+
+      // Leave before freeing the node whose callback is currently running.
+      // The menu is rebuilt on demand, so another profile can be removed by
+      // reopening Manage Saved WiFi.
+      this->changeMenu(savedWifiMenu.parentMenu, true);
+      saved_wifi_release_pending = true;
+    });
+  }
+}
 
 void MenuFunctions::setupSDFileList(bool update) {
   sd_obj.sd_files->clear();

--- a/esp32_marauder/MenuFunctions.h
+++ b/esp32_marauder/MenuFunctions.h
@@ -204,6 +204,7 @@ class MenuFunctions
     LinkedList<String>* sd_delete_selection = nullptr;
     String sd_browser_path = "/";
     bool sd_browser_release_pending = false;
+    bool saved_wifi_release_pending = false;
     void ensureSDDeleteBrowserResources();
     void releaseSDDeleteBrowserResources();
 
@@ -216,6 +217,7 @@ class MenuFunctions
     #endif*/
     Menu wifiGeneralMenu;
     Menu wifiAPMenu;
+    Menu savedWifiMenu;
     Menu wifiIPMenu;
     Menu ssidsMenu;
     //#ifdef HAS_BT
@@ -259,6 +261,8 @@ class MenuFunctions
     void buildUploadFileMenu();
     void setupSDFileList(bool update = false);
     void buildSDFileMenu(bool update = false);
+    void buildSavedWifiMenu(bool replace_mode = false);
+    void releaseSavedWifiMenu();
     void buildSDDeleteBrowser(const String& path, bool reset_selection = false);
     void toggleSDDeleteSelection(const String& path);
     bool isSDFileSelected(const String& path) const;

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -2296,7 +2296,7 @@ void WiFiScan::finishNetworkScanDisplay(const String& result_label) {
 }
 // GCOVR_EXCL_STOP
 
-bool WiFiScan::joinWiFi(String ssid, String password, bool gui) {
+bool WiFiScan::joinWiFi(String ssid, String password, bool gui, bool save_credential) {
   static const char * btns[] ={text16, ""};
   int count = 0;
   
@@ -2370,10 +2370,87 @@ bool WiFiScan::joinWiFi(String ssid, String password, bool gui) {
     #endif
   #endif
 
-  settings_obj.saveSetting<bool>("ClientSSID", ssid);
-  settings_obj.saveSetting<bool>("ClientPW", password);
+  if (save_credential) {
+    WifiCredentialSaveResult save_result = settings_obj.saveWifiCredential(ssid, password);
+    if (save_result == WIFI_CREDENTIAL_FULL) {
+      ssid.toCharArray(this->pending_wifi_ssid, sizeof(this->pending_wifi_ssid));
+      password.toCharArray(this->pending_wifi_password, sizeof(this->pending_wifi_password));
+      this->pending_wifi_credential = true;
+    }
+  }
 
   return true;
+}
+
+bool WiFiScan::joinSavedWiFi(bool gui) {
+  const uint8_t count = settings_obj.getSavedWifiCount();
+  if (count == 0) {
+    Serial.println(F("There are no saved WiFi credentials"));
+    return false;
+  }
+
+  for (uint8_t index = 0; index < count; index++) {
+    String ssid;
+    String password;
+    if (!settings_obj.loadSavedWifiCredential(index, ssid, password))
+      continue;
+
+    Serial.println("Trying saved WiFi: " + ssid);
+    #ifdef HAS_SCREEN
+      if (gui) {
+        display_obj.clearScreen();
+        display_obj.tft.setTextWrap(false);
+        display_obj.tft.setTextSize(1);
+        display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+        display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+        display_obj.tft.println("Trying " + String(index + 1) + "/" + String(count));
+        display_obj.tft.println(ssid);
+      }
+    #endif
+
+    if (this->joinWiFi(ssid, password, false, false)) {
+      settings_obj.markSavedWifiSuccessful(index);
+      Serial.println("Connected to saved WiFi: " + ssid);
+      #ifdef HAS_SCREEN
+        if (gui) {
+          display_obj.clearScreen();
+          display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+          display_obj.tft.setTextColor(TFT_GREEN, TFT_BLACK);
+          display_obj.tft.println(F("Connected:"));
+          display_obj.tft.println(ssid);
+          delay(1000);
+        }
+      #endif
+      return true;
+    }
+  }
+
+  Serial.println(F("Could not connect to any saved WiFi network"));
+  return false;
+}
+
+bool WiFiScan::hasPendingWifiCredential() const {
+  return this->pending_wifi_credential;
+}
+
+bool WiFiScan::savePendingWifiCredential(uint8_t replace_index) {
+  if (!this->pending_wifi_credential)
+    return false;
+  WifiCredentialSaveResult result = settings_obj.saveWifiCredential(
+    String(this->pending_wifi_ssid),
+    String(this->pending_wifi_password),
+    replace_index
+  );
+  if (result == WIFI_CREDENTIAL_ERROR || result == WIFI_CREDENTIAL_FULL)
+    return false;
+  this->discardPendingWifiCredential();
+  return true;
+}
+
+void WiFiScan::discardPendingWifiCredential() {
+  memset(this->pending_wifi_ssid, 0, sizeof(this->pending_wifi_ssid));
+  memset(this->pending_wifi_password, 0, sizeof(this->pending_wifi_password));
+  this->pending_wifi_credential = false;
 }
 
 bool WiFiScan::startWiFi(String ssid, String password, bool gui) {
@@ -2441,8 +2518,6 @@ void WiFiScan::initWiFi(uint8_t scan_mode) {
     this->force_probe = settings_obj.loadSetting<bool>(text_table4[6]);
     this->save_pcap = settings_obj.loadSetting<bool>(text_table4[7]);
     this->ep_deauth = settings_obj.loadSetting<bool>("EPDeauth");
-    settings_obj.loadSetting<String>("ClientSSID");
-    settings_obj.loadSetting<String>("ClientPW");
     //Serial.println(F("Initialization complete"));
   }
 }

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -2389,11 +2389,64 @@ bool WiFiScan::joinSavedWiFi(bool gui) {
     return false;
   }
 
-  for (uint8_t index = 0; index < count; index++) {
+  #ifdef HAS_SCREEN
+    if (gui) {
+      display_obj.clearScreen();
+      display_obj.tft.setTextWrap(false);
+      display_obj.tft.setTextSize(1);
+      display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
+      display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
+      display_obj.tft.println(F("Scanning for saved WiFi..."));
+    }
+  #endif
+
+  WiFi.disconnect(true);
+  delay(100);
+  WiFi.mode(WIFI_MODE_STA);
+  const int16_t network_count = WiFi.scanNetworks(false, true, false, 80);
+
+  // Keep only profile indexes and signal strengths. Credentials are loaded
+  // transiently when a connection is actually attempted, and scan results are
+  // released before association.
+  uint8_t visible_indexes[MAX_SAVED_WIFI_PROFILES] = {0};
+  int32_t visible_rssi[MAX_SAVED_WIFI_PROFILES] = {0};
+  bool visible[MAX_SAVED_WIFI_PROFILES] = {false};
+  uint8_t visible_count = 0;
+
+  if (network_count > 0) {
+    for (uint8_t profile_index = 0; profile_index < count; profile_index++) {
+      String saved_ssid;
+      String saved_password;
+      if (!settings_obj.loadSavedWifiCredential(profile_index, saved_ssid, saved_password))
+        continue;
+
+      int32_t best_rssi = INT32_MIN;
+      for (int16_t network_index = 0; network_index < network_count; network_index++) {
+        if (saved_ssid == WiFi.SSID(network_index) && WiFi.RSSI(network_index) > best_rssi)
+          best_rssi = WiFi.RSSI(network_index);
+      }
+      if (best_rssi == INT32_MIN)
+        continue;
+
+      visible[profile_index] = true;
+      uint8_t insert_at = visible_count;
+      while (insert_at > 0 && best_rssi > visible_rssi[insert_at - 1]) {
+        visible_indexes[insert_at] = visible_indexes[insert_at - 1];
+        visible_rssi[insert_at] = visible_rssi[insert_at - 1];
+        insert_at--;
+      }
+      visible_indexes[insert_at] = profile_index;
+      visible_rssi[insert_at] = best_rssi;
+      visible_count++;
+    }
+  }
+  WiFi.scanDelete();
+
+  auto try_profile = [this, gui](uint8_t profile_index, uint8_t attempt, uint8_t attempts, bool fallback) {
     String ssid;
     String password;
-    if (!settings_obj.loadSavedWifiCredential(index, ssid, password))
-      continue;
+    if (!settings_obj.loadSavedWifiCredential(profile_index, ssid, password))
+      return false;
 
     Serial.println("Trying saved WiFi: " + ssid);
     #ifdef HAS_SCREEN
@@ -2403,13 +2456,13 @@ bool WiFiScan::joinSavedWiFi(bool gui) {
         display_obj.tft.setTextSize(1);
         display_obj.tft.setTextColor(TFT_CYAN, TFT_BLACK);
         display_obj.tft.setCursor(0, SCREEN_HEIGHT / 3);
-        display_obj.tft.println("Trying " + String(index + 1) + "/" + String(count));
+        display_obj.tft.println((fallback ? String("Fallback ") : String("Trying ")) + String(attempt) + "/" + String(attempts));
         display_obj.tft.println(ssid);
       }
     #endif
 
     if (this->joinWiFi(ssid, password, false, false)) {
-      settings_obj.markSavedWifiSuccessful(index);
+      settings_obj.markSavedWifiSuccessful(profile_index);
       Serial.println("Connected to saved WiFi: " + ssid);
       #ifdef HAS_SCREEN
         if (gui) {
@@ -2423,6 +2476,26 @@ bool WiFiScan::joinSavedWiFi(bool gui) {
       #endif
       return true;
     }
+    return false;
+  };
+
+  // The usual path tries only visible profiles, strongest first. Profile order
+  // breaks equal-RSSI ties because insertion above is stable.
+  for (uint8_t i = 0; i < visible_count; i++) {
+    if (try_profile(visible_indexes[i], i + 1, visible_count, false))
+      return true;
+  }
+
+  // Preserve support for hidden SSIDs and transient scan failures. If visible
+  // candidates failed, do not retry them during this fallback pass.
+  const uint8_t fallback_count = count - visible_count;
+  uint8_t fallback_attempt = 0;
+  for (uint8_t profile_index = 0; profile_index < count; profile_index++) {
+    if (visible[profile_index])
+      continue;
+    fallback_attempt++;
+    if (try_profile(profile_index, fallback_attempt, fallback_count, true))
+      return true;
   }
 
   Serial.println(F("Could not connect to any saved WiFi network"));

--- a/esp32_marauder/WiFiScan.h
+++ b/esp32_marauder/WiFiScan.h
@@ -958,6 +958,9 @@ class WiFiScan
     String free_ram = "";
     String old_free_ram = "";
     String connected_network = "";
+    char pending_wifi_ssid[33] = {};
+    char pending_wifi_password[64] = {};
+    bool pending_wifi_credential = false;
 
     IPAddress ip_addr;
     IPAddress gateway;
@@ -1086,7 +1089,11 @@ class WiFiScan
     bool shutdownWiFi();
     bool shutdownBLE();
     bool scanning();
-    bool joinWiFi(String ssid, String password, bool gui = true);
+    bool joinWiFi(String ssid, String password, bool gui = true, bool save_credential = true);
+    bool joinSavedWiFi(bool gui = true);
+    bool hasPendingWifiCredential() const;
+    bool savePendingWifiCredential(uint8_t replace_index);
+    void discardPendingWifiCredential();
     void getMAC(bool get_sta, uint8_t* mac);
     void changeChannel(int chan = -1);
     void RunAPInfo(uint16_t index, bool do_display = true);

--- a/esp32_marauder/configs.h
+++ b/esp32_marauder/configs.h
@@ -44,7 +44,9 @@
   //#define DUAL_MINI_C5
   //// END BOARD TARGETS
 
-  #define JSON_SETTING_SIZE 2048
+  // Allocated only while settings are loaded or updated. This accommodates
+  // five saved WiFi profiles without permanently caching their passwords.
+  #define JSON_SETTING_SIZE 4096
 
 #define MARAUDER_VERSION "v1.16.1"
 

--- a/esp32_marauder/settings.cpp
+++ b/esp32_marauder/settings.cpp
@@ -610,7 +610,10 @@ uint8_t Settings::getSavedWifiCount() {
   if (deserializeJson(json, this->json_settings_string))
     return 0;
   JsonObject setting = findSavedWifiSetting(json);
-  return setting.isNull() ? 0 : setting["value"].as<JsonArray>().size();
+  if (setting.isNull())
+    return 0;
+  const size_t count = setting["value"].as<JsonArray>().size();
+  return count > MAX_SAVED_WIFI_PROFILES ? MAX_SAVED_WIFI_PROFILES : count;
 }
 
 bool Settings::loadSavedWifiCredential(uint8_t index, String& ssid, String& password) {

--- a/esp32_marauder/settings.cpp
+++ b/esp32_marauder/settings.cpp
@@ -1,5 +1,30 @@
 #include "settings.h"
 
+static JsonObject findSavedWifiSetting(DynamicJsonDocument& json) {
+  JsonArray settings = json["Settings"].as<JsonArray>();
+  for (JsonObject setting : settings) {
+    if (strcmp(setting["name"] | "", SAVED_WIFI_KEY_NAME) == 0)
+      return setting;
+  }
+  return JsonObject();
+}
+
+static JsonObject ensureSavedWifiSetting(DynamicJsonDocument& json) {
+  JsonObject setting = findSavedWifiSetting(json);
+  if (!setting.isNull())
+    return setting;
+
+  JsonArray settings = json["Settings"].as<JsonArray>();
+  setting = settings.createNestedObject();
+  setting["name"] = SAVED_WIFI_KEY_NAME;
+  setting["type"] = "wifi_list";
+  setting.createNestedArray("value");
+  JsonObject range = setting.createNestedObject("range");
+  range["min"] = 0;
+  range["max"] = MAX_SAVED_WIFI_PROFILES;
+  return setting;
+}
+
 // ---------------------------------------------------------------------------
 // _buildCache — called once after json_settings_string is loaded/updated.
 // Parses the JSON exactly once and fills every field of _cache.
@@ -76,6 +101,47 @@ bool Settings::begin() {
   DeserializationError error = deserializeJson(jsonBuffer, settingsFile);
   if (error)
     Serial.println(error.f_str());
+
+  settingsFile.close();
+
+  bool settings_changed = false;
+  JsonObject saved_wifi_setting = findSavedWifiSetting(jsonBuffer);
+  if (saved_wifi_setting.isNull()) {
+    saved_wifi_setting = ensureSavedWifiSetting(jsonBuffer);
+    settings_changed = true;
+  }
+
+  // One-time, backward-compatible migration of the previous single profile.
+  JsonArray saved_wifi = saved_wifi_setting["value"].as<JsonArray>();
+  if (saved_wifi.isNull()) {
+    saved_wifi = saved_wifi_setting.createNestedArray("value");
+    settings_changed = true;
+  }
+  if (saved_wifi.size() == 0) {
+    const char* legacy_ssid = "";
+    const char* legacy_password = "";
+    for (JsonObject setting : jsonBuffer["Settings"].as<JsonArray>()) {
+      const char* setting_name = setting["name"] | "";
+      if (strcmp(setting_name, "ClientSSID") == 0)
+        legacy_ssid = setting["value"] | "";
+      else if (strcmp(setting_name, "ClientPW") == 0)
+        legacy_password = setting["value"] | "";
+    }
+    if (legacy_ssid[0] != '\0') {
+      JsonObject profile = saved_wifi.createNestedObject();
+      profile["ssid"] = legacy_ssid;
+      profile["password"] = legacy_password;
+      settings_changed = true;
+    }
+  }
+
+  if (settings_changed) {
+    File updated_settings = SPIFFS.open("/settings.json", FILE_WRITE);
+    if (!updated_settings)
+      return false;
+    serializeJson(jsonBuffer, updated_settings);
+    updated_settings.close();
+  }
 
   serializeJson(jsonBuffer, json_string);
 
@@ -397,9 +463,13 @@ void Settings::printJsonSettings(String json_string) {
 
   Serial.println("Settings\n----------------------------------------------");
   for (int i = 0; i < (int)json["Settings"].size(); i++) {
-    Serial.println("Name: " + json["Settings"][i]["name"].as<String>());
+    String setting_name = json["Settings"][i]["name"].as<String>();
+    Serial.println("Name: " + setting_name);
     Serial.println("Type: " + json["Settings"][i]["type"].as<String>());
-    Serial.println("Value: " + json["Settings"][i]["value"].as<String>() + "\n");
+    if (setting_name == "ClientPW" || setting_name == SAVED_WIFI_KEY_NAME)
+      Serial.println(F("Value: [redacted]\n"));
+    else
+      Serial.println("Value: " + json["Settings"][i]["value"].as<String>() + "\n");
   }
 }
 
@@ -486,6 +556,12 @@ bool Settings::createDefaultSettings(fs::FS &fs, bool spec, uint8_t index, const
     jsonBuffer["Settings"][10]["range"]["min"] = "";
     jsonBuffer["Settings"][10]["range"]["max"] = "";
 
+    jsonBuffer["Settings"][11]["name"] = SAVED_WIFI_KEY_NAME;
+    jsonBuffer["Settings"][11]["type"] = "wifi_list";
+    jsonBuffer["Settings"][11].createNestedArray("value");
+    jsonBuffer["Settings"][11]["range"]["min"] = 0;
+    jsonBuffer["Settings"][11]["range"]["max"] = MAX_SAVED_WIFI_PROFILES;
+
     serializeJson(jsonBuffer, settingsFile);
     serializeJson(jsonBuffer, settings_string);
   } else {
@@ -527,4 +603,110 @@ bool Settings::createDefaultSettings(fs::FS &fs, bool spec, uint8_t index, const
   this->printJsonSettings(settings_string);
 
   return true;
+}
+
+uint8_t Settings::getSavedWifiCount() {
+  DynamicJsonDocument json(JSON_SETTING_SIZE);
+  if (deserializeJson(json, this->json_settings_string))
+    return 0;
+  JsonObject setting = findSavedWifiSetting(json);
+  return setting.isNull() ? 0 : setting["value"].as<JsonArray>().size();
+}
+
+bool Settings::loadSavedWifiCredential(uint8_t index, String& ssid, String& password) {
+  ssid = "";
+  password = "";
+  DynamicJsonDocument json(JSON_SETTING_SIZE);
+  if (deserializeJson(json, this->json_settings_string))
+    return false;
+  JsonObject setting = findSavedWifiSetting(json);
+  JsonArray profiles = setting["value"].as<JsonArray>();
+  if (setting.isNull() || index >= profiles.size())
+    return false;
+  ssid = profiles[index]["ssid"].as<String>();
+  password = profiles[index]["password"].as<String>();
+  return ssid.length() > 0;
+}
+
+WifiCredentialSaveResult Settings::saveWifiCredential(const String& ssid, const String& password, int8_t replace_index) {
+  if (ssid.length() == 0 || ssid.length() > 32 || password.length() > 63)
+    return WIFI_CREDENTIAL_ERROR;
+
+  DynamicJsonDocument json(JSON_SETTING_SIZE);
+  if (deserializeJson(json, this->json_settings_string))
+    return WIFI_CREDENTIAL_ERROR;
+  JsonObject setting = ensureSavedWifiSetting(json);
+  JsonArray profiles = setting["value"].as<JsonArray>();
+
+  int8_t existing_index = -1;
+  for (uint8_t i = 0; i < profiles.size(); i++) {
+    if (ssid == profiles[i]["ssid"].as<String>()) {
+      existing_index = i;
+      break;
+    }
+  }
+
+  WifiCredentialSaveResult result = WIFI_CREDENTIAL_SAVED;
+  int8_t target_index = existing_index;
+  if (existing_index >= 0) {
+    result = WIFI_CREDENTIAL_UPDATED;
+  }
+  else if (profiles.size() < MAX_SAVED_WIFI_PROFILES) {
+    profiles.createNestedObject();
+    target_index = profiles.size() - 1;
+  }
+  else if (replace_index >= 0 && replace_index < (int8_t)profiles.size()) {
+    target_index = replace_index;
+  }
+  else {
+    return WIFI_CREDENTIAL_FULL;
+  }
+
+  // Successful/new credentials become the first profile tried. Rotate the
+  // small bounded array without retaining a second credential collection.
+  for (int8_t i = target_index; i > 0; i--) {
+    profiles[i]["ssid"] = profiles[i - 1]["ssid"].as<String>();
+    profiles[i]["password"] = profiles[i - 1]["password"].as<String>();
+  }
+  profiles[0]["ssid"] = ssid;
+  profiles[0]["password"] = password;
+
+  File settings_file = SPIFFS.open("/settings.json", FILE_WRITE);
+  if (!settings_file)
+    return WIFI_CREDENTIAL_ERROR;
+  serializeJson(json, settings_file);
+  settings_file.close();
+  serializeJson(json, this->json_settings_string);
+  return result;
+}
+
+bool Settings::removeSavedWifiCredential(uint8_t index) {
+  DynamicJsonDocument json(JSON_SETTING_SIZE);
+  if (deserializeJson(json, this->json_settings_string))
+    return false;
+  JsonObject setting = findSavedWifiSetting(json);
+  JsonArray profiles = setting["value"].as<JsonArray>();
+  if (setting.isNull() || index >= profiles.size())
+    return false;
+  profiles.remove(index);
+
+  File settings_file = SPIFFS.open("/settings.json", FILE_WRITE);
+  if (!settings_file)
+    return false;
+  serializeJson(json, settings_file);
+  settings_file.close();
+  serializeJson(json, this->json_settings_string);
+  return true;
+}
+
+bool Settings::markSavedWifiSuccessful(uint8_t index) {
+  // The first profile is already the most recently successful. Avoid an
+  // unnecessary settings-file rewrite on every normal connection.
+  if (index == 0)
+    return getSavedWifiCount() > 0;
+  String ssid;
+  String password;
+  if (!loadSavedWifiCredential(index, ssid, password))
+    return false;
+  return saveWifiCredential(ssid, password) != WIFI_CREDENTIAL_ERROR;
 }

--- a/esp32_marauder/settings.h
+++ b/esp32_marauder/settings.h
@@ -18,6 +18,15 @@
 #endif
 
 #define WDG_KEY_NAME       "wdg_key"   // WDG Wars API key (String)
+#define SAVED_WIFI_KEY_NAME "SavedWiFi"
+#define MAX_SAVED_WIFI_PROFILES 5
+
+enum WifiCredentialSaveResult : uint8_t {
+  WIFI_CREDENTIAL_SAVED,
+  WIFI_CREDENTIAL_UPDATED,
+  WIFI_CREDENTIAL_FULL,
+  WIFI_CREDENTIAL_ERROR
+};
 
 class Settings {
 
@@ -60,6 +69,11 @@ class Settings {
     int getNumberSettings();
 
     String getSettingsString();
+    uint8_t getSavedWifiCount();
+    bool loadSavedWifiCredential(uint8_t index, String& ssid, String& password);
+    WifiCredentialSaveResult saveWifiCredential(const String& ssid, const String& password, int8_t replace_index = -1);
+    bool removeSavedWifiCredential(uint8_t index);
+    bool markSavedWifiSuccessful(uint8_t index);
     //bool createDefaultSettings(fs::FS &fs, bool spec = false, uint8_t index = 0, String typeStr = "bool", String name = "");
     bool createDefaultSettings(fs::FS &fs, bool spec = false, uint8_t index = 0, const char* typeStr = "bool", const char* name = "");
     void printJsonSettings(String json_string);


### PR DESCRIPTION
## Summary
- save and manage up to five WiFi credential profiles with legacy-setting migration and explicit replacement
- use one scan to prioritize visible saved networks by signal strength for joins and wardrive uploads
- keep hidden-network fallback, transient JSON/scan memory, and redact credential output