### PR TITLE
Fix wardrive upload stack overflow

### DIFF
--- a/esp32_marauder/UploadStreamBuffer.h
+++ b/esp32_marauder/UploadStreamBuffer.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+namespace marauder {
+
+constexpr size_t UPLOAD_STREAM_BUFFER_SIZE = 1024;
+
+class UploadStreamBuffer {
+ public:
+  UploadStreamBuffer()
+      : data_(static_cast<uint8_t*>(malloc(UPLOAD_STREAM_BUFFER_SIZE))) {}
+
+  ~UploadStreamBuffer() {
+    free(data_);
+  }
+
+  UploadStreamBuffer(const UploadStreamBuffer&) = delete;
+  UploadStreamBuffer& operator=(const UploadStreamBuffer&) = delete;
+
+  uint8_t* data() const {
+    return data_;
+  }
+
+  size_t size() const {
+    return UPLOAD_STREAM_BUFFER_SIZE;
+  }
+
+  explicit operator bool() const {
+    return data_ != nullptr;
+  }
+
+ private:
+  uint8_t* data_;
+};
+
+}  // namespace marauder

--- a/esp32_marauder/WiFiScan.cpp
+++ b/esp32_marauder/WiFiScan.cpp
@@ -4,6 +4,7 @@
 #include "FoxHuntTarget.h"
 #include "BeaconFrame.h"
 #include "WdgResponse.h"
+#include "UploadStreamBuffer.h"
 #include "lang_var.h"
 
 #ifdef HAS_PSRAM
@@ -11618,15 +11619,20 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
     // Send body
     client->print(part1);
 
-    const size_t CHUNK = 4096;
-    uint8_t buf[CHUNK];
+    marauder::UploadStreamBuffer uploadBuffer;
+    if (!uploadBuffer) {
+      fileToUpload.close();
+      client->stop();
+      Serial.println("[WDG] Could not allocate upload buffer");
+      return false;
+    }
     size_t totalSent = 0;
     uint8_t pct = 0;
 
     while (fileToUpload.available()) {
-      size_t n = fileToUpload.read(buf, CHUNK);
+      size_t n = fileToUpload.read(uploadBuffer.data(), uploadBuffer.size());
       totalSent += n;
-      client->write(buf, n);
+      client->write(uploadBuffer.data(), n);
       pct = (totalSent * 100) / fileToUpload.size();
       #ifdef HAS_SCREEN
       this->drawUploadProgress("WDG WARS", pct); // GCOVR_EXCL_LINE
@@ -11833,8 +11839,13 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
 
     // Send body
     client->print(part1);
-    const size_t BUFFER_SIZE = 4096; // 1KB at a time
-    uint8_t buffer[BUFFER_SIZE];
+    marauder::UploadStreamBuffer uploadBuffer;
+    if (!uploadBuffer) {
+      fileToUpload.close();
+      client->stop();
+      Serial.println("[WIGLE] Could not allocate upload buffer");
+      return false;
+    }
 
     Serial.println("Finished sending part1");
 
@@ -11842,7 +11853,7 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
 
     size_t totalBytesSent = 0;
     while (fileToUpload.available()) {
-      size_t bytesRead = fileToUpload.read(buffer, BUFFER_SIZE);
+      size_t bytesRead = fileToUpload.read(uploadBuffer.data(), uploadBuffer.size());
       totalBytesSent += bytesRead;
       Serial.print("Writing ");
       Serial.print(totalBytesSent);
@@ -11851,7 +11862,7 @@ uint16_t WiFiScan::rssiToColor(int8_t rssi) {
       #ifdef HAS_SCREEN
       this->drawUploadProgress("WiGLE", percent_sent); // GCOVR_EXCL_LINE
       #endif
-      client->write(buffer, bytesRead);
+      client->write(uploadBuffer.data(), bytesRead);
     }
 
     Serial.println("Uploaded file bytes: " + String(totalBytesSent));

--- a/test/test_upload_stream_buffer/test_main.cpp
+++ b/test/test_upload_stream_buffer/test_main.cpp
@@ -1,0 +1,25 @@
+#include <unity.h>
+
+#include "UploadStreamBuffer.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_upload_buffer_uses_fixed_small_chunk(void) {
+  TEST_ASSERT_EQUAL_UINT32(1024, marauder::UPLOAD_STREAM_BUFFER_SIZE);
+  TEST_ASSERT_EQUAL_UINT32(sizeof(void*), sizeof(marauder::UploadStreamBuffer));
+}
+
+void test_upload_buffer_allocates_from_heap(void) {
+  marauder::UploadStreamBuffer buffer;
+  TEST_ASSERT_TRUE(static_cast<bool>(buffer));
+  TEST_ASSERT_NOT_NULL(buffer.data());
+  TEST_ASSERT_EQUAL_UINT32(marauder::UPLOAD_STREAM_BUFFER_SIZE, buffer.size());
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_upload_buffer_uses_fixed_small_chunk);
+  RUN_TEST(test_upload_buffer_allocates_from_heap);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- replace the 4 KiB stack arrays in WDG Wars and WiGLE uploads with a shared 1 KiB heap-backed streaming buffer
- handle allocation failure cleanly without requiring PSRAM
- add native regression coverage for buffer size, allocation, and pointer-sized stack footprint